### PR TITLE
deprecate `validation.getApplicativeS` / `validation.getStaticApplica…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 **Note**: Gaps between patch versions are faulty/broken releases.
 **Note**: A feature tagged as Experimental is in a high state of flux, you're at risk of it changing without notice.
 
+# 0.2.4
+
+- **Polish**
+  - deprecate `validation.getApplicativeS` / `validation.getStaticApplicative` (@gcanti)
+
 # 0.2.3
 
 - **Bug Fix**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fp-ts",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Functional programming in TypeScript",
   "files": [
     "lib",

--- a/src/Validation.ts
+++ b/src/Validation.ts
@@ -185,19 +185,20 @@ export function map<L, A, B>(f: (a: A) => B, fa: Validation<L, A>): Validation<L
   return fa.map(f)
 }
 
-export function of<L, A>(a: A): Success<L, A> {
+export function of<L, A>(a: A): Validation<L, A> {
   return new Success<L, A>(a)
 }
 
-export function getStaticApplicative<L>(semigroup: StaticSemigroup<L>): StaticApplicative<URI> {
-  function ap<A, B>(fab: Validation<L, (a: A) => B>, fa: Validation<L, A>): Validation<L, B> {
-    return fa.ap(fab)
-  }
+export function ap<L, A, B>(fab: Validation<L, (a: A) => B>, fa: Validation<L, A>): Validation<L, B> {
+  return fa.ap(fab)
+}
 
+/** deprecated */
+export function getStaticApplicative<L>(semigroup: StaticSemigroup<L>): StaticApplicative<URI> {
   return { URI, map, of, ap }
 }
 
-/** deprecated, use getStaticApplicative instead */
+/** deprecated */
 export const getApplicativeS = getStaticApplicative
 
 export function bimap<L, L2, A, B>(semigroup: StaticSemigroup<L2>, f: (l: L) => L2, g: (a: A) => B, fa: Validation<L, A>): Validation<L2, B> {
@@ -230,9 +231,7 @@ export function failure<L, A>(semigroup: StaticSemigroup<L>, l: L): Validation<L
   return new Failure<L, A>(semigroup, l)
 }
 
-export function success<L, A>(a: A): Validation<L, A> {
-  return new Success<L, A>(a)
-}
+export const success = of
 
 export function fromPredicate<L, A>(semigroup: StaticSemigroup<L>, predicate: Predicate<A>, l: (a: A) => L): (a: A) => Validation<L, A> {
   return a => predicate(a) ? success<L, A>(a) : failure<L, A>(semigroup, l(a))

--- a/test/Validation.ts
+++ b/test/Validation.ts
@@ -19,7 +19,7 @@ describe('Validation', () => {
       validation.failure<string, number>(monoidString, '[fail 2]')
     ]
 
-    const x = sequence(validation.getApplicativeS(monoidString), array)(success)
+    const x = sequence(validation, array)(success)
 
     if (validation.isSuccess(x)) {
       assert.deepEqual(x.value, [1, 2, 3])
@@ -27,7 +27,7 @@ describe('Validation', () => {
       assert.ok(false)
     }
 
-    const y = sequence(validation.getApplicativeS(monoidString), array)(failure)
+    const y = sequence(validation, array)(failure)
 
     if (validation.isFailure(y)) {
       assert.strictEqual(y.value, '[fail 1][fail 2]')


### PR DESCRIPTION
…tive`