### PR TITLE
simplify getStatic*Composition functions

### DIFF
--- a/docs/OptionT.md
+++ b/docs/OptionT.md
@@ -29,7 +29,7 @@ As you can see, the implementations of all of these variations are very similar.
 `OptionT` can help remove some of this boilerplate. It exposes methods that look like those on `Option`, but it handles the outer map call on the `Task` so we don’t have to:
 
 ```ts
-import { getStaticOptionT } from 'fp-ts/lib/OptionT'
+import { getOptionT } from 'fp-ts/lib/OptionT'
 
 declare module 'fp-ts/lib/HKT' {
   interface HKT<A> {
@@ -37,7 +37,7 @@ declare module 'fp-ts/lib/HKT' {
   }
 }
 
-const taskOption = getStaticOptionT('Task<Option>', task)
+const taskOption = getOptionT('Task<Option>', task)
 
 // customGreeting2 :: Task<Option<string>>
 const customGreeting2 = taskOption.of('welcome back, Lola')

--- a/examples/EitherOption.ts
+++ b/examples/EitherOption.ts
@@ -2,7 +2,7 @@ import { Option } from 'fp-ts/lib/Option'
 import * as option from 'fp-ts/lib/Option'
 import { Either } from 'fp-ts/lib/Either'
 import * as either from 'fp-ts/lib/Either'
-import { getStaticOptionT } from 'fp-ts/lib/OptionT'
+import { getOptionT } from 'fp-ts/lib/OptionT'
 import { FantasyMonad } from 'fp-ts/lib/Monad'
 import { Lazy } from 'fp-ts/lib/function'
 
@@ -13,7 +13,7 @@ declare module 'fp-ts/lib/HKT' {
   }
 }
 
-const optionTEither = getStaticOptionT('Either<Option>', either)
+const optionTEither = getOptionT('Either<Option>', either)
 
 export const URI = 'EitherOption'
 

--- a/examples/IxIO.ts
+++ b/examples/IxIO.ts
@@ -1,4 +1,4 @@
-import { StaticIxMonad, FantasyIxMonad } from '../src/IxMonad'
+import { IxMonad, FantasyIxMonad } from '../src/IxMonad'
 import { IO } from '../src/IO'
 import * as io from '../src/IO'
 
@@ -67,6 +67,6 @@ export function chain<I, A, B>(f: (a: A) => IxIO<I, I, B>, fa: IxIO<I, I, A>): I
 // tslint:disable-next-line no-unused-expression
 ;(
   { URI, iof, ichain, of, map, ap, chain } as (
-    StaticIxMonad<URI>
+    IxMonad<URI>
   )
 )

--- a/examples/OptionT.ts
+++ b/examples/OptionT.ts
@@ -18,7 +18,7 @@ const withFallback = customGreeting.map(x => x.getOrElse(() => 'hello, there!'))
 
 // ====
 
-import { getStaticOptionT } from 'fp-ts/lib/OptionT'
+import { getOptionT } from 'fp-ts/lib/OptionT'
 
 declare module 'fp-ts/lib/HKT' {
   interface HKT<A> {
@@ -26,7 +26,7 @@ declare module 'fp-ts/lib/HKT' {
   }
 }
 
-const taskOption = getStaticOptionT('Task<Option>', task)
+const taskOption = getOptionT('Task<Option>', task)
 
 // customGreeting2 :: Task<Option<string>>
 const customGreeting2 = taskOption.of('welcome back, Lola')

--- a/examples/ReaderOption.ts
+++ b/examples/ReaderOption.ts
@@ -1,7 +1,7 @@
 import { Reader } from 'fp-ts/lib/Reader'
 import { Option } from 'fp-ts/lib/Option'
 import * as option from 'fp-ts/lib/Option'
-import { getStaticReaderT } from 'fp-ts/lib/ReaderT'
+import { getReaderT } from 'fp-ts/lib/ReaderT'
 import { FantasyMonad } from 'fp-ts/lib/Monad'
 import { Endomorphism } from 'fp-ts/lib/function'
 
@@ -13,7 +13,7 @@ declare module 'fp-ts/lib/HKT' {
   }
 }
 
-const readerTOption = getStaticReaderT(option)
+const readerTOption = getReaderT(option)
 
 export const URI = 'ReaderOption'
 

--- a/examples/TaskEither.ts
+++ b/examples/TaskEither.ts
@@ -2,7 +2,7 @@ import { Either } from 'fp-ts/lib/Either'
 import * as either from 'fp-ts/lib/Either'
 import { Task } from 'fp-ts/lib/Task'
 import * as task from 'fp-ts/lib/Task'
-import { getStaticEitherT } from 'fp-ts/lib/EitherT'
+import { getEitherT } from 'fp-ts/lib/EitherT'
 import { FantasyMonad } from 'fp-ts/lib/Monad'
 import { Lazy } from 'fp-ts/lib/function'
 import { Option } from 'fp-ts/lib/Option'
@@ -14,7 +14,7 @@ declare module 'fp-ts/lib/HKT' {
   }
 }
 
-const eitherTTask = getStaticEitherT('Task<Either>', task)
+const eitherTTask = getEitherT('Task<Either>', task)
 
 export const URI = 'TaskEither'
 

--- a/examples/TaskOption.ts
+++ b/examples/TaskOption.ts
@@ -2,7 +2,7 @@ import { Option } from 'fp-ts/lib/Option'
 import * as option from 'fp-ts/lib/Option'
 import { Task } from 'fp-ts/lib/Task'
 import * as task from 'fp-ts/lib/Task'
-import { getStaticOptionT } from 'fp-ts/lib/OptionT'
+import { getOptionT } from 'fp-ts/lib/OptionT'
 import { FantasyMonad } from 'fp-ts/lib/Monad'
 import { Lazy } from 'fp-ts/lib/function'
 
@@ -13,7 +13,7 @@ declare module 'fp-ts/lib/HKT' {
   }
 }
 
-const optionTTask = getStaticOptionT('Task<Option>', task)
+const optionTTask = getOptionT('Task<Option>', task)
 
 export const URI = 'TaskOption'
 

--- a/exercises/answer1.ts
+++ b/exercises/answer1.ts
@@ -1,7 +1,7 @@
-import { StaticOrd } from 'fp-ts/lib/Ord'
+import { Ord } from 'fp-ts/lib/Ord'
 import { numberOrd, stringOrd } from 'fp-ts/lib/Ord'
 
-export function binarySearch<A>(xs: Array<A>, x: A, ord: StaticOrd<A>): number {
+export function binarySearch<A>(xs: Array<A>, x: A, ord: Ord<A>): number {
   function go(low: number, mid: number, high: number): number {
     if (low > high) {
       return -mid - 1

--- a/exercises/answer2.ts
+++ b/exercises/answer2.ts
@@ -1,7 +1,7 @@
-import { StaticOrd } from 'fp-ts/lib/Ord'
+import { Ord } from 'fp-ts/lib/Ord'
 import { greaterThan, numberOrd } from 'fp-ts/lib/Ord'
 
-export function isSorted<A>(xs: Array<A>, ord: StaticOrd<A>): boolean {
+export function isSorted<A>(xs: Array<A>, ord: Ord<A>): boolean {
   const len = xs.length
   function go(n: number): boolean {
     if (n >= len) {

--- a/exercises/answer3.ts
+++ b/exercises/answer3.ts
@@ -1,5 +1,5 @@
 import { HKT } from 'fp-ts/lib/HKT'
-import { StaticFunctor } from 'fp-ts/lib/Functor'
+import { Functor } from 'fp-ts/lib/Functor'
 
 declare module 'fp-ts/lib/HKT' {
   interface HKT<A> {

--- a/exercises/exercise2.ts
+++ b/exercises/exercise2.ts
@@ -6,6 +6,6 @@
 
 */
 
-import { StaticOrd } from 'fp-ts/lib/Ord'
+import { Ord } from 'fp-ts/lib/Ord'
 
-declare function isSorted<A>(xs: Array<A>, ord: StaticOrd<A>): boolean
+declare function isSorted<A>(xs: Array<A>, ord: Ord<A>): boolean

--- a/src/Alt.ts
+++ b/src/Alt.ts
@@ -1,7 +1,7 @@
 import { HKT, HKTS } from './HKT'
-import { StaticFunctor, FantasyFunctor } from './Functor'
+import { Functor, FantasyFunctor } from './Functor'
 
-export interface StaticAlt<F extends HKTS> extends StaticFunctor<F> {
+export interface Alt<F extends HKTS> extends Functor<F> {
   alt<A, U = any, V = any>(fx: HKT<A, U, V>[F], fy: HKT<A, U, V>[F]): HKT<A, U, V>[F]
 }
 

--- a/src/Alternative.ts
+++ b/src/Alternative.ts
@@ -1,7 +1,7 @@
 import { HKTS } from './HKT'
-import { StaticApplicative, FantasyApplicative } from './Applicative'
-import { StaticPlus, FantasyPlus } from './Plus'
+import { Applicative, FantasyApplicative } from './Applicative'
+import { Plus, FantasyPlus } from './Plus'
 
-export interface StaticAlternative<F extends HKTS> extends StaticApplicative<F>, StaticPlus<F> {}
+export interface Alternative<F extends HKTS> extends Applicative<F>, Plus<F> {}
 
 export interface FantasyAlternative<F extends HKTS, A> extends FantasyApplicative<F, A>, FantasyPlus<F, A> {}

--- a/src/Applicative.ts
+++ b/src/Applicative.ts
@@ -1,8 +1,8 @@
 import { HKT, HKTS } from './HKT'
-import { getCompositionStaticFunctor } from './Functor'
-import { StaticApply, FantasyApply } from './Apply'
+import { getCompositionFunctor } from './Functor'
+import { Apply, FantasyApply } from './Apply'
 
-export interface StaticApplicative<F extends HKTS> extends StaticApply<F> {
+export interface Applicative<F extends HKTS> extends Apply<F> {
   of<A, U = any, V = any>(a: A): HKT<A, U, V>[F]
 }
 
@@ -13,8 +13,8 @@ export interface FantasyApplicative<F extends HKTS, A> extends FantasyApply<F, A
 /** returns the composition of two applicatives
  * Note: requires an implicit proof that HKT<A>[FG] ~ HKT<HKT<A>[G]>[F]
  */
-export function getCompositionStaticApplicative<FG extends HKTS, F extends HKTS, G extends HKTS>(URI: FG, applicativeF: StaticApplicative<F>, applicativeG: StaticApplicative<G>): StaticApplicative<FG> {
-  const functor = getCompositionStaticFunctor(URI, applicativeF, applicativeG)
+export function getCompositionApplicative<FG extends HKTS, F extends HKTS, G extends HKTS>(URI: FG, applicativeF: Applicative<F>, applicativeG: Applicative<G>): Applicative<FG> {
+  const functor = getCompositionFunctor(URI, applicativeF, applicativeG)
 
   function of<A>(a: A): HKT<HKT<A>[G]>[F] {
     return applicativeF.of(applicativeG.of(a))
@@ -32,7 +32,7 @@ export function getCompositionStaticApplicative<FG extends HKTS, F extends HKTS,
 }
 
 /** Perform a applicative action when a condition is true */
-export function when<F extends HKTS>(applicative: StaticApplicative<F>): (condition: boolean, fu: HKT<void>[F]) => HKT<void>[F] {
+export function when<F extends HKTS>(applicative: Applicative<F>): (condition: boolean, fu: HKT<void>[F]) => HKT<void>[F] {
   return (condition: boolean, fu: HKT<void>[F]) => {
     return condition ? fu : applicative.of(undefined)
   }

--- a/src/Applicative.ts
+++ b/src/Applicative.ts
@@ -10,24 +10,24 @@ export interface FantasyApplicative<F extends HKTS, A> extends FantasyApply<F, A
   of<A, U = any, V = any>(a: A): HKT<A, U, V>[F]
 }
 
-/** returns the composition of two applicatives */
-export function getStaticApplicativeComposition<FG extends HKTS>(URI: FG): <F extends HKTS, G extends HKTS>(applicativeF: StaticApplicative<F>, applicativeG: StaticApplicative<G>) => StaticApplicative<FG> {
-  return <F extends HKTS, G extends HKTS>(applicativeF: StaticApplicative<F>, applicativeG: StaticApplicative<G>) => {
-    const functor = getStaticFunctorComposition(URI)(applicativeF, applicativeG)
+/** returns the composition of two applicatives
+ * Note: requires an implicit proof that HKT<A>[FG] ~ HKT<HKT<A>[G]>[F]
+ */
+export function getStaticApplicativeComposition<FG extends HKTS, F extends HKTS, G extends HKTS>(URI: FG, applicativeF: StaticApplicative<F>, applicativeG: StaticApplicative<G>): StaticApplicative<FG> {
+  const functor = getStaticFunctorComposition(URI, applicativeF, applicativeG)
 
-    function of<A>(a: A): HKT<HKT<A>[G]>[F] {
-      return applicativeF.of(applicativeG.of(a))
-    }
+  function of<A>(a: A): HKT<HKT<A>[G]>[F] {
+    return applicativeF.of(applicativeG.of(a))
+  }
 
-    function ap<A, B>(fgab: HKT<HKT<(a: A) => B>[G]>[F], fga: HKT<HKT<A>[G]>[F]): HKT<HKT<B>[G]>[F] {
-      return applicativeF.ap<HKT<A>[G], HKT<B>[G]>(applicativeF.map((h: HKT<(a: A) => B>[G]) => (ga: HKT<A>[G]) => applicativeG.ap<A, B>(h, ga), fgab), fga)
-    }
+  function ap<A, B>(fgab: HKT<HKT<(a: A) => B>[G]>[F], fga: HKT<HKT<A>[G]>[F]): HKT<HKT<B>[G]>[F] {
+    return applicativeF.ap<HKT<A>[G], HKT<B>[G]>(applicativeF.map((h: HKT<(a: A) => B>[G]) => (ga: HKT<A>[G]) => applicativeG.ap<A, B>(h, ga), fgab), fga)
+  }
 
-    return {
-      ...functor,
-      of,
-      ap
-    }
+  return {
+    ...functor,
+    of,
+    ap: ap as any
   }
 }
 

--- a/src/Applicative.ts
+++ b/src/Applicative.ts
@@ -1,5 +1,5 @@
 import { HKT, HKTS } from './HKT'
-import { getStaticFunctorComposition } from './Functor'
+import { getCompositionStaticFunctor } from './Functor'
 import { StaticApply, FantasyApply } from './Apply'
 
 export interface StaticApplicative<F extends HKTS> extends StaticApply<F> {
@@ -13,8 +13,8 @@ export interface FantasyApplicative<F extends HKTS, A> extends FantasyApply<F, A
 /** returns the composition of two applicatives
  * Note: requires an implicit proof that HKT<A>[FG] ~ HKT<HKT<A>[G]>[F]
  */
-export function getStaticApplicativeComposition<FG extends HKTS, F extends HKTS, G extends HKTS>(URI: FG, applicativeF: StaticApplicative<F>, applicativeG: StaticApplicative<G>): StaticApplicative<FG> {
-  const functor = getStaticFunctorComposition(URI, applicativeF, applicativeG)
+export function getCompositionStaticApplicative<FG extends HKTS, F extends HKTS, G extends HKTS>(URI: FG, applicativeF: StaticApplicative<F>, applicativeG: StaticApplicative<G>): StaticApplicative<FG> {
+  const functor = getCompositionStaticFunctor(URI, applicativeF, applicativeG)
 
   function of<A>(a: A): HKT<HKT<A>[G]>[F] {
     return applicativeF.of(applicativeG.of(a))

--- a/src/Apply.ts
+++ b/src/Apply.ts
@@ -1,8 +1,8 @@
 import { HKT, HKTS } from './HKT'
-import { StaticFunctor, FantasyFunctor } from './Functor'
+import { Functor, FantasyFunctor } from './Functor'
 import { Curried2, Curried3, Curried4, identity, constant } from './function'
 
-export interface StaticApply<F extends HKTS> extends StaticFunctor<F> {
+export interface Apply<F extends HKTS> extends Functor<F> {
   ap<A, B, U = any, V = any>(fab: HKT<(a: A) => B, U, V>[F], fa: HKT<A, U, V>[F]): HKT<B, U, V>[F]
 }
 
@@ -12,25 +12,25 @@ export interface FantasyApply<F extends HKTS, A> extends FantasyFunctor<F, A> {
 
 const constIdentity = () => identity
 
-export function applyFirst<F extends HKTS>(apply: StaticApply<F>): <A, B, U = any, V = any>(fa: HKT<A, U, V>[F], fb: HKT<B, U, V>[F]) => HKT<A, U, V>[F] {
+export function applyFirst<F extends HKTS>(apply: Apply<F>): <A, B, U = any, V = any>(fa: HKT<A, U, V>[F], fb: HKT<B, U, V>[F]) => HKT<A, U, V>[F] {
   return <A, B>(fa: HKT<A>[F], fb: HKT<B>[F]) => apply.ap(apply.map(constant, fa), fb)
 }
 
-export function applySecond<F extends HKTS>(apply: StaticApply<F>): <A, B, U = any, V = any>(fa: HKT<A, U, V>[F], fb: HKT<B, U, V>[F]) => HKT<B, U, V>[F] {
+export function applySecond<F extends HKTS>(apply: Apply<F>): <A, B, U = any, V = any>(fa: HKT<A, U, V>[F], fb: HKT<B, U, V>[F]) => HKT<B, U, V>[F] {
   return <A, B>(fa: HKT<A>[F], fb: HKT<B>[F]) => apply.ap(apply.map(constIdentity, fa), fb)
 }
 
-export function liftA2<F extends HKTS, A, B, C>(apply: StaticApply<F>, f: Curried2<A, B, C>): <U = any, V = any>(fa: HKT<A, U, V>[F], fb: HKT<B, U, V>[F]) => HKT<C, U, V>[F] {
+export function liftA2<F extends HKTS, A, B, C>(apply: Apply<F>, f: Curried2<A, B, C>): <U = any, V = any>(fa: HKT<A, U, V>[F], fb: HKT<B, U, V>[F]) => HKT<C, U, V>[F] {
   return (fa: HKT<A>[F], fb: HKT<B>[F]) =>
     apply.ap<B, C>(apply.map<A, (b: B) => C>(f, fa), fb)
 }
 
-export function liftA3<F extends HKTS, A, B, C, D>(apply: StaticApply<F>, f: Curried3<A, B, C, D>): <U = any, V = any>(fa: HKT<A, U, V>[F], fb: HKT<B, U, V>[F], fc: HKT<C, U, V>[F]) => HKT<D, U, V>[F] {
+export function liftA3<F extends HKTS, A, B, C, D>(apply: Apply<F>, f: Curried3<A, B, C, D>): <U = any, V = any>(fa: HKT<A, U, V>[F], fb: HKT<B, U, V>[F], fc: HKT<C, U, V>[F]) => HKT<D, U, V>[F] {
   return (fa: HKT<A>[F], fb: HKT<B>[F], fc: HKT<C>[F]) =>
     apply.ap<C, D>(apply.ap<B, (c: C) => D>(apply.map<A, Curried2<B, C, D>>(f, fa), fb), fc)
 }
 
-export function liftA4<F extends HKTS, A, B, C, D, E>(apply: StaticApply<F>, f: Curried4<A, B, C, D, E>): <U = any, V = any>(fa: HKT<A, U, V>[F], fb: HKT<B, U, V>[F], fc: HKT<C, U, V>[F], fd: HKT<D, U, V>[F]) => HKT<E, U, V>[F] {
+export function liftA4<F extends HKTS, A, B, C, D, E>(apply: Apply<F>, f: Curried4<A, B, C, D, E>): <U = any, V = any>(fa: HKT<A, U, V>[F], fb: HKT<B, U, V>[F], fc: HKT<C, U, V>[F], fd: HKT<D, U, V>[F]) => HKT<E, U, V>[F] {
   return (fa: HKT<A>[F], fb: HKT<B>[F], fc: HKT<C>[F], fd: HKT<D>[F]) =>
     apply.ap<D, E>(apply.ap<C, (d: D) => E>(apply.ap<B, Curried2<C, D, E>>(apply.map<A, Curried3<B, C, D, E>>(f, fa), fb), fc), fd)
 }

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -1,15 +1,15 @@
 import { HKT, HKTS } from './HKT'
-import { StaticMonoid } from './Monoid'
-import { StaticApplicative } from './Applicative'
-import { StaticMonad } from './Monad'
-import { StaticFoldable } from './Foldable'
-import { StaticTraversable } from './Traversable'
-import { StaticAlternative } from './Alternative'
-import { StaticPlus } from './Plus'
+import { Monoid } from './Monoid'
+import { Applicative } from './Applicative'
+import { Monad } from './Monad'
+import { Foldable } from './Foldable'
+import { Traversable } from './Traversable'
+import { Alternative } from './Alternative'
+import { Plus } from './Plus'
 import { liftA2 } from './Apply'
 import { Option } from './Option'
 import * as option from './Option'
-import { StaticOrd, toNativeComparator } from './Ord'
+import { Ord, toNativeComparator } from './Ord'
 import { Predicate, identity, constant, curry, Lazy, Endomorphism, Refinement } from './function'
 
 declare module './HKT' {
@@ -57,7 +57,7 @@ export function reduce<A, B>(f: (b: B, a: A) => B, b: B, fa: Array<A>): B {
 
 export const curriedSnoc = curry(snoc)
 
-export function traverse<F extends HKTS>(applicative: StaticApplicative<F>): <A, B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F], ta: Array<A>) => HKT<Array<B>, U, V>[F] {
+export function traverse<F extends HKTS>(applicative: Applicative<F>): <A, B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F], ta: Array<A>) => HKT<Array<B>, U, V>[F] {
   return <A, B>(f: (a: A) => HKT<B>[F], ta: Array<A>) => {
     const snocA2 = liftA2(applicative, curriedSnoc)
     return reduce((fab, a) => snocA2(fab, f(a)), applicative.of(empty()), ta)
@@ -218,18 +218,18 @@ export function catOptions<A>(as: Array<Option<A>>): Array<A> {
   return mapOption<Option<A>, A>(identity, as)
 }
 
-export function sort<A>(ord: StaticOrd<A>, as: Array<A>): Array<A> {
+export function sort<A>(ord: Ord<A>, as: Array<A>): Array<A> {
   return copy(as).sort(toNativeComparator(ord.compare))
 }
 
 // tslint:disable-next-line no-unused-expression
 ;(
   { empty, concat, map, of, ap, chain, reduce, traverse, zero, alt } as (
-    StaticMonoid<Array<any>> &
-    StaticMonad<URI> &
-    StaticFoldable<URI> &
-    StaticTraversable<URI> &
-    StaticAlternative<URI> &
-    StaticPlus<URI>
+    Monoid<Array<any>> &
+    Monad<URI> &
+    Foldable<URI> &
+    Traversable<URI> &
+    Alternative<URI> &
+    Plus<URI>
   )
 )

--- a/src/Bifunctor.ts
+++ b/src/Bifunctor.ts
@@ -1,6 +1,6 @@
 import { HKT, HKTS } from './HKT'
 
-export interface StaticBifunctor<F extends HKTS> {
+export interface Bifunctor<F extends HKTS> {
   readonly URI: F
   bimap<A, B, C, D, V = any>(f: (a: A) => B, g: (c: C) => D, fac: HKT<A, C, V>[F]): HKT<B, D, V>[F]
 }

--- a/src/Chain.ts
+++ b/src/Chain.ts
@@ -1,8 +1,8 @@
 import { HKT, HKTS } from './HKT'
-import { StaticApply, FantasyApply } from './Apply'
+import { Apply, FantasyApply } from './Apply'
 import { Kleisli, identity } from './function'
 
-export interface StaticChain<F extends HKTS> extends StaticApply<F> {
+export interface Chain<F extends HKTS> extends Apply<F> {
   chain<A, B, U = any, V = any>(f: Kleisli<F, A, B, U, V>, fa: HKT<A, U, V>[F]): HKT<B, U, V>[F]
 }
 
@@ -10,6 +10,6 @@ export interface FantasyChain<F extends HKTS, A> extends FantasyApply<F, A> {
   chain<B, U = any, V = any>(f: Kleisli<F, A, B, U, V>): HKT<B, U, V>[F]
 }
 
-export function flatten<F extends HKTS>(chain: StaticChain<F>): <A, U = any, V = any>(mma: HKT<HKT<A, U, V>[F], U, V>[F]) => HKT<A, U, V>[F] {
+export function flatten<F extends HKTS>(chain: Chain<F>): <A, U = any, V = any>(mma: HKT<HKT<A, U, V>[F], U, V>[F]) => HKT<A, U, V>[F] {
   return <A>(mma: HKT<HKT<A>[F]>[F]) => chain.chain<HKT<A>[F], A>(identity, mma)
 }

--- a/src/ChainRec.ts
+++ b/src/ChainRec.ts
@@ -1,9 +1,9 @@
 import { HKT, HKTS } from './HKT'
-import { StaticChain, FantasyChain } from './Chain'
+import { Chain, FantasyChain } from './Chain'
 import { Either, Right } from './Either'
 import { isLeft } from './Either'
 
-export interface StaticChainRec<F extends HKTS> extends StaticChain<F> {
+export interface ChainRec<F extends HKTS> extends Chain<F> {
   chainRec<A, B, U = any, V = any>(f: (a: A) => HKT<Either<A, B>, U, V>[F], a: A): HKT<B, U, V>[F]
 }
 

--- a/src/Comonad.ts
+++ b/src/Comonad.ts
@@ -1,7 +1,7 @@
 import { HKT, HKTS } from './HKT'
-import { StaticExtend, FantasyExtend } from './Extend'
+import { Extend, FantasyExtend } from './Extend'
 
-export interface StaticComonad<F extends HKTS> extends StaticExtend<F> {
+export interface Comonad<F extends HKTS> extends Extend<F> {
   extract<A>(ca: HKT<A>[F]): A
 }
 

--- a/src/Const.ts
+++ b/src/Const.ts
@@ -51,7 +51,7 @@ export function contramap<L, A>(fa: Const<L, A>): <B>(f: (b: B) => A) => Const<L
   return <B>(f: (b: B) => A) => fa.contramap(f)
 }
 
-export function getApply<L>(semigroup: StaticSemigroup<L>): StaticApply<URI> {
+export function getStaticApply<L>(semigroup: StaticSemigroup<L>): StaticApply<URI> {
   return {
     URI,
     map,
@@ -61,8 +61,8 @@ export function getApply<L>(semigroup: StaticSemigroup<L>): StaticApply<URI> {
   }
 }
 
-export function getApplicative<L>(monoid: StaticMonoid<L>): StaticApplicative<URI> {
-  const { ap } = getApply(monoid)
+export function getStaticApplicative<L>(monoid: StaticMonoid<L>): StaticApplicative<URI> {
+  const { ap } = getStaticApply(monoid)
   const empty = new Const<L, any>(monoid.empty())
   return {
     URI,

--- a/src/Const.ts
+++ b/src/Const.ts
@@ -1,10 +1,10 @@
-import { StaticMonoid } from './Monoid'
-import { StaticFunctor, FantasyFunctor } from './Functor'
-import { StaticContravariant, FantasyContravariant } from './Contravariant'
-import { StaticApplicative } from './Applicative'
-import { StaticApply } from './Apply'
-import { StaticSemigroup } from './Semigroup'
-import { StaticSetoid } from './Setoid'
+import { Monoid } from './Monoid'
+import { Functor, FantasyFunctor } from './Functor'
+import { Contravariant, FantasyContravariant } from './Contravariant'
+import { Applicative } from './Applicative'
+import { Apply } from './Apply'
+import { Semigroup } from './Semigroup'
+import { Setoid } from './Setoid'
 import { identity } from './function'
 
 declare module './HKT' {
@@ -34,12 +34,12 @@ export class Const<L, A> implements
   fold<B>(f: (l: L) => B): B {
     return f(this.value)
   }
-  equals(setoid: StaticSetoid<L>, fy: Const<L, A>): boolean {
+  equals(setoid: Setoid<L>, fy: Const<L, A>): boolean {
     return this.fold(x => fy.fold(y => setoid.equals(x, y)))
   }
 }
 
-export function equals<L, A>(setoid: StaticSetoid<L>, fx: Const<L, A>, fy: Const<L, A>): boolean {
+export function equals<L, A>(setoid: Setoid<L>, fx: Const<L, A>, fy: Const<L, A>): boolean {
   return fx.equals(setoid, fy)
 }
 
@@ -51,7 +51,7 @@ export function contramap<L, A>(fa: Const<L, A>): <B>(f: (b: B) => A) => Const<L
   return <B>(f: (b: B) => A) => fa.contramap(f)
 }
 
-export function getStaticApply<L>(semigroup: StaticSemigroup<L>): StaticApply<URI> {
+export function getApply<L>(semigroup: Semigroup<L>): Apply<URI> {
   return {
     URI,
     map,
@@ -61,8 +61,8 @@ export function getStaticApply<L>(semigroup: StaticSemigroup<L>): StaticApply<UR
   }
 }
 
-export function getStaticApplicative<L>(monoid: StaticMonoid<L>): StaticApplicative<URI> {
-  const { ap } = getStaticApply(monoid)
+export function getApplicative<L>(monoid: Monoid<L>): Applicative<URI> {
+  const { ap } = getApply(monoid)
   const empty = new Const<L, any>(monoid.empty())
   return {
     URI,
@@ -77,7 +77,7 @@ export function getStaticApplicative<L>(monoid: StaticMonoid<L>): StaticApplicat
 // tslint:disable-next-line no-unused-expression
 ;(
   { map, contramap } as (
-    StaticFunctor<URI> &
-    StaticContravariant<URI>
+    Functor<URI> &
+    Contravariant<URI>
   )
 )

--- a/src/Contravariant.ts
+++ b/src/Contravariant.ts
@@ -1,6 +1,6 @@
 import { HKT, HKTS } from './HKT'
 
-export interface StaticContravariant<F extends HKTS> {
+export interface Contravariant<F extends HKTS> {
   readonly URI: F
   contramap<A, U = any, V = any>(fa: HKT<A, U, V>[F]): <B>(f: (b: B) => A) => HKT<B, U, V>[F]
 }
@@ -9,6 +9,6 @@ export interface FantasyContravariant<F extends HKTS, A> {
   contramap<B, U = any, V = any>(f: (b: B) => A): HKT<B, U, V>[F]
 }
 
-export function lift<F extends HKTS, A, B>(contravariant: StaticContravariant<F>, f: (b: B) => A): <U = any, V = any>(fa: HKT<A, U, V>[F]) => HKT<B, U, V>[F] {
+export function lift<F extends HKTS, A, B>(contravariant: Contravariant<F>, f: (b: B) => A): <U = any, V = any>(fa: HKT<A, U, V>[F]) => HKT<B, U, V>[F] {
   return (fa: HKT<A>[F]) => contravariant.contramap(fa)(f)
 }

--- a/src/Dictionary.ts
+++ b/src/Dictionary.ts
@@ -1,14 +1,14 @@
 import { HKT, HKTS } from './HKT'
-import { StaticMonoid } from './Monoid'
-import { StaticFunctor } from './Functor'
-import { StaticApplicative } from './Applicative'
-import { StaticFoldable } from './Foldable'
-import { StaticTraversable } from './Traversable'
+import { Monoid } from './Monoid'
+import { Functor } from './Functor'
+import { Applicative } from './Applicative'
+import { Foldable } from './Foldable'
+import { Traversable } from './Traversable'
 import { constant, Lazy, curry } from './function'
 import { liftA2 } from './Apply'
-import { StaticSetoid } from './Setoid'
+import { Setoid } from './Setoid'
 import { Option, none, some } from './Option'
-import { StaticUnfoldable } from './Unfoldable'
+import { Unfoldable } from './Unfoldable'
 
 // https://github.com/purescript/purescript-maps
 
@@ -44,12 +44,12 @@ export function reduce<A, B>(f: (b: B, a: A) => B, b: B, fa: Dictionary<A>): B {
 
 export const curriedConcat = curry<Dictionary<any>, Dictionary<any>, Dictionary<any>>(concat)
 
-export function traverse<F extends HKTS>(applicative: StaticApplicative<F>): <A, B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F], ta: Dictionary<A>) => HKT<Dictionary<B>, U, V>[F] {
+export function traverse<F extends HKTS>(applicative: Applicative<F>): <A, B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F], ta: Dictionary<A>) => HKT<Dictionary<B>, U, V>[F] {
   const traverse = traverseWithKey(applicative)
   return <A, B>(f: (a: A) => HKT<B>[F], ta: Dictionary<A>) => traverse((_, a) => f(a), ta)
 }
 
-export function traverseWithKey<F extends HKTS>(applicative: StaticApplicative<F>): <A, B, U = any, V = any>(f: (k: string, a: A) => HKT<B, U, V>[F], ta: Dictionary<A>) => HKT<Dictionary<B>, U, V>[F] {
+export function traverseWithKey<F extends HKTS>(applicative: Applicative<F>): <A, B, U = any, V = any>(f: (k: string, a: A) => HKT<B, U, V>[F], ta: Dictionary<A>) => HKT<Dictionary<B>, U, V>[F] {
   return <A, B>(f: (k: string, a: A) => HKT<B>[F], ta: Dictionary<A>) => {
     const concatA2 = liftA2(applicative, curriedConcat)
     let out = applicative.of(empty())
@@ -61,7 +61,7 @@ export function traverseWithKey<F extends HKTS>(applicative: StaticApplicative<F
 }
 
 /** Test whether one dictionary contains all of the keys and values contained in another dictionary */
-export function isSubdictionary<A>(setoid: StaticSetoid<A>, d1: Dictionary<A>, d2: Dictionary<A>): boolean {
+export function isSubdictionary<A>(setoid: Setoid<A>, d1: Dictionary<A>, d2: Dictionary<A>): boolean {
   for (let k in d1) {
     if (!d2.hasOwnProperty(k) || !setoid.equals(d1[k], d2[k])) {
       return false
@@ -80,7 +80,7 @@ export function isEmpty<A>(d: Dictionary<A>): boolean {
   return size(d) === 0
 }
 
-export function getStaticSetoid<A>(setoid: StaticSetoid<A>): StaticSetoid<Dictionary<A>> {
+export function getSetoid<A>(setoid: Setoid<A>): Setoid<Dictionary<A>> {
   return {
     equals(x, y) {
       return isSubdictionary(setoid, x, y) && isSubdictionary(setoid, y, x)
@@ -101,7 +101,7 @@ export function lookup<A>(k: string, d: Dictionary<A>): Option<A> {
 /** Create a dictionary from a foldable collection of key/value pairs, using the
  * specified function to combine values for duplicate keys.
  */
-export function fromFoldable<F extends HKTS>(foldable: StaticFoldable<F>): <A>(f: (existing: A, a: A) => A, ta: HKT<[string, A]>[F]) => Dictionary<A> {
+export function fromFoldable<F extends HKTS>(foldable: Foldable<F>): <A>(f: (existing: A, a: A) => A, ta: HKT<[string, A]>[F]) => Dictionary<A> {
   return <A>(f: (existing: A, a: A) => A, ta: HKT<[string, A]>[F]) => foldable.reduce((b, a: [string, A]) => {
     const k = a[0]
     b[k] = b.hasOwnProperty(k) ? f(b[k], a[1]) : a[1]
@@ -122,7 +122,7 @@ export function toArray<A>(d: Dictionary<A>): Array<[string, A]> {
 }
 
 /** Unfolds a dictionary into a list of key/value pairs */
-export function toUnfoldable<F extends HKTS>(unfoldable: StaticUnfoldable<F>): <A>(d: Dictionary<A>) => HKT<[string, A]>[F] {
+export function toUnfoldable<F extends HKTS>(unfoldable: Unfoldable<F>): <A>(d: Dictionary<A>) => HKT<[string, A]>[F] {
   return <A>(d: Dictionary<A>) => {
     const arr = toArray(d)
     if (unfoldable.URI === 'Array') {
@@ -145,9 +145,9 @@ export function mapWithKey<A, B>(f: (k: string, a: A) => B, fa: Dictionary<A>): 
 // tslint:disable-next-line no-unused-expression
 ;(
   { empty, concat, map } as (
-    StaticMonoid<Dictionary<any>> &
-    StaticFunctor<URI> &
-    StaticFoldable<URI> &
-    StaticTraversable<URI>
+    Monoid<Dictionary<any>> &
+    Functor<URI> &
+    Foldable<URI> &
+    Traversable<URI>
   )
 )

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -1,13 +1,13 @@
 import { HKT, HKTS } from './HKT'
-import { StaticApplicative } from './Applicative'
-import { StaticMonad, FantasyMonad } from './Monad'
-import { StaticFoldable, FantasyFoldable } from './Foldable'
-import { StaticExtend, FantasyExtend } from './Extend'
-import { StaticSetoid } from './Setoid'
-import { StaticTraversable, FantasyTraversable } from './Traversable'
-import { StaticBifunctor, FantasyBifunctor } from './Bifunctor'
-import { StaticAlt, FantasyAlt } from './Alt'
-import { StaticChainRec, tailRec } from './ChainRec'
+import { Applicative } from './Applicative'
+import { Monad, FantasyMonad } from './Monad'
+import { Foldable, FantasyFoldable } from './Foldable'
+import { Extend, FantasyExtend } from './Extend'
+import { Setoid } from './Setoid'
+import { Traversable, FantasyTraversable } from './Traversable'
+import { Bifunctor, FantasyBifunctor } from './Bifunctor'
+import { Alt, FantasyAlt } from './Alt'
+import { ChainRec, tailRec } from './ChainRec'
 import { Option, none, some } from './Option'
 import { constFalse, constTrue, Predicate, Lazy } from './function'
 
@@ -61,7 +61,7 @@ export class Left<L, A> implements
   reduce<B>(f: (b: B, a: A) => B, b: B): B {
     return b
   }
-  traverse<F extends HKTS>(applicative: StaticApplicative<F>): <B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F]) => HKT<Either<L, B>, U, V>[F] {
+  traverse<F extends HKTS>(applicative: Applicative<F>): <B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F]) => HKT<Either<L, B>, U, V>[F] {
     return <B>(f: (a: A) => HKT<B>[F]) => applicative.of(this as any)
   }
   fold<B>(left: (l: L) => B, right: (a: A) => B): B {
@@ -70,7 +70,7 @@ export class Left<L, A> implements
   getOrElse(f: Lazy<A>): A {
     return f()
   }
-  equals(setoid: StaticSetoid<A>, fy: Either<L, A>): boolean {
+  equals(setoid: Setoid<A>, fy: Either<L, A>): boolean {
     return fy.fold(constTrue, constFalse)
   }
   mapLeft<L2>(f: (l: L) => L2): Either<L2, A> {
@@ -128,7 +128,7 @@ export class Right<L, A> implements
   reduce<B>(f: (b: B, a: A) => B, b: B): B {
     return f(b, this.value)
   }
-  traverse<F extends HKTS>(applicative: StaticApplicative<F>): <B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F]) => HKT<Either<L, B>, U, V>[F] {
+  traverse<F extends HKTS>(applicative: Applicative<F>): <B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F]) => HKT<Either<L, B>, U, V>[F] {
     return <B>(f: (a: A) => HKT<B>[F]) => applicative.map((b: B) => of<L, B>(b), f(this.value))
   }
   fold<B>(left: (l: L) => B, right: (a: A) => B): B {
@@ -137,7 +137,7 @@ export class Right<L, A> implements
   getOrElse(f: Lazy<A>): A {
     return this.value
   }
-  equals(setoid: StaticSetoid<A>, fy: Either<L, A>): boolean {
+  equals(setoid: Setoid<A>, fy: Either<L, A>): boolean {
     return fy.fold(constFalse, y => setoid.equals(this.value, y))
   }
   mapLeft<L2>(f: (l: L) => L2): Either<L2, A> {
@@ -154,7 +154,7 @@ export class Right<L, A> implements
   }
 }
 
-export function equals<L, A>(setoid: StaticSetoid<A>, fx: Either<L, A>, fy: Either<L, A>): boolean {
+export function equals<L, A>(setoid: Setoid<A>, fx: Either<L, A>, fy: Either<L, A>): boolean {
   return fx.equals(setoid, fy)
 }
 
@@ -198,7 +198,7 @@ export function reduce<L, A, B>(f: (b: B, a: A) => B, b: B, fa: Either<L, A>): B
   return fa.reduce(f, b)
 }
 
-export function traverse<F extends HKTS>(applicative: StaticApplicative<F>): <L, A, B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F], ta: Either<L, A>) => HKT<Either<L, B>, U, V>[F] {
+export function traverse<F extends HKTS>(applicative: Applicative<F>): <L, A, B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F], ta: Either<L, A>) => HKT<Either<L, B>, U, V>[F] {
   return <L, A, B>(f: (a: A) => HKT<B>[F], ta: Either<L, A>) => ta.traverse<F>(applicative)<B>(f)
 }
 
@@ -251,12 +251,12 @@ export function tryCatch<A>(f: Lazy<A>): Either<Error, A> {
 // tslint:disable-next-line no-unused-expression
 ; (
   { map, of, ap, chain, reduce, traverse, bimap, alt, extend, chainRec } as (
-    StaticMonad<URI> &
-    StaticFoldable<URI> &
-    StaticTraversable<URI> &
-    StaticBifunctor<URI> &
-    StaticAlt<URI> &
-    StaticExtend<URI> &
-    StaticChainRec<URI>
+    Monad<URI> &
+    Foldable<URI> &
+    Traversable<URI> &
+    Bifunctor<URI> &
+    Alt<URI> &
+    Extend<URI> &
+    ChainRec<URI>
   )
 )

--- a/src/EitherT.ts
+++ b/src/EitherT.ts
@@ -1,11 +1,11 @@
 import { HKT, HKTS } from './HKT'
-import { StaticMonad } from './Monad'
-import { getCompositionStaticApplicative } from './Applicative'
+import { Monad } from './Monad'
+import { getCompositionApplicative } from './Applicative'
 import { Either } from './Either'
 import * as either from './Either'
 import { Option } from './Option'
 
-export interface StaticEitherT<URI extends HKTS, M extends HKTS> extends StaticMonad<URI> {
+export interface EitherT<URI extends HKTS, M extends HKTS> extends Monad<URI> {
   /** lifts `M<A>` to `M<EitherT<L, A>>` */
   right<L, A, U = any, V = any>(ma: HKT<A, U, V>[M]): HKT<Either<L, A>, U, V>[M]
   /** lifts `M<L>` to `M<Either<L, A>>` */
@@ -16,8 +16,8 @@ export interface StaticEitherT<URI extends HKTS, M extends HKTS> extends StaticM
 }
 
 /** Note: requires an implicit proof that HKT<A>[URI] ~ HKT<Either<L, A>>[M] */
-export function getStaticEitherT<URI extends HKTS, M extends HKTS>(URI: URI, monad: StaticMonad<M>): StaticEitherT<URI, M> {
-  const applicative = getCompositionStaticApplicative(URI, monad, either)
+export function getEitherT<URI extends HKTS, M extends HKTS>(URI: URI, monad: Monad<M>): EitherT<URI, M> {
+  const applicative = getCompositionApplicative(URI, monad, either)
 
   function chain<L, A, B>(f: (a: A) => HKT<Either<L, B>>[M], fa: HKT<Either<L, A>>[M]): HKT<Either<L, B>>[M] {
     return monad.chain<Either<L, A>, Either<L, B>>(e => e.fold<HKT<Either<L, B>>[M]>(

--- a/src/EitherT.ts
+++ b/src/EitherT.ts
@@ -15,8 +15,9 @@ export interface StaticEitherT<URI extends HKTS, M extends HKTS> extends StaticM
   toOption<L, A, U = any, V = any>(fa: HKT<Either<L, A>, U, V>[M]): HKT<Option<A>, U, V>[M]
 }
 
+/** Note: requires an implicit proof that HKT<A>[URI] ~ HKT<Either<L, A>>[M] */
 export function getStaticEitherT<URI extends HKTS, M extends HKTS>(URI: URI, monad: StaticMonad<M>): StaticEitherT<URI, M> {
-  const applicative = getStaticApplicativeComposition(URI)(monad, either)
+  const applicative = getStaticApplicativeComposition(URI, monad, either)
 
   function chain<L, A, B>(f: (a: A) => HKT<Either<L, B>>[M], fa: HKT<Either<L, A>>[M]): HKT<Either<L, B>>[M] {
     return monad.chain<Either<L, A>, Either<L, B>>(e => e.fold<HKT<Either<L, B>>[M]>(

--- a/src/EitherT.ts
+++ b/src/EitherT.ts
@@ -1,6 +1,6 @@
 import { HKT, HKTS } from './HKT'
 import { StaticMonad } from './Monad'
-import { getStaticApplicativeComposition } from './Applicative'
+import { getCompositionStaticApplicative } from './Applicative'
 import { Either } from './Either'
 import * as either from './Either'
 import { Option } from './Option'
@@ -17,7 +17,7 @@ export interface StaticEitherT<URI extends HKTS, M extends HKTS> extends StaticM
 
 /** Note: requires an implicit proof that HKT<A>[URI] ~ HKT<Either<L, A>>[M] */
 export function getStaticEitherT<URI extends HKTS, M extends HKTS>(URI: URI, monad: StaticMonad<M>): StaticEitherT<URI, M> {
-  const applicative = getStaticApplicativeComposition(URI, monad, either)
+  const applicative = getCompositionStaticApplicative(URI, monad, either)
 
   function chain<L, A, B>(f: (a: A) => HKT<Either<L, B>>[M], fa: HKT<Either<L, A>>[M]): HKT<Either<L, B>>[M] {
     return monad.chain<Either<L, A>, Either<L, B>>(e => e.fold<HKT<Either<L, B>>[M]>(

--- a/src/Extend.ts
+++ b/src/Extend.ts
@@ -1,8 +1,8 @@
 import { HKT, HKTS } from './HKT'
 import { Cokleisli, identity } from './function'
-import { StaticFunctor, FantasyFunctor } from './Functor'
+import { Functor, FantasyFunctor } from './Functor'
 
-export interface StaticExtend<F extends HKTS> extends StaticFunctor<F> {
+export interface Extend<F extends HKTS> extends Functor<F> {
   extend<A, B, U = any, V = any>(f: Cokleisli<F, A, B, U, V>, ea: HKT<A, U, V>[F]): HKT<B, U, V>[F]
 }
 
@@ -10,6 +10,6 @@ export interface FantasyExtend<F extends HKTS, A> extends FantasyFunctor<F, A> {
   extend<B, U = any, V = any>(f: Cokleisli<F, A, B, U, V>): HKT<B, U, V>[F]
 }
 
-export function duplicate<F extends HKTS>(extend: StaticExtend<F>): <A, U = any, V = any>(ma: HKT<A, U, V>[F]) => HKT<HKT<A, U, V>[F], U, V>[F] {
+export function duplicate<F extends HKTS>(extend: Extend<F>): <A, U = any, V = any>(ma: HKT<A, U, V>[F]) => HKT<HKT<A, U, V>[F], U, V>[F] {
   return <A>(ma: HKT<A>[F]) => extend.extend<A, HKT<A>[F]>(identity, ma)
 }

--- a/src/Foldable.ts
+++ b/src/Foldable.ts
@@ -1,10 +1,10 @@
 import { HKT, HKTS } from './HKT'
-import { StaticMonoid } from './Monoid'
-import { StaticApplicative } from './Applicative'
+import { Monoid } from './Monoid'
+import { Applicative } from './Applicative'
 import { applyFirst } from './Apply'
 import { identity } from './function'
 
-export interface StaticFoldable<F extends HKTS> {
+export interface Foldable<F extends HKTS> {
   readonly URI: F
   reduce<A, B>(f: (b: B, a: A) => B, b: B, fa: HKT<A>[F]): B
 }
@@ -14,18 +14,18 @@ export interface FantasyFoldable<A> {
 }
 
 /** A default implementation of `foldMap` using `foldl`. */
-export function foldMap<F extends HKTS, M>(foldable: StaticFoldable<F>, monoid: StaticMonoid<M>): <A>(f: (a: A) => M, fa: HKT<A>[F]) => M {
+export function foldMap<F extends HKTS, M>(foldable: Foldable<F>, monoid: Monoid<M>): <A>(f: (a: A) => M, fa: HKT<A>[F]) => M {
   return <A>(f: (a: A) => M, fa: HKT<A>[F]) => foldable.reduce((acc, x: A) => monoid.concat(acc, f(x)), monoid.empty(), fa)
 }
 
-export function toArray<F extends HKTS>(foldable: StaticFoldable<F>): <A>(fa: HKT<A>[F]) => Array<A> {
+export function toArray<F extends HKTS>(foldable: Foldable<F>): <A>(fa: HKT<A>[F]) => Array<A> {
   return <A>(fa: HKT<A>[F]) => foldable.reduce<A, Array<A>>((b, a) => b.concat([a]), [], fa)
 }
 
 /** returns the composition of two foldables
  * Note: requires an implicit proof that HKT<A>[FG] ~ HKT<HKT<A>[G]>[F]
  */
-export function getCompositionStaticFoldable<FG extends HKTS, F extends HKTS, G extends HKTS>(URI: FG, foldableF: StaticFoldable<F>, foldableG: StaticFoldable<G>): StaticFoldable<FG> {
+export function getCompositionFoldable<FG extends HKTS, F extends HKTS, G extends HKTS>(URI: FG, foldableF: Foldable<F>, foldableG: Foldable<G>): Foldable<FG> {
   function reduce<A, B>(f: (b: B, a: A) => B, b: B, fga: HKT<HKT<A>[G]>[F]): B {
     return foldableF.reduce<HKT<A>[G], B>((b, ga) => foldableG.reduce(f, b, ga), b, fga)
   }
@@ -40,7 +40,7 @@ export function getCompositionStaticFoldable<FG extends HKTS, F extends HKTS, G 
  * Fold a data structure, accumulating values in some `Monoid`,
  * combining adjacent elements using the specified separator
  */
-export function intercalate<F extends HKTS, M>(foldable: StaticFoldable<F>, monoid: StaticMonoid<M>): (sep: M, fm: HKT<M>[F]) => M {
+export function intercalate<F extends HKTS, M>(foldable: Foldable<F>, monoid: Monoid<M>): (sep: M, fm: HKT<M>[F]) => M {
   return (sep, fm) => {
     function go({ init, acc }: { init: boolean, acc: M }, x: M): { init: boolean, acc: M } {
       return init ?
@@ -51,12 +51,12 @@ export function intercalate<F extends HKTS, M>(foldable: StaticFoldable<F>, mono
   }
 }
 
-export function traverse_<M extends HKTS, F extends HKTS>(applicative: StaticApplicative<M>, foldable: StaticFoldable<F>): <A, B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[M], fa: HKT<A, U, V>[F]) => HKT<void, U, V>[M] {
+export function traverse_<M extends HKTS, F extends HKTS>(applicative: Applicative<M>, foldable: Foldable<F>): <A, B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[M], fa: HKT<A, U, V>[F]) => HKT<void, U, V>[M] {
   return <A, B>(f: (a: A) => HKT<B>[M], fa: HKT<A>[F]) => toArray(foldable)<A>(fa)
     .reduce((mu, a) => applyFirst(applicative)<undefined, B>(mu, f(a)), applicative.of(undefined))
 }
 
-export function sequence_<M extends HKTS, F extends HKTS>(applicative: StaticApplicative<M>, foldable: StaticFoldable<F>): <A, U = any, V = any>(fa: HKT<A, U, V>[F]) => HKT<void, U, V>[M] {
+export function sequence_<M extends HKTS, F extends HKTS>(applicative: Applicative<M>, foldable: Foldable<F>): <A, U = any, V = any>(fa: HKT<A, U, V>[F]) => HKT<void, U, V>[M] {
   const t = traverse_(applicative, foldable)
   return <A>(fa: HKT<A>[F]) => t(identity, fa)
 }

--- a/src/Foldable.ts
+++ b/src/Foldable.ts
@@ -22,17 +22,17 @@ export function toArray<F extends HKTS>(foldable: StaticFoldable<F>): <A>(fa: HK
   return <A>(fa: HKT<A>[F]) => foldable.reduce<A, Array<A>>((b, a) => b.concat([a]), [], fa)
 }
 
-/** returns the composition of two foldables */
-export function getStaticFoldableComposition<FG extends HKTS>(URI: FG): <F extends HKTS, G extends HKTS>(foldableF: StaticFoldable<F>, foldableG: StaticFoldable<G>) => StaticFoldable<FG> {
-  return <F extends HKTS, G extends HKTS>(foldableF: StaticFoldable<F>, foldableG: StaticFoldable<G>) => {
-    function reduce<A, B>(f: (b: B, a: A) => B, b: B, fga: HKT<HKT<A>[G]>[F]): B {
-      return foldableF.reduce<HKT<A>[G], B>((b, ga) => foldableG.reduce(f, b, ga), b, fga)
-    }
+/** returns the composition of two foldables
+ * Note: requires an implicit proof that HKT<A>[FG] ~ HKT<HKT<A>[G]>[F]
+ */
+export function getStaticFoldableComposition<FG extends HKTS, F extends HKTS, G extends HKTS>(URI: FG, foldableF: StaticFoldable<F>, foldableG: StaticFoldable<G>): StaticFoldable<FG> {
+  function reduce<A, B>(f: (b: B, a: A) => B, b: B, fga: HKT<HKT<A>[G]>[F]): B {
+    return foldableF.reduce<HKT<A>[G], B>((b, ga) => foldableG.reduce(f, b, ga), b, fga)
+  }
 
-    return {
-      URI,
-      reduce
-    }
+  return {
+    URI,
+    reduce
   }
 }
 

--- a/src/Foldable.ts
+++ b/src/Foldable.ts
@@ -25,7 +25,7 @@ export function toArray<F extends HKTS>(foldable: StaticFoldable<F>): <A>(fa: HK
 /** returns the composition of two foldables
  * Note: requires an implicit proof that HKT<A>[FG] ~ HKT<HKT<A>[G]>[F]
  */
-export function getStaticFoldableComposition<FG extends HKTS, F extends HKTS, G extends HKTS>(URI: FG, foldableF: StaticFoldable<F>, foldableG: StaticFoldable<G>): StaticFoldable<FG> {
+export function getCompositionStaticFoldable<FG extends HKTS, F extends HKTS, G extends HKTS>(URI: FG, foldableF: StaticFoldable<F>, foldableG: StaticFoldable<G>): StaticFoldable<FG> {
   function reduce<A, B>(f: (b: B, a: A) => B, b: B, fga: HKT<HKT<A>[G]>[F]): B {
     return foldableF.reduce<HKT<A>[G], B>((b, ga) => foldableG.reduce(f, b, ga), b, fga)
   }

--- a/src/Free.ts
+++ b/src/Free.ts
@@ -1,7 +1,7 @@
 // adapted from http://okmij.org/ftp/Computation/free-monad.html
 
 import { HKT, HKTS } from './HKT'
-import { FantasyMonad, StaticMonad } from './Monad'
+import { FantasyMonad, Monad } from './Monad'
 import { identity as id } from './function'
 
 declare module './HKT' {
@@ -35,7 +35,7 @@ export class Pure<F, A> implements FantasyMonad<URI, A> {
   chain<B>(f: (a: A) => Free<F, B>): Free<F, B> {
     return f(this.a)
   }
-  foldMap<M extends HKTS, U = any, V = any>(monad: StaticMonad<M>, f: <A>(fa: F) => HKT<A, U, V>[M]): HKT<A, U, V>[M] {
+  foldMap<M extends HKTS, U = any, V = any>(monad: Monad<M>, f: <A>(fa: F) => HKT<A, U, V>[M]): HKT<A, U, V>[M] {
     return monad.of(this.a)
   }
 }
@@ -62,7 +62,7 @@ export class Impure<F, A> implements FantasyMonad<URI, A> {
   chain<B>(f: (a: A) => Free<F, B>): Free<F, B> {
     return new Impure<F, B>(this.fx, x => this.f(x).chain(f))
   }
-  foldMap<M extends HKTS, U = any, V = any>(monad: StaticMonad<M>, f: <A>(fa: F) => HKT<A, U, V>[M]): HKT<A, U, V>[M] {
+  foldMap<M extends HKTS, U = any, V = any>(monad: Monad<M>, f: <A>(fa: F) => HKT<A, U, V>[M]): HKT<A, U, V>[M] {
     return monad.chain<any, A>((x: any) => this.f(x).foldMap(monad, f), f(this.fx))
   }
 }

--- a/src/Functor.ts
+++ b/src/Functor.ts
@@ -16,7 +16,7 @@ export function lift<F extends HKTS, A, B>(functor: StaticFunctor<F>, f: (a: A) 
 /** returns the composition of two functors
  * Note: requires an implicit proof that HKT<A>[FG] ~ HKT<HKT<A>[G]>[F]
  */
-export function getStaticFunctorComposition<FG extends HKTS, F extends HKTS, G extends HKTS>(URI: FG, functorF: StaticFunctor<F>, functorG: StaticFunctor<G>): StaticFunctor<FG> {
+export function getCompositionStaticFunctor<FG extends HKTS, F extends HKTS, G extends HKTS>(URI: FG, functorF: StaticFunctor<F>, functorG: StaticFunctor<G>): StaticFunctor<FG> {
   return {
     URI,
     map<A, B>(f: (a: A) => B, fa: HKT<HKT<A>[G]>[F]): HKT<HKT<B>[G]>[F] {

--- a/src/Functor.ts
+++ b/src/Functor.ts
@@ -13,12 +13,14 @@ export function lift<F extends HKTS, A, B>(functor: StaticFunctor<F>, f: (a: A) 
   return (fa: HKT<A>[F]) => functor.map(f, fa)
 }
 
-/** returns the composition of two functors */
-export function getStaticFunctorComposition<FG extends HKTS>(URI: FG): <F extends HKTS, G extends HKTS>(functorF: StaticFunctor<F>, functorG: StaticFunctor<G>) => StaticFunctor<FG> {
-  return <F extends HKTS, G extends HKTS>(functorF: StaticFunctor<F>, functorG: StaticFunctor<G>): StaticFunctor<FG> => ({
+/** returns the composition of two functors
+ * Note: requires an implicit proof that HKT<A>[FG] ~ HKT<HKT<A>[G]>[F]
+ */
+export function getStaticFunctorComposition<FG extends HKTS, F extends HKTS, G extends HKTS>(URI: FG, functorF: StaticFunctor<F>, functorG: StaticFunctor<G>): StaticFunctor<FG> {
+  return {
     URI,
     map<A, B>(f: (a: A) => B, fa: HKT<HKT<A>[G]>[F]): HKT<HKT<B>[G]>[F] {
       return functorF.map((ga: HKT<A>[G]) => functorG.map(f, ga), fa)
     }
-  })
+  }
 }

--- a/src/Functor.ts
+++ b/src/Functor.ts
@@ -1,6 +1,6 @@
 import { HKT, HKTS } from './HKT'
 
-export interface StaticFunctor<F extends HKTS> {
+export interface Functor<F extends HKTS> {
   readonly URI: F
   map<A, B, U = any, V = any>(f: (a: A) => B, fa: HKT<A, U, V>[F]): HKT<B, U, V>[F]
 }
@@ -9,14 +9,14 @@ export interface FantasyFunctor<F extends HKTS, A> {
   map<B, U = any, V = any>(f: (a: A) => B): HKT<B, U, V>[F]
 }
 
-export function lift<F extends HKTS, A, B>(functor: StaticFunctor<F>, f: (a: A) => B): <U = any, V = any>(fa: HKT<A, U, V>[F]) => HKT<B, U, V>[F] {
+export function lift<F extends HKTS, A, B>(functor: Functor<F>, f: (a: A) => B): <U = any, V = any>(fa: HKT<A, U, V>[F]) => HKT<B, U, V>[F] {
   return (fa: HKT<A>[F]) => functor.map(f, fa)
 }
 
 /** returns the composition of two functors
  * Note: requires an implicit proof that HKT<A>[FG] ~ HKT<HKT<A>[G]>[F]
  */
-export function getCompositionStaticFunctor<FG extends HKTS, F extends HKTS, G extends HKTS>(URI: FG, functorF: StaticFunctor<F>, functorG: StaticFunctor<G>): StaticFunctor<FG> {
+export function getCompositionFunctor<FG extends HKTS, F extends HKTS, G extends HKTS>(URI: FG, functorF: Functor<F>, functorG: Functor<G>): Functor<FG> {
   return {
     URI,
     map<A, B>(f: (a: A) => B, fa: HKT<HKT<A>[G]>[F]): HKT<HKT<B>[G]>[F] {

--- a/src/IO.ts
+++ b/src/IO.ts
@@ -58,13 +58,13 @@ export function concat<A>(semigroup: StaticSemigroup<A>, fx: IO<A>, fy: IO<A>): 
   return fx.concat(semigroup, fy)
 }
 
-export function getSemigroup<A>(semigroup: StaticSemigroup<A>): StaticSemigroup<IO<A>> {
+export function getStaticSemigroup<A>(semigroup: StaticSemigroup<A>): StaticSemigroup<IO<A>> {
   return { concat: (fx, fy) => concat(semigroup, fx, fy) }
 }
 
-export function getMonoid<A>(monoid: StaticMonoid<A>): StaticMonoid<IO<A>> {
+export function getStaticMonoid<A>(monoid: StaticMonoid<A>): StaticMonoid<IO<A>> {
   const empty = monoid.empty()
-  return { empty: constant(of(empty)), concat: getSemigroup(monoid).concat }
+  return { empty: constant(of(empty)), concat: getStaticSemigroup(monoid).concat }
 }
 
 // tslint:disable-next-line no-unused-expression

--- a/src/IO.ts
+++ b/src/IO.ts
@@ -1,6 +1,6 @@
-import { StaticMonoid } from './Monoid'
-import { StaticSemigroup } from './Semigroup'
-import { StaticMonad, FantasyMonad } from './Monad'
+import { Monoid } from './Monoid'
+import { Semigroup } from './Semigroup'
+import { Monad, FantasyMonad } from './Monad'
 import { constant, Lazy } from './function'
 
 declare module './HKT' {
@@ -33,7 +33,7 @@ export class IO<A> implements FantasyMonad<URI, A> {
   chain<B>(f: (a: A) => IO<B>): IO<B> {
     return new IO(() => f(this.run()).run())
   }
-  concat(semigroup: StaticSemigroup<A>, fy: IO<A>): IO<A> {
+  concat(semigroup: Semigroup<A>, fy: IO<A>): IO<A> {
     return new IO(() => semigroup.concat(this.run(), fy.run()))
   }
 }
@@ -54,22 +54,22 @@ export function chain<A, B>(f: (a: A) => IO<B>, fa: IO<A>): IO<B> {
   return fa.chain(f)
 }
 
-export function concat<A>(semigroup: StaticSemigroup<A>, fx: IO<A>, fy: IO<A>): IO<A> {
+export function concat<A>(semigroup: Semigroup<A>, fx: IO<A>, fy: IO<A>): IO<A> {
   return fx.concat(semigroup, fy)
 }
 
-export function getStaticSemigroup<A>(semigroup: StaticSemigroup<A>): StaticSemigroup<IO<A>> {
+export function getSemigroup<A>(semigroup: Semigroup<A>): Semigroup<IO<A>> {
   return { concat: (fx, fy) => concat(semigroup, fx, fy) }
 }
 
-export function getStaticMonoid<A>(monoid: StaticMonoid<A>): StaticMonoid<IO<A>> {
+export function getMonoid<A>(monoid: Monoid<A>): Monoid<IO<A>> {
   const empty = monoid.empty()
-  return { empty: constant(of(empty)), concat: getStaticSemigroup(monoid).concat }
+  return { empty: constant(of(empty)), concat: getSemigroup(monoid).concat }
 }
 
 // tslint:disable-next-line no-unused-expression
 ;(
   { map, of, ap, chain } as (
-    StaticMonad<URI>
+    Monad<URI>
   )
 )

--- a/src/Identity.ts
+++ b/src/Identity.ts
@@ -1,13 +1,13 @@
 import { HKT, HKTS } from './HKT'
-import { StaticApplicative } from './Applicative'
-import { StaticMonad, FantasyMonad } from './Monad'
-import { StaticFoldable, FantasyFoldable } from './Foldable'
-import { StaticSetoid } from './Setoid'
-import { StaticTraversable, FantasyTraversable } from './Traversable'
-import { StaticAlt, FantasyAlt } from './Alt'
-import { StaticComonad, FantasyComonad } from './Comonad'
+import { Applicative } from './Applicative'
+import { Monad, FantasyMonad } from './Monad'
+import { Foldable, FantasyFoldable } from './Foldable'
+import { Setoid } from './Setoid'
+import { Traversable, FantasyTraversable } from './Traversable'
+import { Alt, FantasyAlt } from './Alt'
+import { Comonad, FantasyComonad } from './Comonad'
 import { Either } from './Either'
-import { StaticChainRec, tailRec } from './ChainRec'
+import { ChainRec, tailRec } from './ChainRec'
 
 declare module './HKT' {
   interface HKT<A> {
@@ -46,7 +46,7 @@ export class Identity<A> implements
   reduce<B>(f: (b: B, a: A) => B, b: B): B {
     return f(b, this.value)
   }
-  traverse<F extends HKTS>(applicative: StaticApplicative<F>): <B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F]) => HKT<Identity<B>, U, V>[F] {
+  traverse<F extends HKTS>(applicative: Applicative<F>): <B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F]) => HKT<Identity<B>, U, V>[F] {
     return <B>(f: (a: A) => HKT<B>[F]) => applicative.map<B, Identity<B>>(of, f(this.value))
   }
   alt(fx: Identity<A>): Identity<A> {
@@ -61,7 +61,7 @@ export class Identity<A> implements
   fold<B>(f: (a: A) => B): B {
     return f(this.value)
   }
-  equals(setoid: StaticSetoid<A>, fy: Identity<A>): boolean {
+  equals(setoid: Setoid<A>, fy: Identity<A>): boolean {
     return setoid.equals(this.value, fy.value)
   }
   inspect() {
@@ -72,7 +72,7 @@ export class Identity<A> implements
   }
 }
 
-export function equals<A>(setoid: StaticSetoid<A>, fx: Identity<A>, fy: Identity<A>): boolean {
+export function equals<A>(setoid: Setoid<A>, fx: Identity<A>, fy: Identity<A>): boolean {
   return fx.equals(setoid, fy as Identity<A>)
 }
 
@@ -100,7 +100,7 @@ export function alt<A>(fx: Identity<A>, fy: Identity<A>): Identity<A> {
   return fx.alt(fy)
 }
 
-export function traverse<F extends HKTS>(applicative: StaticApplicative<F>): <A, B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F], ta: Identity<A>) => HKT<Identity<B>, U, V>[F] {
+export function traverse<F extends HKTS>(applicative: Applicative<F>): <A, B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F], ta: Identity<A>) => HKT<Identity<B>, U, V>[F] {
   return <A, B>(f: (a: A) => HKT<B>[F], ta: Identity<A>) => ta.traverse<F>(applicative)<B>(f)
 }
 
@@ -119,11 +119,11 @@ export function chainRec<A, B>(f: (a: A) => Identity<Either<A, B>>, a: A): Ident
 // tslint:disable-next-line no-unused-expression
 ;(
   { map, of, ap, chain, reduce, traverse, alt, extract, extend, chainRec } as (
-    StaticMonad<URI> &
-    StaticFoldable<URI> &
-    StaticTraversable<URI> &
-    StaticAlt<URI> &
-    StaticComonad<URI> &
-    StaticChainRec<URI>
+    Monad<URI> &
+    Foldable<URI> &
+    Traversable<URI> &
+    Alt<URI> &
+    Comonad<URI> &
+    ChainRec<URI>
   )
 )

--- a/src/IxMonad.ts
+++ b/src/IxMonad.ts
@@ -1,10 +1,10 @@
 import { HKT, HKTS } from './HKT'
-import { StaticMonad, FantasyMonad } from './Monad'
+import { Monad, FantasyMonad } from './Monad'
 import { constant } from './function'
 
 // Adapted from https://github.com/garyb/purescript-indexed-monad
 
-export interface StaticIxMonad<F extends HKTS> extends StaticMonad<F> {
+export interface IxMonad<F extends HKTS> extends Monad<F> {
   iof<I, A>(a: A): HKT<A, I, I>[F]
   ichain<I, O, Z, A, B>(f: (a: A) => HKT<B, Z, O>[F], fa: HKT<A, O, I>[F]): HKT<B, Z, I>[F]
 }
@@ -14,10 +14,10 @@ export interface FantasyIxMonad<F extends HKTS, A, O, I> extends FantasyMonad<F,
   ichain<Z, B>(f: (a: A) => HKT<B, Z, O>[F]): HKT<B, Z, I>[F]
 }
 
-export function iapplyFirst<F extends HKTS>(ixmonad: StaticIxMonad<F>): <I, O, Z, A, B>(fa: HKT<A, O, I>[F], fb: HKT<B, Z, O>[F]) => HKT<A, Z, I>[F] {
+export function iapplyFirst<F extends HKTS>(ixmonad: IxMonad<F>): <I, O, Z, A, B>(fa: HKT<A, O, I>[F], fb: HKT<B, Z, O>[F]) => HKT<A, Z, I>[F] {
   return <I, O, Z, A, B>(fa: HKT<A, O, I>[F], fb: HKT<B, Z, O>[F]) => ixmonad.ichain(a => ixmonad.ichain(() => ixmonad.iof(a), fb), fa)
 }
 
-export function iapplySecond<F extends HKTS>(ixmonad: StaticIxMonad<F>): <I, O, Z, A, B>(fa: HKT<A, O, I>[F], fb: HKT<B, Z, O>[F]) => HKT<B, Z, I>[F] {
+export function iapplySecond<F extends HKTS>(ixmonad: IxMonad<F>): <I, O, Z, A, B>(fa: HKT<A, O, I>[F], fb: HKT<B, Z, O>[F]) => HKT<B, Z, I>[F] {
   return <I, O, Z, A, B>(fa: HKT<A, O, I>[F], fb: HKT<B, Z, O>[F]) => ixmonad.ichain(constant(fb), fa)
 }

--- a/src/Monad.ts
+++ b/src/Monad.ts
@@ -1,7 +1,7 @@
 import { HKTS } from './HKT'
-import { StaticApplicative, FantasyApplicative } from './Applicative'
-import { StaticChain, FantasyChain } from './Chain'
+import { Applicative, FantasyApplicative } from './Applicative'
+import { Chain, FantasyChain } from './Chain'
 
-export interface StaticMonad<F extends HKTS> extends StaticApplicative<F>, StaticChain<F> {}
+export interface Monad<F extends HKTS> extends Applicative<F>, Chain<F> {}
 
 export interface FantasyMonad<F extends HKTS, A> extends FantasyApplicative<F, A>, FantasyChain<F, A> {}

--- a/src/Monoid.ts
+++ b/src/Monoid.ts
@@ -1,69 +1,69 @@
 import {
-  StaticSemigroup,
-  getProductStaticSemigroup,
-  getDualStaticSemigroup,
+  Semigroup,
+  getProductSemigroup,
+  getDualSemigroup,
   fold as foldSemigroup
 } from './Semigroup'
 import { constant } from './function'
 
-export interface StaticMonoid<A> extends StaticSemigroup<A> {
+export interface Monoid<A> extends Semigroup<A> {
   empty(): A
 }
 
-export function fold<A>(monoid: StaticMonoid<A>, as: Array<A>): A {
+export function fold<A>(monoid: Monoid<A>, as: Array<A>): A {
   return foldSemigroup(monoid, monoid.empty(), as)
 }
 
-export function getProductStaticMonoid<A, B>(amonoid: StaticMonoid<A>, bmonoid: StaticMonoid<B>): StaticMonoid<[A, B]> {
+export function getProductMonoid<A, B>(amonoid: Monoid<A>, bmonoid: Monoid<B>): Monoid<[A, B]> {
   const empty: [A, B] = [amonoid.empty(), bmonoid.empty()]
   return {
     empty: () => empty,
-    concat: getProductStaticSemigroup(amonoid, bmonoid).concat
+    concat: getProductSemigroup(amonoid, bmonoid).concat
   }
 }
 
-export function getDualStaticMonoid<A>(monoid: StaticMonoid<A>): StaticMonoid<A> {
-  return { empty: monoid.empty, concat: getDualStaticSemigroup(monoid).concat }
+export function getDualMonoid<A>(monoid: Monoid<A>): Monoid<A> {
+  return { empty: monoid.empty, concat: getDualSemigroup(monoid).concat }
 }
 
 /** Boolean monoid under conjunction */
-export const monoidAll: StaticMonoid<boolean> = {
+export const monoidAll: Monoid<boolean> = {
   empty: () => true,
   concat: (x, y) => x && y
 }
 
 /** Boolean monoid under disjunction */
-export const monoidAny: StaticMonoid<boolean> = {
+export const monoidAny: Monoid<boolean> = {
   empty: () => false,
   concat: (x, y) => x || y
 }
 
 /** Monoid under array concatenation */
-export const monoidArray: StaticMonoid<Array<any>> = {
+export const monoidArray: Monoid<Array<any>> = {
   empty: () => [],
   concat: (x, y) => x.concat(y)
 }
 
 /** Monoid under addition */
-export const monoidSum: StaticMonoid<number> = {
+export const monoidSum: Monoid<number> = {
   empty: () => 0,
   concat: (x, y) => x + y
 }
 
 /** Monoid under multiplication */
-export const monoidProduct: StaticMonoid<number> = {
+export const monoidProduct: Monoid<number> = {
   empty: () => 1,
   concat: (x, y) => x * y
 }
 
-export const monoidString: StaticMonoid<string> = {
+export const monoidString: Monoid<string> = {
   empty: () => '',
   concat: (x, y) => x + y
 }
 
-export function getFunctionStaticMonoid<M>(monoid: StaticMonoid<M>): <A>() => StaticMonoid<(a: A) => M> {
+export function getFunctionMonoid<M>(monoid: Monoid<M>): <A>() => Monoid<(a: A) => M> {
   const empty = constant(constant(monoid.empty()))
-  return <A>(): StaticMonoid<(a: A) => M> => ({
+  return <A>(): Monoid<(a: A) => M> => ({
     empty,
     concat: (f, g) => a => monoid.concat(f(a), g(a))
   })

--- a/src/Monoidal.ts
+++ b/src/Monoidal.ts
@@ -1,6 +1,6 @@
 import { HKT, HKTS } from './HKT'
-import { StaticFunctor } from './Functor'
-import { StaticApplicative } from './Applicative'
+import { Functor } from './Functor'
+import { Applicative } from './Applicative'
 import { tuple } from './Tuple'
 import { constant } from './function'
 
@@ -9,13 +9,13 @@ import { constant } from './function'
  * - https://wiki.haskell.org/Typeclassopedia#Alternative_formulation
  * - https://bartoszmilewski.com/2017/02/06/applicative-functors/
  */
-export interface StaticMonoidal<F extends HKTS> extends StaticFunctor<F> {
+export interface Monoidal<F extends HKTS> extends Functor<F> {
   readonly URI: F
   unit<U = any, V = any>(): HKT<void, U, V>[F]
   mult<A, B, U = any, V = any>(fa: HKT<A, U, V>[F], fb: HKT<B, U, V>[F]): HKT<[A, B], U, V>[F]
 }
 
-export function fromApplicative<F extends HKTS>(applicative: StaticApplicative<F>): StaticMonoidal<F> {
+export function fromApplicative<F extends HKTS>(applicative: Applicative<F>): Monoidal<F> {
   return {
     URI: applicative.URI,
     map: applicative.map,
@@ -28,7 +28,7 @@ export function fromApplicative<F extends HKTS>(applicative: StaticApplicative<F
   }
 }
 
-export function toApplicative<F extends HKTS>(monoidal: StaticMonoidal<F>): StaticApplicative<F> {
+export function toApplicative<F extends HKTS>(monoidal: Monoidal<F>): Applicative<F> {
   return {
     URI: monoidal.URI,
     map: monoidal.map,

--- a/src/NonEmptyArray.ts
+++ b/src/NonEmptyArray.ts
@@ -1,9 +1,9 @@
 import { HKT, HKTS } from './HKT'
-import { StaticMonad, FantasyMonad } from './Monad'
-import { StaticSemigroup } from './Semigroup'
-import { StaticFoldable, FantasyFoldable } from './Foldable'
-import { StaticApplicative } from './Applicative'
-import { StaticTraversable, FantasyTraversable } from './Traversable'
+import { Monad, FantasyMonad } from './Monad'
+import { Semigroup } from './Semigroup'
+import { Foldable, FantasyFoldable } from './Foldable'
+import { Applicative } from './Applicative'
+import { Traversable, FantasyTraversable } from './Traversable'
 import * as array from './Array'
 import { Option, some, none } from './Option'
 
@@ -49,7 +49,7 @@ export class NonEmptyArray<A> implements
   reduce<B>(f: (b: B, a: A) => B, b: B): B {
     return array.reduce(f, b, this.toArray())
   }
-  traverse<F extends HKTS>(applicative: StaticApplicative<F>): <B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F]) => HKT<NonEmptyArray<B>, U, V>[F] {
+  traverse<F extends HKTS>(applicative: Applicative<F>): <B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F]) => HKT<NonEmptyArray<B>, U, V>[F] {
     return <B>(f: (a: A) => HKT<B>[F]) => applicative.map((bs: Array<B>) => unsafeFromArray(bs), array.traverse<F>(applicative)<A, B>(f, this.toArray()))
   }
 }
@@ -86,16 +86,16 @@ export function reduce<A, B>(f: (b: B, a: A) => B, b: B, fa: NonEmptyArray<A>): 
   return fa.reduce(f, b)
 }
 
-export function traverse<F extends HKTS>(applicative: StaticApplicative<F>): <A, B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F], ta: NonEmptyArray<A>) => HKT<NonEmptyArray<B>, U, V>[F] {
+export function traverse<F extends HKTS>(applicative: Applicative<F>): <A, B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F], ta: NonEmptyArray<A>) => HKT<NonEmptyArray<B>, U, V>[F] {
   return <A, B>(f: (a: A) => HKT<B>[F], ta: NonEmptyArray<A>) => ta.traverse<F>(applicative)<B>(f)
 }
 
 // tslint:disable-next-line no-unused-expression
 ;(
   { map, of, ap, chain, concat, reduce, traverse } as (
-    StaticMonad<URI> &
-    StaticSemigroup<any> &
-    StaticFoldable<URI> &
-    StaticTraversable<URI>
+    Monad<URI> &
+    Semigroup<any> &
+    Foldable<URI> &
+    Traversable<URI>
   )
 )

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -1,14 +1,14 @@
 import { HKT, HKTS } from './HKT'
-import { StaticMonoid, getDualStaticMonoid } from './Monoid'
-import { StaticApplicative } from './Applicative'
-import { StaticSemigroup } from './Semigroup'
-import { StaticMonad, FantasyMonad } from './Monad'
-import { StaticFoldable, FantasyFoldable } from './Foldable'
-import { StaticPlus } from './Plus'
-import { StaticExtend, FantasyExtend } from './Extend'
-import { StaticSetoid } from './Setoid'
-import { StaticTraversable, FantasyTraversable } from './Traversable'
-import { StaticAlternative, FantasyAlternative } from './Alternative'
+import { Monoid, getDualMonoid } from './Monoid'
+import { Applicative } from './Applicative'
+import { Semigroup } from './Semigroup'
+import { Monad, FantasyMonad } from './Monad'
+import { Foldable, FantasyFoldable } from './Foldable'
+import { Plus } from './Plus'
+import { Extend, FantasyExtend } from './Extend'
+import { Setoid } from './Setoid'
+import { Traversable, FantasyTraversable } from './Traversable'
+import { Alternative, FantasyAlternative } from './Alternative'
 import { constant, constFalse, constTrue, Lazy, Predicate } from './function'
 
 declare module './HKT' {
@@ -53,7 +53,7 @@ export class None<A> implements
   reduce<B>(f: (b: B, a: A) => B, b: B): B {
     return b
   }
-  traverse<F extends HKTS>(applicative: StaticApplicative<F>): <B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F]) => HKT<Option<B>, U, V>[F] {
+  traverse<F extends HKTS>(applicative: Applicative<F>): <B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F]) => HKT<Option<B>, U, V>[F] {
     return <B>(f: (a: A) => HKT<B>[F]) => applicative.of(none)
   }
   zero<B>(): Option<B> {
@@ -71,10 +71,10 @@ export class None<A> implements
   getOrElse(f: Lazy<A>): A {
     return f()
   }
-  concat(semigroup: StaticSemigroup<A>, fy: Option<A>): Option<A> {
+  concat(semigroup: Semigroup<A>, fy: Option<A>): Option<A> {
     return fy
   }
-  equals(setoid: StaticSetoid<A>, fy: Option<A>): boolean {
+  equals(setoid: Setoid<A>, fy: Option<A>): boolean {
     return fy.fold(constTrue, constFalse)
   }
   toNullable(): A | null {
@@ -127,7 +127,7 @@ export class Some<A> implements
   reduce<B>(f: (b: B, a: A) => B, b: B): B {
     return this.fold<B>(constant(b), (a: A) => f(b, a))
   }
-  traverse<F extends HKTS>(applicative: StaticApplicative<F>): <B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F]) => HKT<Option<B>, U, V>[F] {
+  traverse<F extends HKTS>(applicative: Applicative<F>): <B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F]) => HKT<Option<B>, U, V>[F] {
     return <B>(f: (a: A) => HKT<B>[F]) => applicative.map<B, Option<B>>(some, f(this.value))
   }
   zero<B>(): Option<B> {
@@ -145,10 +145,10 @@ export class Some<A> implements
   getOrElse(f: Lazy<A>): A {
     return this.value
   }
-  concat(semigroup: StaticSemigroup<A>, fy: Option<A>): Option<A> {
+  concat(semigroup: Semigroup<A>, fy: Option<A>): Option<A> {
     return fy.fold(() => this, y => new Some(semigroup.concat(this.value, y)))
   }
-  equals(setoid: StaticSetoid<A>, fy: Option<A>): boolean {
+  equals(setoid: Setoid<A>, fy: Option<A>): boolean {
     return fy.fold(constFalse, y => setoid.equals(this.value, y))
   }
   toNullable(): A | null {
@@ -162,7 +162,7 @@ export class Some<A> implements
   }
 }
 
-export function equals<A>(setoid: StaticSetoid<A>, fx: Option<A>, fy: Option<A>): boolean {
+export function equals<A>(setoid: Setoid<A>, fx: Option<A>, fy: Option<A>): boolean {
   return fx.equals(setoid, fy)
 }
 
@@ -198,7 +198,7 @@ export function reduce<A, B>(f: (b: B, a: A) => B, b: B, fa: Option<A>): B {
   return fa.reduce(f, b)
 }
 
-export function traverse<F extends HKTS>(applicative: StaticApplicative<F>): <A, B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F], ta: Option<A>) => HKT<Option<B>, U, V>[F] {
+export function traverse<F extends HKTS>(applicative: Applicative<F>): <A, B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F], ta: Option<A>) => HKT<Option<B>, U, V>[F] {
   return <A, B>(f: (a: A) => HKT<B>[F], ta: Option<A>) => ta.traverse<F>(applicative)<B>(f)
 }
 
@@ -211,28 +211,28 @@ export function extend<A, B>(f: (ea: Option<A>) => B, ea: Option<A>): Option<B> 
 }
 
 const first = { empty, concat: alt }
-const last = getDualStaticMonoid(first)
+const last = getDualMonoid(first)
 
 /** Maybe monoid returning the left-most non-None value */
-export function getFirstStaticMonoid<A>(): StaticMonoid<Option<A>> {
+export function getFirstMonoid<A>(): Monoid<Option<A>> {
   return first
 }
 
 /** Maybe monoid returning the right-most non-None value */
-export function getLastStaticMonoid<A>(): StaticMonoid<Option<A>> {
+export function getLastMonoid<A>(): Monoid<Option<A>> {
   return last
 }
 
-export function concat<A>(semigroup: StaticSemigroup<A>, fx: Option<A>, fy: Option<A>): Option<A> {
+export function concat<A>(semigroup: Semigroup<A>, fx: Option<A>, fy: Option<A>): Option<A> {
   return fx.concat(semigroup, fy)
 }
 
-export function getStaticSemigroup<A>(semigroup: StaticSemigroup<A>): StaticSemigroup<Option<A>> {
+export function getSemigroup<A>(semigroup: Semigroup<A>): Semigroup<Option<A>> {
   return { concat: (fx, fy) => concat(semigroup, fx, fy) }
 }
 
-export function getStaticMonoid<A>(semigroup: StaticSemigroup<A>): StaticMonoid<Option<A>> {
-  return { empty, concat: getStaticSemigroup(semigroup).concat }
+export function getMonoid<A>(semigroup: Semigroup<A>): Monoid<Option<A>> {
+  return { empty, concat: getSemigroup(semigroup).concat }
 }
 
 export function isSome<A>(fa: Option<A>): fa is Some<A> {
@@ -252,11 +252,11 @@ export function fromPredicate<A>(predicate: Predicate<A>): (a: A) => Option<A> {
 // tslint:disable-next-line no-unused-expression
 ;(
   { map, of, ap, chain, reduce, traverse, zero, alt, extend } as (
-    StaticMonad<URI> &
-    StaticFoldable<URI> &
-    StaticPlus<URI> &
-    StaticTraversable<URI> &
-    StaticAlternative<URI> &
-    StaticExtend<URI>
+    Monad<URI> &
+    Foldable<URI> &
+    Plus<URI> &
+    Traversable<URI> &
+    Alternative<URI> &
+    Extend<URI>
   )
 )

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -1,5 +1,5 @@
 import { HKT, HKTS } from './HKT'
-import { StaticMonoid } from './Monoid'
+import { StaticMonoid, getDualStaticMonoid } from './Monoid'
 import { StaticApplicative } from './Applicative'
 import { StaticSemigroup } from './Semigroup'
 import { StaticMonad, FantasyMonad } from './Monad'
@@ -210,9 +210,17 @@ export function extend<A, B>(f: (ea: Option<A>) => B, ea: Option<A>): Option<B> 
   return ea.extend(f)
 }
 
-/** Maybe monoid returning the leftmost non-None value */
+const first = { empty, concat: alt }
+const last = getDualStaticMonoid(first)
+
+/** Maybe monoid returning the left-most non-None value */
 export function getFirstStaticMonoid<A>(): StaticMonoid<Option<A>> {
-  return { empty, concat: alt }
+  return first
+}
+
+/** Maybe monoid returning the right-most non-None value */
+export function getLastStaticMonoid<A>(): StaticMonoid<Option<A>> {
+  return last
 }
 
 export function concat<A>(semigroup: StaticSemigroup<A>, fx: Option<A>, fy: Option<A>): Option<A> {

--- a/src/OptionT.ts
+++ b/src/OptionT.ts
@@ -1,11 +1,11 @@
 import { HKT, HKTS } from './HKT'
-import { StaticMonad } from './Monad'
-import { getCompositionStaticApplicative } from './Applicative'
+import { Monad } from './Monad'
+import { getCompositionApplicative } from './Applicative'
 import { Option } from './Option'
 import * as option from './Option'
 import { Lazy } from './function'
 
-export interface StaticOptionT<URI extends HKTS, M extends HKTS> extends StaticMonad<URI> {
+export interface OptionT<URI extends HKTS, M extends HKTS> extends Monad<URI> {
   some<A, U = any, V = any>(a: A): HKT<Option<A>, U, V>[M]
   none<U = any, V = any>(): HKT<Option<any>, U, V>[M]
   fromOption<A, U = any, V = any>(oa: Option<A>): HKT<Option<A>, U, V>[M]
@@ -15,8 +15,8 @@ export interface StaticOptionT<URI extends HKTS, M extends HKTS> extends StaticM
 }
 
 /** Note: requires an implicit proof that HKT<A>[URI] ~ HKT<Option<A>>[M] */
-export function getStaticOptionT<URI extends HKTS, M extends HKTS>(URI: URI, monad: StaticMonad<M>): StaticOptionT<URI, M> {
-  const applicative = getCompositionStaticApplicative(URI, monad, option)
+export function getOptionT<URI extends HKTS, M extends HKTS>(URI: URI, monad: Monad<M>): OptionT<URI, M> {
+  const applicative = getCompositionApplicative(URI, monad, option)
 
   function chain<A, B>(f: (a: A) => HKT<Option<B>>[M], fa: HKT<Option<A>>[M]): HKT<Option<B>>[M] {
     return monad.chain<Option<A>, Option<B>>(e => e.fold<HKT<Option<B>>[M]>(

--- a/src/OptionT.ts
+++ b/src/OptionT.ts
@@ -14,8 +14,9 @@ export interface StaticOptionT<URI extends HKTS, M extends HKTS> extends StaticM
   getOrElse<A, U = any, V = any>(f: Lazy<A>, fa: HKT<Option<A>, U, V>[M]): HKT<A, U, V>[M]
 }
 
+/** Note: requires an implicit proof that HKT<A>[URI] ~ HKT<Option<A>>[M] */
 export function getStaticOptionT<URI extends HKTS, M extends HKTS>(URI: URI, monad: StaticMonad<M>): StaticOptionT<URI, M> {
-  const applicative = getStaticApplicativeComposition(URI)(monad, option)
+  const applicative = getStaticApplicativeComposition(URI, monad, option)
 
   function chain<A, B>(f: (a: A) => HKT<Option<B>>[M], fa: HKT<Option<A>>[M]): HKT<Option<B>>[M] {
     return monad.chain<Option<A>, Option<B>>(e => e.fold<HKT<Option<B>>[M]>(

--- a/src/OptionT.ts
+++ b/src/OptionT.ts
@@ -1,6 +1,6 @@
 import { HKT, HKTS } from './HKT'
 import { StaticMonad } from './Monad'
-import { getStaticApplicativeComposition } from './Applicative'
+import { getCompositionStaticApplicative } from './Applicative'
 import { Option } from './Option'
 import * as option from './Option'
 import { Lazy } from './function'
@@ -16,7 +16,7 @@ export interface StaticOptionT<URI extends HKTS, M extends HKTS> extends StaticM
 
 /** Note: requires an implicit proof that HKT<A>[URI] ~ HKT<Option<A>>[M] */
 export function getStaticOptionT<URI extends HKTS, M extends HKTS>(URI: URI, monad: StaticMonad<M>): StaticOptionT<URI, M> {
-  const applicative = getStaticApplicativeComposition(URI, monad, option)
+  const applicative = getCompositionStaticApplicative(URI, monad, option)
 
   function chain<A, B>(f: (a: A) => HKT<Option<B>>[M], fa: HKT<Option<A>>[M]): HKT<Option<B>>[M] {
     return monad.chain<Option<A>, Option<B>>(e => e.fold<HKT<Option<B>>[M]>(

--- a/src/Ord.ts
+++ b/src/Ord.ts
@@ -1,12 +1,12 @@
 import { Ordering } from './Ordering'
 import {
-  StaticSetoid,
+  Setoid,
   setoidBoolean,
   setoidNumber,
   setoidString
 } from './Setoid'
 
-export interface StaticOrd<A> extends StaticSetoid<A> {
+export interface Ord<A> extends Setoid<A> {
   compare(x: A, y: A): Ordering
 }
 
@@ -21,40 +21,40 @@ export function unsafeCompare(x: any, y: any): Ordering {
   return x < y ? 'LT' : x > y ? 'GT' : 'EQ'
 }
 
-export const stringOrd: StaticOrd<string> = { compare: unsafeCompare, equals: setoidString.equals }
+export const stringOrd: Ord<string> = { compare: unsafeCompare, equals: setoidString.equals }
 
-export const numberOrd: StaticOrd<number> = { compare: unsafeCompare, equals: setoidNumber.equals }
+export const numberOrd: Ord<number> = { compare: unsafeCompare, equals: setoidNumber.equals }
 
-export const booleanOrd: StaticOrd<boolean> = { compare: unsafeCompare, equals: setoidBoolean.equals }
+export const booleanOrd: Ord<boolean> = { compare: unsafeCompare, equals: setoidBoolean.equals }
 
-export function lessThan<A>(ord: StaticOrd<A>, x: A, y: A): boolean {
+export function lessThan<A>(ord: Ord<A>, x: A, y: A): boolean {
   return ord.compare(x, y) === 'LT'
 }
 
-export function greaterThan<A>(ord: StaticOrd<A>, x: A, y: A): boolean {
+export function greaterThan<A>(ord: Ord<A>, x: A, y: A): boolean {
   return ord.compare(x, y) === 'GT'
 }
 
-export function lessThanOrEq<A>(ord: StaticOrd<A>, x: A, y: A): boolean {
+export function lessThanOrEq<A>(ord: Ord<A>, x: A, y: A): boolean {
   return ord.compare(x, y) !== 'GT'
 }
 
-export function greaterThanOrEq<A>(ord: StaticOrd<A>, x: A, y: A): boolean {
+export function greaterThanOrEq<A>(ord: Ord<A>, x: A, y: A): boolean {
   return ord.compare(x, y) !== 'LT'
 }
 
-export function min<A>(ord: StaticOrd<A>, x: A, y: A): A {
+export function min<A>(ord: Ord<A>, x: A, y: A): A {
   return ord.compare(x, y) === 'GT' ? y : x
 }
 
-export function max<A>(ord: StaticOrd<A>, x: A, y: A): A {
+export function max<A>(ord: Ord<A>, x: A, y: A): A {
   return ord.compare(x, y) === 'LT' ? y : x
 }
 
-export function clamp<A>(ord: StaticOrd<A>, low: A, hi: A, x: A): A {
+export function clamp<A>(ord: Ord<A>, low: A, hi: A, x: A): A {
   return min(ord, hi, max(ord, low, x))
 }
 
-export function between<A>(ord: StaticOrd<A>, low: A, hi: A, x: A): boolean {
+export function between<A>(ord: Ord<A>, low: A, hi: A, x: A): boolean {
   return lessThan(ord, x, low) || greaterThan(ord, x, hi) ? false : true
 }

--- a/src/Ordering.ts
+++ b/src/Ordering.ts
@@ -1,15 +1,15 @@
-import { StaticSetoid } from './Setoid'
-import { StaticSemigroup } from './Semigroup'
+import { Setoid } from './Setoid'
+import { Semigroup } from './Semigroup'
 
 export type Ordering = 'LT' | 'EQ' | 'GT'
 
-export const orderingSetoid: StaticSetoid<Ordering> = {
+export const orderingSetoid: Setoid<Ordering> = {
   equals(a, b) {
     return a === b
   }
 }
 
-export const orderingSemigroup: StaticSemigroup<Ordering> = {
+export const orderingSemigroup: Semigroup<Ordering> = {
   concat(a, b) {
     if (a === 'LT') {
       return 'LT'

--- a/src/Plus.ts
+++ b/src/Plus.ts
@@ -1,7 +1,7 @@
 import { HKT, HKTS } from './HKT'
-import { StaticAlt, FantasyAlt } from './Alt'
+import { Alt, FantasyAlt } from './Alt'
 
-export interface StaticPlus<F extends HKTS> extends StaticAlt<F> {
+export interface Plus<F extends HKTS> extends Alt<F> {
   zero(): HKT<any>[F]
 }
 

--- a/src/Profunctor.ts
+++ b/src/Profunctor.ts
@@ -1,8 +1,8 @@
 import { HKT, HKTS } from './HKT'
-import { StaticFunctor, FantasyFunctor } from './Functor'
+import { Functor, FantasyFunctor } from './Functor'
 import { identity } from './function'
 
-export interface StaticProfunctor<F extends HKTS> extends StaticFunctor<F> {
+export interface Profunctor<F extends HKTS> extends Functor<F> {
   promap<A, B, C, D, V = any>(ab: (a: A) => B, cd: (c: C) => D, fbc: HKT<C, B, V>[F]): HKT<D, A, V>[F]
 }
 
@@ -10,10 +10,10 @@ export interface FantasyProfunctor<F extends HKTS, B, C> extends FantasyFunctor<
   promap<A, D, V = any>(ab: (a: A) => B, cd: (c: C) => D): HKT<D, A, V>[F]
 }
 
-export function lmap<F extends HKTS>(profunctor: StaticProfunctor<F>): <A, B, C, V = any>(f: (a: A) => B, fbc: HKT<C, B, V>[F]) => HKT<C, A, V>[F] {
+export function lmap<F extends HKTS>(profunctor: Profunctor<F>): <A, B, C, V = any>(f: (a: A) => B, fbc: HKT<C, B, V>[F]) => HKT<C, A, V>[F] {
   return <A, B, C>(f: (a: A) => B, fbc: HKT<C, B>[F]) => profunctor.promap<A, B, C, C>(f, identity, fbc)
 }
 
-export function rmap<F extends HKTS>(profunctor: StaticProfunctor<F>): <B, C, D, V = any>(f: (a: C) => D, fbc: HKT<C, B, V>[F]) => HKT<D, B, V>[F] {
+export function rmap<F extends HKTS>(profunctor: Profunctor<F>): <B, C, D, V = any>(f: (a: C) => D, fbc: HKT<C, B, V>[F]) => HKT<D, B, V>[F] {
   return <B, C, D>(f: (a: C) => D, fbc: HKT<C, B>[F]) => profunctor.map<C, D>(f, fbc)
 }

--- a/src/Reader.ts
+++ b/src/Reader.ts
@@ -1,4 +1,4 @@
-import { StaticMonad, FantasyMonad } from './Monad'
+import { Monad, FantasyMonad } from './Monad'
 import { identity, Endomorphism } from './function'
 
 declare module './HKT' {
@@ -68,6 +68,6 @@ export function local<E, A>(f: Endomorphism<E>, fa: Reader<E, A>): Reader<E, A> 
 // tslint:disable-next-line no-unused-expression
 ;(
   { map, of, ap, chain } as (
-    StaticMonad<URI>
+    Monad<URI>
   )
 )

--- a/src/ReaderT.ts
+++ b/src/ReaderT.ts
@@ -1,10 +1,10 @@
 import { HKT, HKTS } from './HKT'
-import { StaticMonad } from './Monad'
+import { Monad } from './Monad'
 import { Reader } from './Reader'
 import * as reader from './Reader'
 import { Endomorphism } from './function'
 
-export interface StaticReaderT<M extends HKTS> {
+export interface ReaderT<M extends HKTS> {
   of<E, A, U = any, V = any>(a: A): Reader<E, HKT<A, U, V>[M]>
   map<E, A, B, U = any, V = any>(f: (a: A) => B, fa: Reader<E, HKT<A, U, V>[M]>): Reader<E, HKT<B, U, V>[M]>
   ap<E, A, B, U = any, V = any>(fab: Reader<E, HKT<(a: A) => B, U, V>[M]>, fa: Reader<E, HKT<A, U, V>[M]>): Reader<E, HKT<B, U, V>[M]>
@@ -14,7 +14,7 @@ export interface StaticReaderT<M extends HKTS> {
   local<E, A, U = any, V = any>(f: Endomorphism<E>, fa: Reader<E, HKT<A, U, V>[M]>): Reader<E, HKT<A, U, V>[M]>
 }
 
-export function getStaticReaderT<M extends HKTS>(monad: StaticMonad<M>): StaticReaderT<M> {
+export function getReaderT<M extends HKTS>(monad: Monad<M>): ReaderT<M> {
   function of<E, A>(a: A): Reader<E, HKT<A>[M]> {
     return reader.of<E, HKT<A>[M]>(monad.of(a))
   }

--- a/src/Semigroup.ts
+++ b/src/Semigroup.ts
@@ -1,23 +1,23 @@
-export interface StaticSemigroup<A> {
+export interface Semigroup<A> {
   concat(x: A, y: A): A
 }
 
-export function fold<A>(semigroup: StaticSemigroup<A>, a: A, as: Array<A>): A {
+export function fold<A>(semigroup: Semigroup<A>, a: A, as: Array<A>): A {
   return as.reduce((acc, a) => semigroup.concat(acc, a), a)
 }
 
-export function getFirstStaticSemigroup<A>(): StaticSemigroup<A> {
+export function getFirstSemigroup<A>(): Semigroup<A> {
   return { concat: (x, y) => x }
 }
 
-export function getLastStaticSemigroup<A>(): StaticSemigroup<A> {
+export function getLastSemigroup<A>(): Semigroup<A> {
   return { concat: (x, y) => y }
 }
 
-export function getProductStaticSemigroup<A, B>(asemigroup: StaticSemigroup<A>, bsemigroup: StaticSemigroup<B>): StaticSemigroup<[A, B]> {
+export function getProductSemigroup<A, B>(asemigroup: Semigroup<A>, bsemigroup: Semigroup<B>): Semigroup<[A, B]> {
   return { concat: ([xa, xb], [ya, yb]) => [asemigroup.concat(xa, ya), bsemigroup.concat(xb, yb)] }
 }
 
-export function getDualStaticSemigroup<A>(semigroup: StaticSemigroup<A>): StaticSemigroup<A> {
+export function getDualSemigroup<A>(semigroup: Semigroup<A>): Semigroup<A> {
   return { concat: (x, y) => semigroup.concat(y, x) }
 }

--- a/src/Semigroupoid.ts
+++ b/src/Semigroupoid.ts
@@ -1,5 +1,5 @@
 import { HKT, HKTS } from './HKT'
 
-export interface StaticSemigroupoid<F extends HKTS> {
+export interface Semigroupoid<F extends HKTS> {
   compose<A, B, C, V = any>(bc: HKT<C, B, V>[F], ab: HKT<B, A, V>[F]): HKT<C, A, V>[F]
 }

--- a/src/Setoid.ts
+++ b/src/Setoid.ts
@@ -1,4 +1,4 @@
-export interface StaticSetoid<M> {
+export interface Setoid<M> {
   equals(x: M, y: M): boolean
 }
 
@@ -6,8 +6,8 @@ export function strictEqual(a: any, b: any): boolean {
   return a === b
 }
 
-export const setoidString: StaticSetoid<string> = { equals: strictEqual }
+export const setoidString: Setoid<string> = { equals: strictEqual }
 
-export const setoidNumber: StaticSetoid<number> = { equals: strictEqual }
+export const setoidNumber: Setoid<number> = { equals: strictEqual }
 
-export const setoidBoolean: StaticSetoid<boolean> = { equals: strictEqual }
+export const setoidBoolean: Setoid<boolean> = { equals: strictEqual }

--- a/src/State.ts
+++ b/src/State.ts
@@ -1,4 +1,4 @@
-import { StaticMonad, FantasyMonad } from './Monad'
+import { Monad, FantasyMonad } from './Monad'
 import { Endomorphism } from './function'
 
 declare module './HKT' {
@@ -80,6 +80,6 @@ export function gets<S, A>(f: (s: S) => A): State<S, A> {
 // tslint:disable-next-line no-unused-expression
 ;(
   { map, of, ap, chain } as (
-    StaticMonad<URI>
+    Monad<URI>
   )
 )

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -1,6 +1,6 @@
 import { HKT, HKTS } from './HKT'
-import { StaticComonad, FantasyComonad } from './Comonad'
-import { StaticFunctor } from './Functor'
+import { Comonad, FantasyComonad } from './Comonad'
+import { Functor } from './Functor'
 import { Endomorphism } from './function'
 
 export const URI = 'Store'
@@ -75,13 +75,13 @@ export function seeks<S, A>(f: Endomorphism<S>, sa: Store<S, A>): Store<S, A> {
 }
 
 /** Extract a collection of values from positions which depend on the current position */
-export function experiment<F extends HKTS, S, A, U = any, V = any>(functor: StaticFunctor<F>, f: (s: S) => HKT<S, U, V>[F], sa: Store<S, A>): HKT<A, U, V>[F] {
+export function experiment<F extends HKTS, S, A, U = any, V = any>(functor: Functor<F>, f: (s: S) => HKT<S, U, V>[F], sa: Store<S, A>): HKT<A, U, V>[F] {
   return functor.map<S, A>(s => sa.peek(s), f(sa.pos()))
 }
 
 // tslint:disable-next-line no-unused-expression
 ; (
   { map, extract, extend } as (
-    StaticComonad<URI>
+    Comonad<URI>
   )
 )

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -1,5 +1,5 @@
-import { StaticMonoid } from './Monoid'
-import { StaticMonad, FantasyMonad } from './Monad'
+import { Monoid } from './Monoid'
+import { Monad, FantasyMonad } from './Monad'
 import { Lazy } from './function'
 
 declare module './HKT' {
@@ -82,7 +82,7 @@ export function empty<A>(): Task<A> {
 // tslint:disable-next-line no-unused-expression
 ;(
   { map, of, ap, chain, concat, empty } as (
-    StaticMonad<URI> &
-    StaticMonoid<Task<any>>
+    Monad<URI> &
+    Monoid<Task<any>>
   )
 )

--- a/src/These.ts
+++ b/src/These.ts
@@ -1,8 +1,8 @@
 import { HKT, HKTS } from './HKT'
-import { StaticApplicative } from './Applicative'
+import { Applicative } from './Applicative'
 import { Option, none, some } from './Option'
-import { StaticSetoid } from './Setoid'
-import { StaticSemigroup } from './Semigroup'
+import { Setoid } from './Setoid'
+import { Semigroup } from './Semigroup'
 import { constFalse } from './function'
 
 // Data type isomorphic to `α ∨ β ∨ (α ∧ β)`
@@ -30,14 +30,14 @@ export class This<L, A> {
   map<B>(f: (a: A) => B): These<L, B> {
     return this as any
   }
-  ap<B>(semigroupL: StaticSemigroup<L>, fab: These<L, (a: A) => B>): These<L, B> {
+  ap<B>(semigroupL: Semigroup<L>, fab: These<L, (a: A) => B>): These<L, B> {
     return fab.fold(
       () => fab as any,
       () => this as any,
       (l, _) => this_<L, B>(semigroupL.concat(l, this.value))
     )
   }
-  chain<B>(semigroupL: StaticSemigroup<L>, f: (a: A) => These<L, B>): These<L, B> {
+  chain<B>(semigroupL: Semigroup<L>, f: (a: A) => These<L, B>): These<L, B> {
     return this as any
   }
   bimap<L2, B>(f: (l: L) => L2, g: (a: A) => B): These<L2, B> {
@@ -46,20 +46,20 @@ export class This<L, A> {
   reduce<B>(f: (b: B, a: A) => B, b: B): B {
     return b
   }
-  traverse<F extends HKTS>(applicative: StaticApplicative<F>): <B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F]) => HKT<These<L, B>, U, V>[F] {
+  traverse<F extends HKTS>(applicative: Applicative<F>): <B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F]) => HKT<These<L, B>, U, V>[F] {
     return <B>(f: (a: A) => HKT<B>[F]) => applicative.of(this)
   }
   fold<B>(this_: (l: L) => B, that: (a: A) => B, both: (l: L, a: A) => B): B {
     return this_(this.value)
   }
-  equals(setoidL: StaticSetoid<L>, setoidA: StaticSetoid<A>, fy: These<L, A>): boolean {
+  equals(setoidL: Setoid<L>, setoidA: Setoid<A>, fy: These<L, A>): boolean {
     return fy.fold(
       l => setoidL.equals(l, this.value),
       constFalse,
       constFalse
     )
   }
-  concat(semigroupL: StaticSemigroup<L>, semigroupA: StaticSemigroup<A>, fy: These<L, A>): These<L, A> {
+  concat(semigroupL: Semigroup<L>, semigroupA: Semigroup<A>, fy: These<L, A>): These<L, A> {
     return fy.fold(
       l => this_<L, A>(semigroupL.concat(this.value, l)),
       a => both(this.value, a),
@@ -78,14 +78,14 @@ export class That<L, A> {
   map<B>(f: (a: A) => B): These<L, B> {
     return new That<L, B>(f(this.value))
   }
-  ap<B>(semigroupL: StaticSemigroup<L>, fab: These<L, (a: A) => B>): These<L, B> {
+  ap<B>(semigroupL: Semigroup<L>, fab: These<L, (a: A) => B>): These<L, B> {
     return fab.fold(
       () => fab as any,
       f => that(f(this.value)),
       (l, f) => both(l, f(this.value))
     )
   }
-  chain<B>(semigroupL: StaticSemigroup<L>, f: (a: A) => These<L, B>): These<L, B> {
+  chain<B>(semigroupL: Semigroup<L>, f: (a: A) => These<L, B>): These<L, B> {
     return f(this.value)
   }
   bimap<L2, B>(f: (l: L) => L2, g: (a: A) => B): These<L2, B> {
@@ -94,20 +94,20 @@ export class That<L, A> {
   reduce<B>(f: (b: B, a: A) => B, b: B): B {
     return f(b, this.value)
   }
-  traverse<F extends HKTS>(applicative: StaticApplicative<F>): <B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F]) => HKT<These<L, B>, U, V>[F] {
+  traverse<F extends HKTS>(applicative: Applicative<F>): <B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F]) => HKT<These<L, B>, U, V>[F] {
     return <B>(f: (a: A) => HKT<B>[F]) => applicative.map((b: B) => that<L, B>(b), f(this.value))
   }
   fold<B>(this_: (l: L) => B, that: (a: A) => B, both: (l: L, a: A) => B): B {
     return that(this.value)
   }
-  equals(setoidL: StaticSetoid<L>, setoidA: StaticSetoid<A>, fy: These<L, A>): boolean {
+  equals(setoidL: Setoid<L>, setoidA: Setoid<A>, fy: These<L, A>): boolean {
     return fy.fold(
       constFalse,
       a => setoidA.equals(a, this.value),
       constFalse
     )
   }
-  concat(semigroupL: StaticSemigroup<L>, semigroupA: StaticSemigroup<A>, fy: These<L, A>): These<L, A> {
+  concat(semigroupL: Semigroup<L>, semigroupA: Semigroup<A>, fy: These<L, A>): These<L, A> {
     return fy.fold(
       l => both(l, this.value),
       a => that<L, A>(semigroupA.concat(this.value, a)),
@@ -126,14 +126,14 @@ export class Both<L, A> {
   map<B>(f: (a: A) => B): These<L, B> {
     return new Both<L, B>(this.l, f(this.a))
   }
-  ap<B>(semigroupL: StaticSemigroup<L>, fab: These<L, (a: A) => B>): These<L, B> {
+  ap<B>(semigroupL: Semigroup<L>, fab: These<L, (a: A) => B>): These<L, B> {
     return fab.fold(
       () => fab as any,
       f => both(this.l, f(this.a)),
       (l, f) => both(semigroupL.concat(l, this.l), f(this.a))
     )
   }
-  chain<B>(semigroupL: StaticSemigroup<L>, f: (a: A) => These<L, B>): These<L, B> {
+  chain<B>(semigroupL: Semigroup<L>, f: (a: A) => These<L, B>): These<L, B> {
     return f(this.a).fold(
       l => this_<L, B>(semigroupL.concat(this.l, l)),
       a => both(this.l, a),
@@ -146,20 +146,20 @@ export class Both<L, A> {
   reduce<B>(f: (b: B, a: A) => B, b: B): B {
     return f(b, this.a)
   }
-  traverse<F extends HKTS>(applicative: StaticApplicative<F>): <B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F]) => HKT<These<L, B>, U, V>[F] {
+  traverse<F extends HKTS>(applicative: Applicative<F>): <B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F]) => HKT<These<L, B>, U, V>[F] {
     return <B>(f: (a: A) => HKT<B>[F]) => applicative.map((b: B) => both(this.l, b), f(this.a))
   }
   fold<B>(this_: (l: L) => B, that: (a: A) => B, both: (l: L, a: A) => B): B {
     return both(this.l, this.a)
   }
-  equals(setoidL: StaticSetoid<L>, setoidA: StaticSetoid<A>, fy: These<L, A>): boolean {
+  equals(setoidL: Setoid<L>, setoidA: Setoid<A>, fy: These<L, A>): boolean {
     return fy.fold(
       constFalse,
       constFalse,
       (l, a) => setoidL.equals(l, this.l) && setoidA.equals(a, this.a)
     )
   }
-  concat(semigroupL: StaticSemigroup<L>, semigroupA: StaticSemigroup<A>, fy: These<L, A>): These<L, A> {
+  concat(semigroupL: Semigroup<L>, semigroupA: Semigroup<A>, fy: These<L, A>): These<L, A> {
     return fy.fold(
       l => both(semigroupL.concat(this.l, l), this.a),
       a => both(this.l, semigroupA.concat(this.a, a)),
@@ -168,11 +168,11 @@ export class Both<L, A> {
   }
 }
 
-export function equals<L, A>(setoidL: StaticSetoid<L>, setoidA: StaticSetoid<A>, fx: These<L, A>, fy: These<L, A>): boolean {
+export function equals<L, A>(setoidL: Setoid<L>, setoidA: Setoid<A>, fx: These<L, A>, fy: These<L, A>): boolean {
   return fx.equals(setoidL, setoidA, fy)
 }
 
-export function concat<L, A>(semigroupL: StaticSemigroup<L>, semigroupA: StaticSemigroup<A>, fx: These<L, A>, fy: These<L, A>): These<L, A> {
+export function concat<L, A>(semigroupL: Semigroup<L>, semigroupA: Semigroup<A>, fx: These<L, A>, fy: These<L, A>): These<L, A> {
   return fx.concat(semigroupL, semigroupA, fy)
 }
 
@@ -187,11 +187,11 @@ export function of<L, A>(a: A): These<L, A> {
   return new That<L, A>(a)
 }
 
-export function ap<L, A, B>(semigroupL: StaticSemigroup<L>, fab: These<L, (a: A) => B>, fa: These<L, A>): These<L, B> {
+export function ap<L, A, B>(semigroupL: Semigroup<L>, fab: These<L, (a: A) => B>, fa: These<L, A>): These<L, B> {
   return fa.ap(semigroupL, fab)
 }
 
-export function chain<L, A, B>(semigroupL: StaticSemigroup<L>, f: (a: A) => These<L, B>, fa: These<L, A>): These<L, B> {
+export function chain<L, A, B>(semigroupL: Semigroup<L>, f: (a: A) => These<L, B>, fa: These<L, A>): These<L, B> {
   return fa.chain(semigroupL, f)
 }
 
@@ -203,7 +203,7 @@ export function reduce<L, A, B>(f: (b: B, a: A) => B, b: B, fa: These<L, A>): B 
   return fa.reduce(f, b)
 }
 
-export function traverse<F extends HKTS>(applicative: StaticApplicative<F>): <L, A, B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F], ta: These<L, A>) => HKT<These<L, B>, U, V>[F] {
+export function traverse<F extends HKTS>(applicative: Applicative<F>): <L, A, B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F], ta: These<L, A>) => HKT<These<L, B>, U, V>[F] {
   return <L, A, B>(f: (a: A) => HKT<B>[F], ta: These<L, A>) => ta.traverse<F>(applicative)<B>(f)
 }
 

--- a/src/Traced.ts
+++ b/src/Traced.ts
@@ -1,5 +1,5 @@
-import { StaticMonoid } from './Monoid'
-import { StaticComonad, FantasyComonad } from './Comonad'
+import { Monoid } from './Monoid'
+import { Comonad, FantasyComonad } from './Comonad'
 
 declare module './HKT' {
   interface HKT<A, U> {
@@ -15,7 +15,7 @@ export class Traced<E, A> implements FantasyComonad<URI, A> {
   readonly _E: E
   readonly _A: A
   readonly _URI: URI
-  constructor(public readonly monoid: StaticMonoid<E>, public readonly value: (e: E) => A) { }
+  constructor(public readonly monoid: Monoid<E>, public readonly value: (e: E) => A) { }
   run(e: E): A {
     return this.value(e)
   }
@@ -55,6 +55,6 @@ export function extend<E, A, B>(f: (ea: Traced<E, A>) => B, ea: Traced<E, A>): T
 // tslint:disable-next-line no-unused-expression
 ;(
   { map, extract, extend } as (
-    StaticComonad<URI>
+    Comonad<URI>
   )
 )

--- a/src/Traversable.ts
+++ b/src/Traversable.ts
@@ -1,29 +1,29 @@
 import { HKT, HKTS } from './HKT'
-import { StaticFunctor, FantasyFunctor, getCompositionStaticFunctor } from './Functor'
-import { StaticFoldable, FantasyFoldable, getCompositionStaticFoldable } from './Foldable'
-import { StaticApplicative } from './Applicative'
+import { Functor, FantasyFunctor, getCompositionFunctor } from './Functor'
+import { Foldable, FantasyFoldable, getCompositionFoldable } from './Foldable'
+import { Applicative } from './Applicative'
 import { identity } from './function'
 
-export interface StaticTraversable<T extends HKTS> extends StaticFunctor<T>, StaticFoldable<T> {
-  traverse<F extends HKTS>(applicative: StaticApplicative<F>): <A, B, UF = any, UT = any, VF = any, VT = any>(f: (a: A) => HKT<B, UF, VF>[F], ta: HKT<A, UT, VT>[T]) => HKT<HKT<B, UT, VT>[T], UF, VF>[F]
+export interface Traversable<T extends HKTS> extends Functor<T>, Foldable<T> {
+  traverse<F extends HKTS>(applicative: Applicative<F>): <A, B, UF = any, UT = any, VF = any, VT = any>(f: (a: A) => HKT<B, UF, VF>[F], ta: HKT<A, UT, VT>[T]) => HKT<HKT<B, UT, VT>[T], UF, VF>[F]
 }
 
 export interface FantasyTraversable<T extends HKTS, A> extends FantasyFunctor<T, A>, FantasyFoldable<A> {
-  traverse<F extends HKTS>(applicative: StaticApplicative<F>): <B, UF = any, UT = any, VF = any, VT = any>(f: (a: A) => HKT<B, UF, VF>[F]) => HKT<HKT<B, UT, VT>[T], UF, VF>[F]
+  traverse<F extends HKTS>(applicative: Applicative<F>): <B, UF = any, UT = any, VF = any, VT = any>(f: (a: A) => HKT<B, UF, VF>[F]) => HKT<HKT<B, UT, VT>[T], UF, VF>[F]
 }
 
-export function sequence<F extends HKTS, T extends HKTS>(applicative: StaticApplicative<F>, traversable: StaticTraversable<T>): <A, UF = any, UT = any, VF = any, VT = any>(tfa: HKT<HKT<A, UF, VF>[F], UT, VT>[T]) => HKT<HKT<A, UT, VT>[T], UF, VF>[F] {
+export function sequence<F extends HKTS, T extends HKTS>(applicative: Applicative<F>, traversable: Traversable<T>): <A, UF = any, UT = any, VF = any, VT = any>(tfa: HKT<HKT<A, UF, VF>[F], UT, VT>[T]) => HKT<HKT<A, UT, VT>[T], UF, VF>[F] {
   return <A>(tfa: HKT<HKT<A>[F]>[T]) => traversable.traverse<F>(applicative)<HKT<A>[F], A>(identity, tfa)
 }
 
 /** returns the composition of two traversables
  * Note: requires an implicit proof that HKT<A>[FG] ~ HKT<HKT<A>[G]>[F]
  */
-export function getCompositionStaticTraversable<FG extends HKTS, F extends HKTS, G extends HKTS>(URI: FG, traversableF: StaticTraversable<F>, traversableG: StaticTraversable<G>): StaticTraversable<FG> {
-  const functor = getCompositionStaticFunctor(URI, traversableF, traversableG)
-  const foldable = getCompositionStaticFoldable(URI, traversableF, traversableG)
+export function getCompositionTraversable<FG extends HKTS, F extends HKTS, G extends HKTS>(URI: FG, traversableF: Traversable<F>, traversableG: Traversable<G>): Traversable<FG> {
+  const functor = getCompositionFunctor(URI, traversableF, traversableG)
+  const foldable = getCompositionFoldable(URI, traversableF, traversableG)
 
-  function traverse<AP extends HKTS>(applicative: StaticApplicative<AP>): <A, B>(f: (a: A) => HKT<B>[AP], fga: HKT<HKT<A>[G]>[F]) => HKT<HKT<HKT<A>[G]>[F]>[AP] {
+  function traverse<AP extends HKTS>(applicative: Applicative<AP>): <A, B>(f: (a: A) => HKT<B>[AP], fga: HKT<HKT<A>[G]>[F]) => HKT<HKT<HKT<A>[G]>[F]>[AP] {
     return <A, B>(f: (a: A) => HKT<B>[AP], fga: HKT<HKT<A>[G]>[F]) =>
       traversableF.traverse(applicative)<HKT<A>[G], HKT<B>[G]>((ga: HKT<A>[G]) => traversableG.traverse(applicative)<A, B>(f, ga), fga)
   }

--- a/src/Traversable.ts
+++ b/src/Traversable.ts
@@ -16,21 +16,21 @@ export function sequence<F extends HKTS, T extends HKTS>(applicative: StaticAppl
   return <A>(tfa: HKT<HKT<A>[F]>[T]) => traversable.traverse<F>(applicative)<HKT<A>[F], A>(identity, tfa)
 }
 
-/** returns the composition of two traversables */
-export function getStaticTraversableComposition<FG extends HKTS>(URI: FG): <F extends HKTS, G extends HKTS>(traversableF: StaticTraversable<F>, traversableG: StaticTraversable<G>) => StaticTraversable<FG> {
-  return <F extends HKTS, G extends HKTS>(traversableF: StaticTraversable<F>, traversableG: StaticTraversable<G>) => {
-    const functor = getStaticFunctorComposition(URI)(traversableF, traversableG)
-    const foldable = getStaticFoldableComposition(URI)(traversableF, traversableG)
+/** returns the composition of two traversables
+ * Note: requires an implicit proof that HKT<A>[FG] ~ HKT<HKT<A>[G]>[F]
+ */
+export function getStaticTraversableComposition<FG extends HKTS, F extends HKTS, G extends HKTS>(URI: FG, traversableF: StaticTraversable<F>, traversableG: StaticTraversable<G>): StaticTraversable<FG> {
+  const functor = getStaticFunctorComposition(URI, traversableF, traversableG)
+  const foldable = getStaticFoldableComposition(URI, traversableF, traversableG)
 
-    function traverse<AP extends HKTS>(applicative: StaticApplicative<AP>): <A, B>(f: (a: A) => HKT<B>[AP], fga: HKT<HKT<A>[G]>[F]) => HKT<HKT<HKT<A>[G]>[F]>[AP] {
-      return <A, B>(f: (a: A) => HKT<B>[AP], fga: HKT<HKT<A>[G]>[F]) =>
-        traversableF.traverse(applicative)<HKT<A>[G], HKT<B>[G]>((ga: HKT<A>[G]) => traversableG.traverse(applicative)<A, B>(f, ga), fga)
-    }
+  function traverse<AP extends HKTS>(applicative: StaticApplicative<AP>): <A, B>(f: (a: A) => HKT<B>[AP], fga: HKT<HKT<A>[G]>[F]) => HKT<HKT<HKT<A>[G]>[F]>[AP] {
+    return <A, B>(f: (a: A) => HKT<B>[AP], fga: HKT<HKT<A>[G]>[F]) =>
+      traversableF.traverse(applicative)<HKT<A>[G], HKT<B>[G]>((ga: HKT<A>[G]) => traversableG.traverse(applicative)<A, B>(f, ga), fga)
+  }
 
-    return {
-      ...functor,
-      ...foldable,
-      traverse
-    }
+  return {
+    ...functor,
+    ...foldable,
+    traverse
   }
 }

--- a/src/Traversable.ts
+++ b/src/Traversable.ts
@@ -1,6 +1,6 @@
 import { HKT, HKTS } from './HKT'
-import { StaticFunctor, FantasyFunctor, getStaticFunctorComposition } from './Functor'
-import { StaticFoldable, FantasyFoldable, getStaticFoldableComposition } from './Foldable'
+import { StaticFunctor, FantasyFunctor, getCompositionStaticFunctor } from './Functor'
+import { StaticFoldable, FantasyFoldable, getCompositionStaticFoldable } from './Foldable'
 import { StaticApplicative } from './Applicative'
 import { identity } from './function'
 
@@ -19,9 +19,9 @@ export function sequence<F extends HKTS, T extends HKTS>(applicative: StaticAppl
 /** returns the composition of two traversables
  * Note: requires an implicit proof that HKT<A>[FG] ~ HKT<HKT<A>[G]>[F]
  */
-export function getStaticTraversableComposition<FG extends HKTS, F extends HKTS, G extends HKTS>(URI: FG, traversableF: StaticTraversable<F>, traversableG: StaticTraversable<G>): StaticTraversable<FG> {
-  const functor = getStaticFunctorComposition(URI, traversableF, traversableG)
-  const foldable = getStaticFoldableComposition(URI, traversableF, traversableG)
+export function getCompositionStaticTraversable<FG extends HKTS, F extends HKTS, G extends HKTS>(URI: FG, traversableF: StaticTraversable<F>, traversableG: StaticTraversable<G>): StaticTraversable<FG> {
+  const functor = getCompositionStaticFunctor(URI, traversableF, traversableG)
+  const foldable = getCompositionStaticFoldable(URI, traversableF, traversableG)
 
   function traverse<AP extends HKTS>(applicative: StaticApplicative<AP>): <A, B>(f: (a: A) => HKT<B>[AP], fga: HKT<HKT<A>[G]>[F]) => HKT<HKT<HKT<A>[G]>[F]>[AP] {
     return <A, B>(f: (a: A) => HKT<B>[AP], fga: HKT<HKT<A>[G]>[F]) =>

--- a/src/Tuple.ts
+++ b/src/Tuple.ts
@@ -1,16 +1,16 @@
 import { HKT, HKTS } from './HKT'
-import { StaticSetoid } from './Setoid'
-import { StaticOrd } from './Ord'
-import { StaticSemigroupoid } from './Semigroupoid'
-import { StaticSemigroup } from './Semigroup'
-import { StaticMonoid } from './Monoid'
-import { StaticBifunctor } from './Bifunctor'
-import { StaticComonad } from './Comonad'
-import { StaticApply } from './Apply'
-import { StaticMonad } from './Monad'
-import { StaticFoldable } from './Foldable'
-import { StaticApplicative } from './Applicative'
-import { StaticTraversable } from './Traversable'
+import { Setoid } from './Setoid'
+import { Ord } from './Ord'
+import { Semigroupoid } from './Semigroupoid'
+import { Semigroup } from './Semigroup'
+import { Monoid } from './Monoid'
+import { Bifunctor } from './Bifunctor'
+import { Comonad } from './Comonad'
+import { Apply } from './Apply'
+import { Monad } from './Monad'
+import { Foldable } from './Foldable'
+import { Applicative } from './Applicative'
+import { Traversable } from './Traversable'
 import { Cokleisli } from './function'
 
 // https://github.com/purescript/purescript-tuples
@@ -49,11 +49,11 @@ export function reduce<A, B, C>(f: (c: C, b: B) => C, c: C, fa: Tuple<A, B>): C 
   return f(c, fa[1])
 }
 
-export function traverse<F extends HKTS>(applicative: StaticApplicative<F>): <A, B, C, U = any, V = any>(f: (b: B) => HKT<C, U, V>[F], ta: Tuple<A, B>) => HKT<Tuple<A, C>, U, V>[F] {
+export function traverse<F extends HKTS>(applicative: Applicative<F>): <A, B, C, U = any, V = any>(f: (b: B) => HKT<C, U, V>[F], ta: Tuple<A, B>) => HKT<Tuple<A, C>, U, V>[F] {
   return <A, B, C>(f: (b: B) => HKT<C>[F], ta: Tuple<A, B>) => applicative.map(c => [ta[0], c] as Tuple<A, C>, f(ta[1]))
 }
 
-export function getStaticSetoid<A, B>(setoidA: StaticSetoid<A>, setoidB: StaticSetoid<B>): StaticSetoid<Tuple<A, B>> {
+export function getSetoid<A, B>(setoidA: Setoid<A>, setoidB: Setoid<B>): Setoid<Tuple<A, B>> {
   return {
     equals([xa, xb], [ya, yb]) {
       return setoidA.equals(xa, ya) && setoidB.equals(xb, yb)
@@ -64,9 +64,9 @@ export function getStaticSetoid<A, B>(setoidA: StaticSetoid<A>, setoidB: StaticS
 /** To obtain the result, the `fst`s are `compare`d, and if they are `EQ`ual, the
  * `snd`s are `compare`d.
  */
-export function getStaticOrd<A, B>(ordA: StaticOrd<A>, ordB: StaticOrd<B>): StaticOrd<Tuple<A, B>> {
+export function getOrd<A, B>(ordA: Ord<A>, ordB: Ord<B>): Ord<Tuple<A, B>> {
   return {
-    equals: getStaticSetoid(ordA, ordB).equals,
+    equals: getSetoid(ordA, ordB).equals,
     compare([xa, xb], [ya, yb]) {
       const ordering = ordA.compare(xa, ya)
       return ordering === 'EQ' ? ordB.compare(xb, yb) : ordering
@@ -74,7 +74,7 @@ export function getStaticOrd<A, B>(ordA: StaticOrd<A>, ordB: StaticOrd<B>): Stat
   }
 }
 
-export function getStaticSemigroup<A, B>(semigroupA: StaticSemigroup<A>, semigroupB: StaticSemigroup<B>): StaticSemigroup<Tuple<A, B>> {
+export function getSemigroup<A, B>(semigroupA: Semigroup<A>, semigroupB: Semigroup<B>): Semigroup<Tuple<A, B>> {
   return {
     concat([xa, xb], [ya, yb]) {
       return [semigroupA.concat(xa, ya), semigroupB.concat(xb, yb)]
@@ -82,15 +82,15 @@ export function getStaticSemigroup<A, B>(semigroupA: StaticSemigroup<A>, semigro
   }
 }
 
-export function getStaticMonoid<A, B>(monoidA: StaticMonoid<A>, monoidB: StaticMonoid<B>): StaticMonoid<Tuple<A, B>> {
+export function getMonoid<A, B>(monoidA: Monoid<A>, monoidB: Monoid<B>): Monoid<Tuple<A, B>> {
   const empty = [monoidA.empty(), monoidB.empty()] as Tuple<A, B>
   return {
-    concat: getStaticSemigroup(monoidA, monoidB).concat,
+    concat: getSemigroup(monoidA, monoidB).concat,
     empty: () => empty
   }
 }
 
-export function getStaticApply<A>(semigroupA: StaticSemigroup<A>): StaticApply<URI> {
+export function getApply<A>(semigroupA: Semigroup<A>): Apply<URI> {
   return {
     URI,
     map,
@@ -100,10 +100,10 @@ export function getStaticApply<A>(semigroupA: StaticSemigroup<A>): StaticApply<U
   }
 }
 
-export function getStaticMonad<A>(monoidA: StaticMonoid<A>): StaticMonad<URI> {
+export function getMonad<A>(monoidA: Monoid<A>): Monad<URI> {
   const empty = monoidA.empty()
   return {
-    ...getStaticApply(monoidA),
+    ...getApply(monoidA),
     of<B>(b: B): Tuple<A, B> {
       return [empty, b]
     },
@@ -136,10 +136,10 @@ export function tuple<A>(a: A): <B>(b: B) => Tuple<A, B> {
 // tslint:disable-next-line no-unused-expression
 ;(
   { compose, map, bimap, extract, extend, reduce } as (
-    StaticSemigroupoid<URI> &
-    StaticBifunctor<URI> &
-    StaticComonad<URI> &
-    StaticFoldable<URI> &
-    StaticTraversable<URI>
+    Semigroupoid<URI> &
+    Bifunctor<URI> &
+    Comonad<URI> &
+    Foldable<URI> &
+    Traversable<URI>
   )
 )

--- a/src/Unfoldable.ts
+++ b/src/Unfoldable.ts
@@ -1,6 +1,6 @@
 import { HKT, HKTS } from './HKT'
-import { StaticApplicative } from './Applicative'
-import { StaticTraversable } from './Traversable'
+import { Applicative } from './Applicative'
+import { Traversable } from './Traversable'
 import * as option from './Option'
 import { sequence } from './Traversable'
 import { constant } from './function'
@@ -8,13 +8,13 @@ import { constant } from './function'
 /** This class identifies data structures which can be _unfolded_,
  * generalizing `unfoldr` on arrays.
  */
-export interface StaticUnfoldable<F extends HKTS> {
+export interface Unfoldable<F extends HKTS> {
   readonly URI: F
   unfoldr<A, B, U = any, V = any>(f: (b: B) => option.Option<[A, B]>, b: B): HKT<A, U, V>[F]
 }
 
 /** Replicate a value some natural number of times. */
-export function replicate<F extends HKTS>(unfoldable: StaticUnfoldable<F>): <A, U = any, V = any>(n: number, a: A) => HKT<A, U, V>[F] {
+export function replicate<F extends HKTS>(unfoldable: Unfoldable<F>): <A, U = any, V = any>(n: number, a: A) => HKT<A, U, V>[F] {
   return <A>(n: number, a: A) => {
     function step(n: number): option.Option<[A, number]> {
       return n <= 0 ? option.none : option.of<[A, number]>([a, n - 1])
@@ -24,15 +24,15 @@ export function replicate<F extends HKTS>(unfoldable: StaticUnfoldable<F>): <A, 
 }
 
 /** Perform an Applicative action `n` times, and accumulate all the results. */
-export function replicateA<F extends HKTS, T extends HKTS>(applicative: StaticApplicative<F>, unfoldableTraversable: StaticUnfoldable<T> & StaticTraversable<T>): <A, UF = any, UT = any, VF = any, VT = any>(n: number, ma: HKT<A, UF, VF>[F]) => HKT<HKT<A, UT, VT>[T], UF, VF>[F] {
+export function replicateA<F extends HKTS, T extends HKTS>(applicative: Applicative<F>, unfoldableTraversable: Unfoldable<T> & Traversable<T>): <A, UF = any, UT = any, VF = any, VT = any>(n: number, ma: HKT<A, UF, VF>[F]) => HKT<HKT<A, UT, VT>[T], UF, VF>[F] {
   return <A>(n: number, ma: HKT<A>[F]) => sequence<F, T>(applicative, unfoldableTraversable)<A>(replicate(unfoldableTraversable)(n, ma))
 }
 
 /** The container with no elements - unfolded with zero iterations. */
-export function none<F extends HKTS, A, U = any, V = any>(unfoldable: StaticUnfoldable<F>): HKT<A, U, V>[F] {
+export function none<F extends HKTS, A, U = any, V = any>(unfoldable: Unfoldable<F>): HKT<A, U, V>[F] {
   return unfoldable.unfoldr<A, void>(constant(option.none), undefined)
 }
 
-export function singleton<F extends HKTS, A, U = any, V = any>(unfoldable: StaticUnfoldable<F>, a: A): HKT<A, U, V>[F] {
+export function singleton<F extends HKTS, A, U = any, V = any>(unfoldable: Unfoldable<F>, a: A): HKT<A, U, V>[F] {
   return replicate(unfoldable)(1, a)
 }

--- a/src/Validation.ts
+++ b/src/Validation.ts
@@ -1,12 +1,12 @@
 import { HKT, HKTS } from './HKT'
-import { StaticFunctor } from './Functor'
-import { StaticApplicative } from './Applicative'
-import { StaticSemigroup } from './Semigroup'
+import { Functor } from './Functor'
+import { Applicative } from './Applicative'
+import { Semigroup } from './Semigroup'
 import { FantasyApply } from './Apply'
-import { StaticFoldable, FantasyFoldable } from './Foldable'
-import { StaticSetoid } from './Setoid'
-import { StaticTraversable, FantasyTraversable } from './Traversable'
-import { StaticAlt, FantasyAlt } from './Alt'
+import { Foldable, FantasyFoldable } from './Foldable'
+import { Setoid } from './Setoid'
+import { Traversable, FantasyTraversable } from './Traversable'
+import { Alt, FantasyAlt } from './Alt'
 import { constFalse, constTrue, Predicate } from './function'
 import { Option, some, none } from './Option'
 import { Either, left, right } from './Either'
@@ -35,7 +35,7 @@ export class Failure<L, A> implements
   readonly _L: L
   readonly _A: A
   readonly _URI: URI
-  constructor(public readonly semigroup: StaticSemigroup<L>, public readonly value: L) {}
+  constructor(public readonly semigroup: Semigroup<L>, public readonly value: L) {}
   map<B>(f: (a: A) => B): Validation<L, B> {
     return this as any
   }
@@ -48,7 +48,7 @@ export class Failure<L, A> implements
     }
     return this as any
   }
-  bimap<L2, B>(semigroup: StaticSemigroup<L2>, f: (l: L) => L2, g: (a: A) => B): Validation<L2, B> {
+  bimap<L2, B>(semigroup: Semigroup<L2>, f: (l: L) => L2, g: (a: A) => B): Validation<L2, B> {
     return failure<L2, B>(semigroup, f(this.value))
   }
   alt(fy: Validation<L, A>): Validation<L, A> {
@@ -57,13 +57,13 @@ export class Failure<L, A> implements
   reduce<B>(f: (b: B, a: A) => B, b: B): B {
     return b
   }
-  traverse<F extends HKTS>(applicative: StaticApplicative<F>): <B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F]) => HKT<Validation<L, B>, U, V>[F] {
+  traverse<F extends HKTS>(applicative: Applicative<F>): <B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F]) => HKT<Validation<L, B>, U, V>[F] {
     return <B>(f: (a: A) => HKT<B>[F]) => applicative.of(this as any)
   }
   fold<B>(failure: (l: L) => B, success: (a: A) => B): B {
     return failure(this.value)
   }
-  equals(setoid: StaticSetoid<A>, fy: Validation<L, A>): boolean {
+  equals(setoid: Setoid<A>, fy: Validation<L, A>): boolean {
     return fy.fold(constTrue, constFalse)
   }
   concat(fy: Validation<L, A>): Validation<L, A> {
@@ -72,10 +72,10 @@ export class Failure<L, A> implements
       () => this
     )
   }
-  mapFailure<L2>(semigroup: StaticSemigroup<L2>, f: (l: L) => L2): Validation<L2, A> {
+  mapFailure<L2>(semigroup: Semigroup<L2>, f: (l: L) => L2): Validation<L2, A> {
     return failure<L2, A>(semigroup, f(this.value))
   }
-  swap(semigroup: StaticSemigroup<A>): Validation<A, L> {
+  swap(semigroup: Semigroup<A>): Validation<A, L> {
     return success<A, L>(this.value)
   }
   toOption(): Option<A> {
@@ -120,7 +120,7 @@ export class Success<L, A> implements
     }
     return fab as any
   }
-  bimap<L2, B>(semigroup: StaticSemigroup<L2>, f: (l: L) => L2, g: (a: A) => B): Validation<L2, B> {
+  bimap<L2, B>(semigroup: Semigroup<L2>, f: (l: L) => L2, g: (a: A) => B): Validation<L2, B> {
     return new Success<L2, B>(g(this.value))
   }
   alt(fy: Validation<L, A>): Validation<L, A> {
@@ -129,22 +129,22 @@ export class Success<L, A> implements
   reduce<B>(f: (b: B, a: A) => B, b: B): B {
     return f(b, this.value)
   }
-  traverse<F extends HKTS>(applicative: StaticApplicative<F>): <B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F]) => HKT<Validation<L, B>, U, V>[F] {
+  traverse<F extends HKTS>(applicative: Applicative<F>): <B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F]) => HKT<Validation<L, B>, U, V>[F] {
     return <B>(f: (a: A) => HKT<B>[F]) => applicative.map((b: B) => of<L, B>(b), f(this.value))
   }
   fold<B>(failure: (l: L) => B, success: (a: A) => B): B {
     return success(this.value)
   }
-  equals(setoid: StaticSetoid<A>, fy: Validation<L, A>): boolean {
+  equals(setoid: Setoid<A>, fy: Validation<L, A>): boolean {
     return fy.fold(constFalse, y => setoid.equals(this.value, y))
   }
   concat(fy: Validation<L, A>): Validation<L, A> {
     return this
   }
-  mapFailure<L2>(semigroup: StaticSemigroup<L2>, f: (l: L) => L2): Validation<L2, A> {
+  mapFailure<L2>(semigroup: Semigroup<L2>, f: (l: L) => L2): Validation<L2, A> {
     return this as any
   }
-  swap(semigroup: StaticSemigroup<A>): Validation<A, L> {
+  swap(semigroup: Semigroup<A>): Validation<A, L> {
     return failure<A, L>(semigroup, this.value)
   }
   toOption(): Option<A> {
@@ -165,7 +165,7 @@ export class Success<L, A> implements
   }
 }
 
-export function equals<L, A>(setoid: StaticSetoid<A>, fx: Validation<L, A>, fy: Validation<L, A>): boolean {
+export function equals<L, A>(setoid: Setoid<A>, fx: Validation<L, A>, fy: Validation<L, A>): boolean {
   return fx.equals(setoid, fy)
 }
 
@@ -185,7 +185,7 @@ export function ap<L, A, B>(fab: Validation<L, (a: A) => B>, fa: Validation<L, A
   return fa.ap(fab)
 }
 
-export function bimap<L, L2, A, B>(semigroup: StaticSemigroup<L2>, f: (l: L) => L2, g: (a: A) => B, fa: Validation<L, A>): Validation<L2, B> {
+export function bimap<L, L2, A, B>(semigroup: Semigroup<L2>, f: (l: L) => L2, g: (a: A) => B, fa: Validation<L, A>): Validation<L2, B> {
   return fa.bimap(semigroup, f, g)
 }
 
@@ -197,7 +197,7 @@ export function reduce<L, A, B>(f: (b: B, a: A) => B, b: B, fa: Validation<L, A>
   return fa.reduce(f, b)
 }
 
-export function traverse<F extends HKTS>(applicative: StaticApplicative<F>): <L, A, B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F], ta: Validation<L, A>) => HKT<Validation<L, B>, U, V>[F] {
+export function traverse<F extends HKTS>(applicative: Applicative<F>): <L, A, B, U = any, V = any>(f: (a: A) => HKT<B, U, V>[F], ta: Validation<L, A>) => HKT<Validation<L, B>, U, V>[F] {
   return <L, A, B>(f: (a: A) => HKT<B>[F], ta: Validation<L, A>) => ta.traverse<F>(applicative)<B>(f)
 }
 
@@ -209,13 +209,13 @@ export function isSuccess<L, A>(fa: Validation<L, A>): fa is Success<L, A> {
   return fa._tag === 'Success'
 }
 
-export function failure<L, A>(semigroup: StaticSemigroup<L>, l: L): Validation<L, A> {
+export function failure<L, A>(semigroup: Semigroup<L>, l: L): Validation<L, A> {
   return new Failure<L, A>(semigroup, l)
 }
 
 export const success = of
 
-export function fromPredicate<L, A>(semigroup: StaticSemigroup<L>, predicate: Predicate<A>, l: (a: A) => L): (a: A) => Validation<L, A> {
+export function fromPredicate<L, A>(semigroup: Semigroup<L>, predicate: Predicate<A>, l: (a: A) => L): (a: A) => Validation<L, A> {
   return a => predicate(a) ? success<L, A>(a) : failure<L, A>(semigroup, l(a))
 }
 
@@ -223,11 +223,11 @@ export function concat<L, A>(fx: Validation<L, A>, fy: Validation<L, A>): Valida
   return fx.concat(fy)
 }
 
-export function mapFailure<L, L2, A>(semigroup: StaticSemigroup<L2>, f: (l: L) => L2, fa: Validation<L, A>): Validation<L2, A> {
+export function mapFailure<L, L2, A>(semigroup: Semigroup<L2>, f: (l: L) => L2, fa: Validation<L, A>): Validation<L2, A> {
   return fa.mapFailure(semigroup, f)
 }
 
-export function swap<L, A>(semigroup: StaticSemigroup<A>, fa: Validation<L, A>): Validation<A, L> {
+export function swap<L, A>(semigroup: Semigroup<A>, fa: Validation<L, A>): Validation<A, L> {
   return fa.swap(semigroup)
 }
 
@@ -246,10 +246,10 @@ export function toEitherNea<L, A>(fa: Validation<L, A>): Option<Validation<nea.N
 // tslint:disable-next-line no-unused-expression
 ;(
   { map, of, reduce, traverse, alt } as (
-    StaticFunctor<URI> &
-    StaticApplicative<URI> &
-    StaticFoldable<URI> &
-    StaticTraversable<URI> &
-    StaticAlt<URI>
+    Functor<URI> &
+    Applicative<URI> &
+    Foldable<URI> &
+    Traversable<URI> &
+    Alt<URI>
   )
 )

--- a/src/Writer.ts
+++ b/src/Writer.ts
@@ -66,7 +66,7 @@ export function tell<W>(monoid: StaticMonoid<W>): (w: W) => Writer<W, void> {
   return w => new Writer(monoid, () => [undefined, w])
 }
 
-export function getMonadS<W>(monoid: StaticMonoid<W>): StaticMonad<URI> {
+export function getStaticMonad<W>(monoid: StaticMonoid<W>): StaticMonad<URI> {
   return {
     URI,
     map,

--- a/src/Writer.ts
+++ b/src/Writer.ts
@@ -1,6 +1,6 @@
-import { StaticMonoid } from './Monoid'
-import { StaticFunctor } from './Functor'
-import { StaticMonad, FantasyMonad } from './Monad'
+import { Monoid } from './Monoid'
+import { Functor } from './Functor'
+import { Monad, FantasyMonad } from './Monad'
 import { Lazy } from './function'
 
 declare module './HKT' {
@@ -18,7 +18,7 @@ export class Writer<W, A> implements FantasyMonad<URI, A> {
   readonly _A: A
   readonly _URI: URI
   of: (a: A) => Writer<W, A>
-  constructor(public readonly monoid: StaticMonoid<W>, public readonly value: Lazy<[A, W]>) {
+  constructor(public readonly monoid: Monoid<W>, public readonly value: Lazy<[A, W]>) {
     this.of = of<W>(monoid)
   }
   run(): [A, W] {
@@ -50,7 +50,7 @@ export function map<W, A, B>(f: (a: A) => B, fa: Writer<W, A>): Writer<W, B> {
   return fa.map(f)
 }
 
-export function of<W>(monoid: StaticMonoid<W>): <A>(a: A) => Writer<W, A> {
+export function of<W>(monoid: Monoid<W>): <A>(a: A) => Writer<W, A> {
   return <A>(a: A) => new Writer<W, A>(monoid, () => [a, monoid.empty()])
 }
 
@@ -62,11 +62,11 @@ export function chain<W, A, B>(f: (a: A) => Writer<W, B>, fa: Writer<W, A>): Wri
   return fa.chain(f)
 }
 
-export function tell<W>(monoid: StaticMonoid<W>): (w: W) => Writer<W, void> {
+export function tell<W>(monoid: Monoid<W>): (w: W) => Writer<W, void> {
   return w => new Writer(monoid, () => [undefined, w])
 }
 
-export function getStaticMonad<W>(monoid: StaticMonoid<W>): StaticMonad<URI> {
+export function getMonad<W>(monoid: Monoid<W>): Monad<URI> {
   return {
     URI,
     map,
@@ -79,6 +79,6 @@ export function getStaticMonad<W>(monoid: StaticMonoid<W>): StaticMonad<URI> {
 // tslint:disable-next-line no-unused-expression
 ;(
   { map } as (
-    StaticFunctor<URI>
+    Functor<URI>
   )
 )

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,8 @@ import * as setoid from './Setoid'
 export { setoid }
 import * as state from './State'
 export { state }
+import * as store from './Store'
+export { store }
 import * as task from './Task'
 export { task }
 import * as these from './These'

--- a/test/Applicative.ts
+++ b/test/Applicative.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert'
 
 import {
-  getStaticApplicativeComposition,
+  getCompositionStaticApplicative,
   when
 } from '../src/Applicative'
 import * as validation from '../src/Validation'
@@ -25,7 +25,7 @@ describe('Applicative', () => {
 
   it('getStaticApplicativeComposition', () => {
 
-    const taskValidationApplicative = getStaticApplicativeComposition(TaskValidationURI, task, validation)
+    const taskValidationApplicative = getCompositionStaticApplicative(TaskValidationURI, task, validation)
 
     const allsuccess = [
       validation.success<string, number>(1),

--- a/test/Applicative.ts
+++ b/test/Applicative.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert'
 
 import {
-  getCompositionStaticApplicative,
+  getCompositionApplicative,
   when
 } from '../src/Applicative'
 import * as validation from '../src/Validation'
@@ -23,9 +23,9 @@ declare module '../src/HKT' {
 
 describe('Applicative', () => {
 
-  it('getStaticApplicativeComposition', () => {
+  it('getCompositionApplicative', () => {
 
-    const taskValidationApplicative = getCompositionStaticApplicative(TaskValidationURI, task, validation)
+    const taskValidationApplicative = getCompositionApplicative(TaskValidationURI, task, validation)
 
     const allsuccess = [
       validation.success<string, number>(1),

--- a/test/Applicative.ts
+++ b/test/Applicative.ts
@@ -25,7 +25,7 @@ describe('Applicative', () => {
 
   it('getStaticApplicativeComposition', () => {
 
-    const taskValidationApplicative = getStaticApplicativeComposition(TaskValidationURI)(task, validation)
+    const taskValidationApplicative = getStaticApplicativeComposition(TaskValidationURI, task, validation)
 
     const allsuccess = [
       validation.success<string, number>(1),

--- a/test/Dictionary.ts
+++ b/test/Dictionary.ts
@@ -5,7 +5,7 @@ import {
   map,
   reduce,
   traverse,
-  getStaticSetoid,
+  getSetoid,
   lookup,
   fromFoldable,
   toArray,
@@ -48,10 +48,10 @@ describe('Dictionary', () => {
     eq(t2, option.some({ k1: 2, k2: 3 }))
   })
 
-  it('getStaticSetoid', () => {
-    assert.strictEqual(getStaticSetoid(setoidNumber).equals({ a: 1 }, { a: 1 }), true)
-    assert.strictEqual(getStaticSetoid(setoidNumber).equals({ a: 1 }, { a: 2 }), false)
-    assert.strictEqual(getStaticSetoid(setoidNumber).equals({ a: 1 }, { b: 1 }), false)
+  it('getSetoid', () => {
+    assert.strictEqual(getSetoid(setoidNumber).equals({ a: 1 }, { a: 1 }), true)
+    assert.strictEqual(getSetoid(setoidNumber).equals({ a: 1 }, { a: 2 }), false)
+    assert.strictEqual(getSetoid(setoidNumber).equals({ a: 1 }, { b: 1 }), false)
   })
 
   it('lookup', () => {

--- a/test/Foldable.ts
+++ b/test/Foldable.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert'
 import {
   toArray,
   foldMap,
-  getCompositionStaticFoldable,
+  getCompositionFoldable,
   intercalate,
   traverse_,
   sequence_
@@ -33,14 +33,14 @@ describe('Foldable', () => {
     assert.deepEqual(foldMap(array, monoidString)(identity, ['a', 'b', 'c']), 'abc')
   })
 
-  it('getStaticFoldableComposition', () => {
-    const arrayOptionFoldable = getCompositionStaticFoldable(ArrayOptionURI, array, option)
+  it('getCompositionFoldable', () => {
+    const arrayOptionFoldable = getCompositionFoldable(ArrayOptionURI, array, option)
     assert.strictEqual(arrayOptionFoldable.reduce((b, a) => b + a, 0, [option.some(1), option.some(2)]), 3)
     assert.strictEqual(arrayOptionFoldable.reduce((b, a) => b + a, 0, [option.none, option.some(2)]), 2)
   })
 
   it('intercalate', () => {
-    const join = intercalate(getCompositionStaticFoldable('ArrayOption', array, option), monoidString)
+    const join = intercalate(getCompositionFoldable('ArrayOption', array, option), monoidString)
     assert.strictEqual(join(' ', []), '')
     assert.strictEqual(join(' ', [option.some('a')]), 'a')
     assert.strictEqual(join(' ', [

--- a/test/Foldable.ts
+++ b/test/Foldable.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert'
 import {
   toArray,
   foldMap,
-  getStaticFoldableComposition,
+  getCompositionStaticFoldable,
   intercalate,
   traverse_,
   sequence_
@@ -34,13 +34,13 @@ describe('Foldable', () => {
   })
 
   it('getStaticFoldableComposition', () => {
-    const arrayOptionFoldable = getStaticFoldableComposition(ArrayOptionURI, array, option)
+    const arrayOptionFoldable = getCompositionStaticFoldable(ArrayOptionURI, array, option)
     assert.strictEqual(arrayOptionFoldable.reduce((b, a) => b + a, 0, [option.some(1), option.some(2)]), 3)
     assert.strictEqual(arrayOptionFoldable.reduce((b, a) => b + a, 0, [option.none, option.some(2)]), 2)
   })
 
   it('intercalate', () => {
-    const join = intercalate(getStaticFoldableComposition('ArrayOption', array, option), monoidString)
+    const join = intercalate(getCompositionStaticFoldable('ArrayOption', array, option), monoidString)
     assert.strictEqual(join(' ', []), '')
     assert.strictEqual(join(' ', [option.some('a')]), 'a')
     assert.strictEqual(join(' ', [

--- a/test/Foldable.ts
+++ b/test/Foldable.ts
@@ -34,13 +34,13 @@ describe('Foldable', () => {
   })
 
   it('getStaticFoldableComposition', () => {
-    const arrayOptionFoldable = getStaticFoldableComposition(ArrayOptionURI)(array, option)
+    const arrayOptionFoldable = getStaticFoldableComposition(ArrayOptionURI, array, option)
     assert.strictEqual(arrayOptionFoldable.reduce((b, a) => b + a, 0, [option.some(1), option.some(2)]), 3)
     assert.strictEqual(arrayOptionFoldable.reduce((b, a) => b + a, 0, [option.none, option.some(2)]), 2)
   })
 
   it('intercalate', () => {
-    const join = intercalate(getStaticFoldableComposition('ArrayOption')(array, option), monoidString)
+    const join = intercalate(getStaticFoldableComposition('ArrayOption', array, option), monoidString)
     assert.strictEqual(join(' ', []), '')
     assert.strictEqual(join(' ', [option.some('a')]), 'a')
     assert.strictEqual(join(' ', [

--- a/test/Functor.ts
+++ b/test/Functor.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert'
 import * as option from '../src/Option'
 import * as array from '../src/Array'
-import { lift, getStaticFunctorComposition } from '../src/Functor'
+import { lift, getCompositionStaticFunctor } from '../src/Functor'
 import { eqOptions as eq } from './helpers'
 
 declare module '../src/HKT' {
@@ -20,7 +20,7 @@ describe('Functor', () => {
   })
 
   it('getStaticFunctorComposition', () => {
-    const arrayOption = getStaticFunctorComposition('Array<Option>', array, option)
+    const arrayOption = getCompositionStaticFunctor('Array<Option>', array, option)
     const double = (a: number) => a * 2
     assert.deepEqual(arrayOption.map(double, [option.some(1)]), [option.some(2)])
   })

--- a/test/Functor.ts
+++ b/test/Functor.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert'
 import * as option from '../src/Option'
 import * as array from '../src/Array'
-import { lift, getCompositionStaticFunctor } from '../src/Functor'
+import { lift, getCompositionFunctor } from '../src/Functor'
 import { eqOptions as eq } from './helpers'
 
 declare module '../src/HKT' {
@@ -19,8 +19,8 @@ describe('Functor', () => {
     eq(actual, option.some(4))
   })
 
-  it('getStaticFunctorComposition', () => {
-    const arrayOption = getCompositionStaticFunctor('Array<Option>', array, option)
+  it('getCompositionFunctor', () => {
+    const arrayOption = getCompositionFunctor('Array<Option>', array, option)
     const double = (a: number) => a * 2
     assert.deepEqual(arrayOption.map(double, [option.some(1)]), [option.some(2)])
   })

--- a/test/Functor.ts
+++ b/test/Functor.ts
@@ -20,7 +20,7 @@ describe('Functor', () => {
   })
 
   it('getStaticFunctorComposition', () => {
-    const arrayOption = getStaticFunctorComposition('Array<Option>')(array, option)
+    const arrayOption = getStaticFunctorComposition('Array<Option>', array, option)
     const double = (a: number) => a * 2
     assert.deepEqual(arrayOption.map(double, [option.some(1)]), [option.some(2)])
   })

--- a/test/Monoid.ts
+++ b/test/Monoid.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert'
 import {
   fold,
   monoidSum,
-  getFunctionStaticMonoid,
+  getFunctionMonoid,
   monoidAll,
   monoidAny
 } from '../src/Monoid'
@@ -14,15 +14,15 @@ describe('Monoid', () => {
     assert.strictEqual(fold(monoidSum, [1, 2, 3]), 6)
   })
 
-  it('getFunctionStaticMonoid', () => {
-    const getPredicateStaticMonoidAll = getFunctionStaticMonoid(monoidAll)
-    const getPredicateStaticMonoidAny = getFunctionStaticMonoid(monoidAny)
+  it('getFunctionMonoid', () => {
+    const getPredicateMonoidAll = getFunctionMonoid(monoidAll)
+    const getPredicateMonoidAny = getFunctionMonoid(monoidAny)
 
     const isLessThan10 = (n: number) => n <= 10
     const isEven = (n: number) => n % 2 === 0
 
-    assert.deepEqual(filter(fold(getPredicateStaticMonoidAll<number>(), [isLessThan10, isEven]), [1, 2, 3, 40]), [2])
-    assert.deepEqual(filter(fold(getPredicateStaticMonoidAny<number>(), [isLessThan10, isEven]), [1, 2, 3, 40, 41]), [1, 2, 3, 40])
+    assert.deepEqual(filter(fold(getPredicateMonoidAll<number>(), [isLessThan10, isEven]), [1, 2, 3, 40]), [2])
+    assert.deepEqual(filter(fold(getPredicateMonoidAny<number>(), [isLessThan10, isEven]), [1, 2, 3, 40, 41]), [1, 2, 3, 40])
   })
 
 })

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -8,10 +8,10 @@ import {
   ap,
   chain,
   alt,
-  getStaticMonoid,
+  getMonoid,
   fromNullable,
-  getFirstStaticMonoid,
-  getLastStaticMonoid
+  getFirstMonoid,
+  getLastMonoid
 } from '../src/Option'
 import * as option from '../src/Option'
 import { setoidNumber } from '../src/Setoid'
@@ -59,7 +59,7 @@ describe('Option', () => {
   })
 
   it('getMonoid', () => {
-    const { concat } = getStaticMonoid({ concat(x: number, y: number) { return x + y } })
+    const { concat } = getMonoid({ concat(x: number, y: number) { return x + y } })
     eq(concat(none, some(1)), some(1))
     eq(concat(some(2), none), some(2))
     eq(concat(some(2), some(1)), some(3))
@@ -92,16 +92,16 @@ describe('Option', () => {
     assert.strictEqual(y, '3')
   })
 
-  it('getFirstStaticMonoid', () => {
-    const first = getFirstStaticMonoid<number>()
+  it('getFirstMonoid', () => {
+    const first = getFirstMonoid<number>()
     assert.deepEqual(first.concat(none, some(1)), some(1))
     assert.deepEqual(first.concat(some(1), none), some(1))
     assert.deepEqual(first.concat(none, none), none)
     assert.deepEqual(first.concat(some(1), some(2)), some(1))
   })
 
-  it('getLastStaticMonoid', () => {
-    const last = getLastStaticMonoid<number>()
+  it('getLastMonoid', () => {
+    const last = getLastMonoid<number>()
     assert.deepEqual(last.concat(none, some(1)), some(1))
     assert.deepEqual(last.concat(some(1), none), some(1))
     assert.deepEqual(last.concat(none, none), none)

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -9,7 +9,9 @@ import {
   chain,
   alt,
   getStaticMonoid,
-  fromNullable
+  fromNullable,
+  getFirstStaticMonoid,
+  getLastStaticMonoid
 } from '../src/Option'
 import * as option from '../src/Option'
 import { setoidNumber } from '../src/Setoid'
@@ -89,4 +91,21 @@ describe('Option', () => {
     const y = fromNullable(3).reduce((b, a) => a.toString(), '4')
     assert.strictEqual(y, '3')
   })
+
+  it('getFirstStaticMonoid', () => {
+    const first = getFirstStaticMonoid<number>()
+    assert.deepEqual(first.concat(none, some(1)), some(1))
+    assert.deepEqual(first.concat(some(1), none), some(1))
+    assert.deepEqual(first.concat(none, none), none)
+    assert.deepEqual(first.concat(some(1), some(2)), some(1))
+  })
+
+  it('getLastStaticMonoid', () => {
+    const last = getLastStaticMonoid<number>()
+    assert.deepEqual(last.concat(none, some(1)), some(1))
+    assert.deepEqual(last.concat(some(1), none), some(1))
+    assert.deepEqual(last.concat(none, none), none)
+    assert.deepEqual(last.concat(some(1), some(2)), some(2))
+  })
+
 })

--- a/test/OptionT.ts
+++ b/test/OptionT.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert'
 import {
-  getStaticOptionT
+  getOptionT
 } from '../src/OptionT'
 import * as option from '../src/Option'
 import * as task from '../src/Task'
@@ -12,7 +12,7 @@ declare module '../src/HKT' {
   }
 }
 
-const taskOption = getStaticOptionT('Task<Option>', task)
+const taskOption = getOptionT('Task<Option>', task)
 
 describe('OptionT', () => {
 

--- a/test/ReaderT.ts
+++ b/test/ReaderT.ts
@@ -1,12 +1,12 @@
 import * as option from '../src/Option'
 import { Dictionary, lookup } from '../src/Dictionary'
-import { getStaticReaderT } from '../src/ReaderT'
+import { getReaderT } from '../src/ReaderT'
 import * as reader from '../src/Reader'
 import { eqOptions as eq } from './helpers'
 
 export type ReaderTOption<E, A> = reader.Reader<E, option.Option<A>>
 
-const readerOption = getStaticReaderT(option)
+const readerOption = getReaderT(option)
 
 describe('ReaderT', () => {
 

--- a/test/Traversable.ts
+++ b/test/Traversable.ts
@@ -1,5 +1,5 @@
 import {
-  getCompositionStaticTraversable
+  getCompositionTraversable
 } from '../src/Traversable'
 import * as array from '../src/Array'
 import * as option from '../src/Option'
@@ -17,8 +17,8 @@ declare module '../src/HKT' {
 
 describe('Traversable', () => {
 
-  it('getStaticTraversableComposition', () => {
-    const arrayOptionTraversable = getCompositionStaticTraversable(ArrayOptionURI, array, option)
+  it('getCompositionTraversable', () => {
+    const arrayOptionTraversable = getCompositionTraversable(ArrayOptionURI, array, option)
     eq(arrayOptionTraversable.traverse(option)(n => n <= 2 ? option.some(n * 2) : option.none, [option.some(1), option.some(2)]), option.some([option.some(2), option.some(4)]))
     eq(arrayOptionTraversable.traverse(option)(n => n <= 2 ? option.some(n * 2) : option.none, [option.some(1), option.some(3)]), option.none)
   })

--- a/test/Traversable.ts
+++ b/test/Traversable.ts
@@ -1,5 +1,5 @@
 import {
-  getStaticTraversableComposition
+  getCompositionStaticTraversable
 } from '../src/Traversable'
 import * as array from '../src/Array'
 import * as option from '../src/Option'
@@ -18,7 +18,7 @@ declare module '../src/HKT' {
 describe('Traversable', () => {
 
   it('getStaticTraversableComposition', () => {
-    const arrayOptionTraversable = getStaticTraversableComposition(ArrayOptionURI, array, option)
+    const arrayOptionTraversable = getCompositionStaticTraversable(ArrayOptionURI, array, option)
     eq(arrayOptionTraversable.traverse(option)(n => n <= 2 ? option.some(n * 2) : option.none, [option.some(1), option.some(2)]), option.some([option.some(2), option.some(4)]))
     eq(arrayOptionTraversable.traverse(option)(n => n <= 2 ? option.some(n * 2) : option.none, [option.some(1), option.some(3)]), option.none)
   })

--- a/test/Traversable.ts
+++ b/test/Traversable.ts
@@ -18,7 +18,7 @@ declare module '../src/HKT' {
 describe('Traversable', () => {
 
   it('getStaticTraversableComposition', () => {
-    const arrayOptionTraversable = getStaticTraversableComposition(ArrayOptionURI)(array, option)
+    const arrayOptionTraversable = getStaticTraversableComposition(ArrayOptionURI, array, option)
     eq(arrayOptionTraversable.traverse(option)(n => n <= 2 ? option.some(n * 2) : option.none, [option.some(1), option.some(2)]), option.some([option.some(2), option.some(4)]))
     eq(arrayOptionTraversable.traverse(option)(n => n <= 2 ? option.some(n * 2) : option.none, [option.some(1), option.some(3)]), option.none)
   })

--- a/test/Tuple.ts
+++ b/test/Tuple.ts
@@ -5,7 +5,7 @@ import {
   bimap,
   extract,
   extend,
-  getStaticSemigroup
+  getSemigroup
 } from '../src/Tuple'
 import { monoidString, monoidSum } from '../src/Monoid'
 
@@ -34,8 +34,8 @@ describe('Tuple', () => {
     assert.deepEqual(extend((t: [string, number]): number => t[0].length + t[1], ['s', 1]), ['s', 2])
   })
 
-  it('getStaticSemigroup', () => {
-    const semigroup = getStaticSemigroup(monoidString, monoidSum)
+  it('getSemigroup', () => {
+    const semigroup = getSemigroup(monoidString, monoidSum)
     assert.deepEqual(semigroup.concat(['a', 1], ['b', 2]), ['ab', 3])
   })
 


### PR DESCRIPTION
Note that all `getComposition[something]` require an implicit proof that

```
HKT<A>[FG] ~ HKT<HKT<A>[G]>[F]
```

where the proof is provided by augmenting the `HKT` interface. Example

```ts
import * as task from 'fp-ts/lib/Task'
import * as option from 'fp-ts/lib/Option'
import { getCompositionFunctor } from 'fp-ts/lib/Functor'

declare module 'fp-ts/lib/HKT' {
  interface HKT<A> {
    'Task<Option>': task.Task<option.Option<A>> // <= this is the implicit proof
  }
}

const taskOption = getCompositionFunctor('Task<Option>', task, option)

```

Not sure if the proof can be made explicit