### PR TITLE
fix Some.reduce so it calls f

### DIFF
--- a/src/Option.ts
+++ b/src/Option.ts
@@ -9,7 +9,7 @@ import { StaticExtend, FantasyExtend } from './Extend'
 import { StaticSetoid } from './Setoid'
 import { StaticTraversable, FantasyTraversable } from './Traversable'
 import { StaticAlternative, FantasyAlternative } from './Alternative'
-import { identity, constant, constFalse, constTrue, Lazy, Predicate } from './function'
+import { constant, constFalse, constTrue, Lazy, Predicate } from './function'
 
 declare module './HKT' {
   interface HKT<A> {
@@ -131,7 +131,7 @@ export class Some<A> implements
     return f(this.value)
   }
   reduce<B>(f: (b: B, a: A) => B, b: B): B {
-    return this.fold<B>(constant(b), identity)
+    return this.fold<B>(constant(b), (a: A) => f(b, a))
   }
   traverse<F extends HKT2S>(applicative: StaticApplicative<F>): <L, B>(f: (a: A) => HKT2<L, B>[F]) => HKT2<L, Option<B>>[F]
   traverse<F extends HKTS>(applicative: StaticApplicative<F>): <B>(f: (a: A) => HKT<B>[F]) => HKT<Option<B>>[F]

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -83,4 +83,10 @@ describe('Option', () => {
     eq(y, some(some(5)))
   })
 
+  it('reduce', () => {
+    const x = fromNullable(null).reduce((b, a) => 1, 2)
+    assert.strictEqual(x, 2)
+    const y = fromNullable(3).reduce((b, a) => a.toString(), '4')
+    assert.strictEqual(y, '3')
+  })
 })


### PR DESCRIPTION
Hi. I'm switch a project over from flow and flow-static-land to ts and fp-ts. In updating a section that used `Maybe` from flow-static-land to use `Option`, i noticed that the behaviour changed. It looks to me like `reduce` on `Some` isn't quite right, as it never calls `f`. This is different to how it was in flow-static-land. Is that intentional and should I be using `fold` directly instead? 

I'm still very much in the training-wheels phase with a lot of this stuff, but it strikes me that `reduce` and `fold` do very similar things. When should one be used over the other? Is it just that `reduce` should be used when you don't want to have to deal with converting to `Lazy<A>` yourself?
