### PR TITLE
Allow chain to accumulate error types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fp-ts",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Functional programming in TypeScript",
   "files": [
     "lib"

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -48,7 +48,7 @@ export class Left<L, A>
   ap<B>(fab: Either<L, (a: A) => B>): Either<L, B> {
     return (isLeft(fab) ? fab : this) as any
   }
-  chain<B>(f: (a: A) => Either<L, B>): Either<L, B> {
+  chain<L2, B>(f: (a: A) => Either<L2, B>): Either<L2 | L, B> {
     return this as any
   }
   bimap<L2, B>(f: (l: L) => L2, g: (a: A) => B): Either<L2, B> {
@@ -116,7 +116,7 @@ export class Right<L, A>
     }
     return fab as any
   }
-  chain<B>(f: (a: A) => Either<L, B>): Either<L, B> {
+  chain<L2, B>(f: (a: A) => Either<L2, B>): Either<L2 | L, B> {
     return f(this.value)
   }
   bimap<L2, B>(f: (l: L) => L2, g: (a: A) => B): Either<L2, B> {
@@ -183,7 +183,7 @@ export function ap<L, A, B>(fab: Either<L, (a: A) => B>, fa: Either<L, A>): Eith
   return fa.ap(fab)
 }
 
-export function chain<L, A, B>(f: (a: A) => Either<L, B>, fa: Either<L, A>): Either<L, B> {
+export function chain<L, L2, A, B>(f: (a: A) => Either<L2, B>, fa: Either<L, A>): Either<L2 | L, B> {
   return fa.chain(f)
 }
 

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -51,7 +51,10 @@ export class Left<L, A>
   ap_<B, C>(this: Either<L, (a: B) => C>, fb: Either<L, B>): Either<L, C> {
     return fb.ap(this)
   }
-  chain<L2, B>(f: (a: A) => Either<L2, B>): Either<L | L2, B> {
+  chain<B>(f: (a: A) => Either<L, B>): Either<L, B> {
+    return this as any
+  }
+  chain_<L2, B>(f: (a: A) => Either<L2, B>): Either<L | L2, B> {
     return this as any
   }
   bimap<L2, B>(f: (l: L) => L2, g: (a: A) => B): Either<L2, B> {
@@ -122,7 +125,10 @@ export class Right<L, A>
   ap_<B, C>(this: Either<L, (a: B) => C>, fb: Either<L, B>): Either<L, C> {
     return fb.ap(this)
   }
-  chain<L2, B>(f: (a: A) => Either<L2, B>): Either<L | L2, B> {
+  chain<B>(f: (a: A) => Either<L, B>): Either<L, B> {
+    return f(this.value)
+  }
+  chain_<L2, B>(f: (a: A) => Either<L2, B>): Either<L | L2, B> {
     return f(this.value)
   }
   bimap<L2, B>(f: (l: L) => L2, g: (a: A) => B): Either<L2, B> {
@@ -195,8 +201,12 @@ export function ap<L, A, B>(fab: Either<L, (a: A) => B>, fa: Either<L, A>): Eith
   return fa.ap(fab)
 }
 
-export function chain<L, L2, A, B>(f: (a: A) => Either<L2, B>, fa: Either<L, A>): Either<L | L2, B> {
+export function chain<L, A, B>(f: (a: A) => Either<L, B>, fa: Either<L, A>): Either<L, B> {
   return fa.chain(f)
+}
+
+export function chain_<L1, L2, A, B>(f: (a: A) => Either<L2, B>, fa: Either<L1, A>): Either<L1 | L2, B> {
+  return fa.chain_(f)
 }
 
 export function bimap<L, L2, A, B>(f: (l: L) => L2, g: (a: A) => B, fa: Either<L, A>): Either<L2, B> {

--- a/src/EitherT.ts
+++ b/src/EitherT.ts
@@ -21,7 +21,10 @@ export interface EitherT<URI extends HKTS, M extends HKTS> extends Monad<URI> {
   ): HKT<R, U, V>[M]
   mapLeft<L2, L, A, U = any, V = any>(f: (l: L) => L2, fa: HKT<Either<L, A>, U, V>[M]): HKT<Either<L2, A>, U, V>[M]
   toOption<L, A, U = any, V = any>(fa: HKT<Either<L, A>, U, V>[M]): HKT<Option<A>, U, V>[M]
-  chain_<L, L2, A, B, U = any, V = any>(f: (a: A) => HKT<Either<L2, B>, U, V>[M], fa: HKT<Either<L, A>, U, V>[M]): HKT<Either<L2 | L, B>, U, V>[M]
+  chain_<L, L2, A, B, U = any, V = any>(
+    f: (a: A) => HKT<Either<L2, B>, U, V>[M],
+    fa: HKT<Either<L, A>, U, V>[M]
+  ): HKT<Either<L2 | L, B>, U, V>[M]
 }
 
 /** Note: requires an implicit proof that HKT<A>[URI] ~ HKT<Either<L, A>>[M] */
@@ -32,8 +35,14 @@ export function getEitherT<URI extends HKTS, M extends HKTS>(URI: URI, monad: Mo
     return monad.chain<Either<L, A>, Either<L, B>>(e => e.fold<HKT<Either<L, B>>[M]>(() => fa as any, a => f(a)), fa)
   }
 
-  function chain_<L, L2, A, B>(f: (a: A) => HKT<Either<L2, B>>[M], fa: HKT<Either<L, A>>[M]): HKT<Either<L2 | L, B>>[M] {
-    return monad.chain<Either<L, A>, Either<L | L2, B>>(e => e.fold<HKT<Either<L | L2, B>>[M]>(() => fa as any, a => f(a)), fa)
+  function chain_<L, L2, A, B>(
+    f: (a: A) => HKT<Either<L2, B>>[M],
+    fa: HKT<Either<L, A>>[M]
+  ): HKT<Either<L2 | L, B>>[M] {
+    return monad.chain<Either<L, A>, Either<L | L2, B>>(
+      e => e.fold<HKT<Either<L | L2, B>>[M]>(() => fa as any, a => f(a)),
+      fa
+    )
   }
 
   function right<L, A>(ma: HKT<A>[M]): HKT<Either<L, A>>[M] {

--- a/src/EitherT.ts
+++ b/src/EitherT.ts
@@ -27,8 +27,8 @@ export interface EitherT<URI extends HKTS, M extends HKTS> extends Monad<URI> {
 export function getEitherT<URI extends HKTS, M extends HKTS>(URI: URI, monad: Monad<M>): EitherT<URI, M> {
   const applicative = getCompositionApplicative(URI, monad, either)
 
-  function chain<L, A, B>(f: (a: A) => HKT<Either<L, B>>[M], fa: HKT<Either<L, A>>[M]): HKT<Either<L, B>>[M] {
-    return monad.chain<Either<L, A>, Either<L, B>>(e => e.fold<HKT<Either<L, B>>[M]>(() => fa as any, a => f(a)), fa)
+  function chain<L, L2, A, B>(f: (a: A) => HKT<Either<L2, B>>[M], fa: HKT<Either<L, A>>[M]): HKT<Either<L2 | L, B>>[M] {
+    return monad.chain<Either<L, A>, Either<L | L2, B>>(e => e.fold<HKT<Either<L | L2, B>>[M]>(() => fa as any, a => f(a)), fa)
   }
 
   function right<L, A>(ma: HKT<A>[M]): HKT<Either<L, A>>[M] {


### PR DESCRIPTION
Allows chaining Either methods to accumulate a union of error types.

Example

```
import * as T from 'io-ts'
import {Either, left, right} from 'fp-ts/lib/Either

const isBuffer = (x: any): Either<S3Error, Buffer> =>
    Buffer.isBuffer(x) ? right(x) : left(S3Error.NotBuffer)

export const validateData = (data: any):  =>
    isBuffer(data)
    .map(x => x.toString())
    .chain(x => T.validate(x, Project)) 
```

Without this chain is unable to match S3Error and T.ValidationError[]

I think this strictly speaking breaks FantasyLand spec but it seems useful to unify the error types.

Alternative solution is to cast up the Either type when you call the method, but it requires to to add all the other errors that could come along.

```
import * as T from 'io-ts'
import {Either, left, right} from 'fp-ts/lib/Either

const isBuffer = (x: any): Either<S3Error, Buffer> =>
    Buffer.isBuffer(x) ? right(x) : left(S3Error.NotBuffer)

export const validateData = (data: any):  =>
    (isBuffer(data) as Either<S3Error | T.ValidationError[], Buffer>)
    .map(x => x.toString())
    .chain(x => T.validate(x, Project)) 
```

