### PR TITLE
Added integrity checking and HKTAs

### DIFF
--- a/src/Applicative.ts
+++ b/src/Applicative.ts
@@ -1,4 +1,4 @@
-import { HKT, HKTS, HKT2S, URI2HKT, URI2HKT2 } from './HKT'
+import { HKT, HKTS, HKT2S, HKTAs, HKT2As } from './HKT'
 import { Apply, FantasyApply } from './Apply'
 import {
   getFunctorComposition,
@@ -23,38 +23,38 @@ export interface ApplicativeComposition<F, G> extends FunctorComposition<F, G> {
 }
 
 export interface ApplicativeComposition11<F extends HKTS, G extends HKTS> extends FunctorComposition11<F, G> {
-  of<A>(a: A): URI2HKT<URI2HKT<A>[G]>[F]
-  ap<A, B>(fgab: URI2HKT<URI2HKT<(a: A) => B>[G]>[F], fga: URI2HKT<URI2HKT<A>[G]>[F]): URI2HKT<URI2HKT<B>[G]>[F]
+  of<A>(a: A): HKTAs<F, HKTAs<G, A>>
+  ap<A, B>(fgab: HKTAs<F, HKTAs<G, (a: A) => B>>, fga: HKTAs<F, HKTAs<G, A>>): HKTAs<F, HKTAs<G, B>>
 }
 
 export interface ApplicativeComposition12<F extends HKTS, G extends HKT2S> extends FunctorComposition12<F, G> {
-  of<L, A>(a: A): URI2HKT<URI2HKT2<L, A>[G]>[F]
+  of<L, A>(a: A): HKTAs<F, HKT2As<G, L, A>>
   ap<L, A, B>(
-    fgab: URI2HKT<URI2HKT2<L, (a: A) => B>[G]>[F],
-    fga: URI2HKT<URI2HKT2<L, A>[G]>[F]
-  ): URI2HKT<URI2HKT2<L, B>[G]>[F]
+    fgab: HKTAs<F, HKT2As<G, L, (a: A) => B>>,
+    fga: HKTAs<F, HKT2As<G, L, A>>
+  ): HKTAs<F, HKT2As<G, L, B>>
 }
 
 export interface ApplicativeComposition21<F extends HKT2S, G extends HKTS> extends FunctorComposition21<F, G> {
-  of<L, A>(a: A): URI2HKT2<L, URI2HKT<A>[G]>[F]
+  of<L, A>(a: A): HKT2As<F, L, HKTAs<G, A>>
   ap<L, A, B>(
-    fgab: URI2HKT2<L, URI2HKT<(a: A) => B>[G]>[F],
-    fga: URI2HKT2<L, URI2HKT<A>[G]>[F]
-  ): URI2HKT2<L, URI2HKT<B>[G]>[F]
+    fgab: HKT2As<F, L, HKTAs<G, (a: A) => B>>,
+    fga: HKT2As<F, L, HKTAs<G, A>>
+  ): HKT2As<F, L, HKTAs<G, B>>
 }
 
 export interface ApplicativeComposition22<F extends HKT2S, G extends HKT2S> extends FunctorComposition22<F, G> {
-  of<L, M, A>(a: A): URI2HKT2<L, URI2HKT2<M, A>[G]>[F]
+  of<L, M, A>(a: A): HKT2As<F, L, HKT2As<G, M, A>>
   ap<L, M, A, B>(
-    fgab: URI2HKT2<L, URI2HKT2<M, (a: A) => B>[G]>[F],
-    fga: URI2HKT2<L, URI2HKT2<M, A>[G]>[F]
-  ): URI2HKT2<L, URI2HKT2<M, B>[G]>[F]
+    fgab: HKT2As<F, L, HKT2As<G, M, (a: A) => B>>,
+    fga: HKT2As<F, L, HKT2As<G, M, A>>
+  ): HKT2As<F, L, HKT2As<G, M, B>>
 }
 
 export class Ops {
   /** Perform a applicative action when a condition is true */
-  when<F extends HKT2S>(F: Applicative<F>): <L>(condition: boolean, fu: URI2HKT2<L, void>[F]) => URI2HKT2<L, void>[F]
-  when<F extends HKTS>(F: Applicative<F>): (condition: boolean, fu: URI2HKT<void>[F]) => URI2HKT<void>[F]
+  when<F extends HKT2S>(F: Applicative<F>): <L>(condition: boolean, fu: HKT2As<F, L, void>) => HKT2As<F, L, void>
+  when<F extends HKTS>(F: Applicative<F>): (condition: boolean, fu: HKTAs<F, void>) => HKTAs<F, void>
   when<F>(F: Applicative<F>): (condition: boolean, fu: HKT<F, void>) => HKT<F, void>
   when<F>(F: Applicative<F>): (condition: boolean, fu: HKT<F, void>) => HKT<F, void> {
     return (condition, fu) => (condition ? fu : F.of(undefined))

--- a/src/Applicative.ts
+++ b/src/Applicative.ts
@@ -29,18 +29,12 @@ export interface ApplicativeComposition11<F extends HKTS, G extends HKTS> extend
 
 export interface ApplicativeComposition12<F extends HKTS, G extends HKT2S> extends FunctorComposition12<F, G> {
   of<L, A>(a: A): HKTAs<F, HKT2As<G, L, A>>
-  ap<L, A, B>(
-    fgab: HKTAs<F, HKT2As<G, L, (a: A) => B>>,
-    fga: HKTAs<F, HKT2As<G, L, A>>
-  ): HKTAs<F, HKT2As<G, L, B>>
+  ap<L, A, B>(fgab: HKTAs<F, HKT2As<G, L, (a: A) => B>>, fga: HKTAs<F, HKT2As<G, L, A>>): HKTAs<F, HKT2As<G, L, B>>
 }
 
 export interface ApplicativeComposition21<F extends HKT2S, G extends HKTS> extends FunctorComposition21<F, G> {
   of<L, A>(a: A): HKT2As<F, L, HKTAs<G, A>>
-  ap<L, A, B>(
-    fgab: HKT2As<F, L, HKTAs<G, (a: A) => B>>,
-    fga: HKT2As<F, L, HKTAs<G, A>>
-  ): HKT2As<F, L, HKTAs<G, B>>
+  ap<L, A, B>(fgab: HKT2As<F, L, HKTAs<G, (a: A) => B>>, fga: HKT2As<F, L, HKTAs<G, A>>): HKT2As<F, L, HKTAs<G, B>>
 }
 
 export interface ApplicativeComposition22<F extends HKT2S, G extends HKT2S> extends FunctorComposition22<F, G> {

--- a/src/Apply.ts
+++ b/src/Apply.ts
@@ -1,4 +1,4 @@
-import { HKT, HKTS, HKT2S, URI2HKT, URI2HKT2 } from './HKT'
+import { HKT, HKTS, HKT2S, HKTAs, HKT2As } from './HKT'
 import { Functor, FantasyFunctor } from './Functor'
 import { Curried2, Curried3, Curried4, identity, constant } from './function'
 
@@ -22,8 +22,8 @@ const constIdentity = () => identity
 export class Ops {
   applyFirst<F extends HKT2S>(
     apply: Apply<F>
-  ): <L, A, B>(fa: URI2HKT2<L, A>[F], fb: URI2HKT2<L, B>[F]) => URI2HKT2<L, A>[F]
-  applyFirst<F extends HKTS>(apply: Apply<F>): <A, B>(fa: URI2HKT<A>[F], fb: URI2HKT<B>[F]) => URI2HKT<A>[F]
+  ): <L, A, B>(fa: HKT2As<F, L, A>, fb: HKT2As<F, L, B>) => HKT2As<F, L, A>
+  applyFirst<F extends HKTS>(apply: Apply<F>): <A, B>(fa: HKTAs<F, A>, fb: HKTAs<F, B>) => HKTAs<F, A>
   applyFirst<F>(apply: Apply<F>): <A, B>(fa: HKT<F, A>, fb: HKT<F, B>) => HKT<F, A>
   applyFirst<F>(apply: Apply<F>): <A, B>(fa: HKT<F, A>, fb: HKT<F, B>) => HKT<F, A> {
     return (fa, fb) => apply.ap(apply.map(a => constant(a), fa), fb)
@@ -31,8 +31,8 @@ export class Ops {
 
   applySecond<F extends HKT2S>(
     apply: Apply<F>
-  ): <L, A, B>(fa: URI2HKT2<L, A>[F], fb: URI2HKT2<L, B>[F]) => URI2HKT2<L, B>[F]
-  applySecond<F extends HKTS>(apply: Apply<F>): <A, B>(fa: URI2HKT<A>[F], fb: URI2HKT<B>[F]) => URI2HKT<B>[F]
+  ): <L, A, B>(fa: HKT2As<F, L, A>, fb: HKT2As<F, L, B>) => HKT2As<F, L, B>
+  applySecond<F extends HKTS>(apply: Apply<F>): <A, B>(fa: HKTAs<F, A>, fb: HKTAs<F, B>) => HKTAs<F, B>
   applySecond<F>(apply: Apply<F>): <A, B>(fa: HKT<F, A>, fb: HKT<F, B>) => HKT<F, B>
   applySecond<F>(apply: Apply<F>): <A, B>(fa: HKT<F, A>, fb: HKT<F, B>) => HKT<F, B> {
     return <A, B>(fa: HKT<F, A>, fb: HKT<F, B>) => apply.ap(apply.map(constIdentity, fa), fb)
@@ -41,11 +41,11 @@ export class Ops {
   liftA2<F extends HKT2S, A, B, C>(
     apply: Apply<F>,
     f: Curried2<A, B, C>
-  ): <L>(fa: URI2HKT2<L, A>[F], fb: URI2HKT2<L, B>[F]) => URI2HKT2<L, C>[F]
+  ): <L>(fa: HKT2As<F, L, A>, fb: HKT2As<F, L, B>) => HKT2As<F, L, C>
   liftA2<F extends HKTS, A, B, C>(
     apply: Apply<F>,
     f: Curried2<A, B, C>
-  ): (fa: URI2HKT<A>[F], fb: URI2HKT<B>[F]) => URI2HKT<C>[F]
+  ): (fa: HKTAs<F, A>, fb: HKTAs<F, B>) => HKTAs<F, C>
   liftA2<F, A, B, C>(apply: Apply<F>, f: Curried2<A, B, C>): (fa: HKT<F, A>, fb: HKT<F, B>) => HKT<F, C>
   liftA2<F, A, B, C>(apply: Apply<F>, f: Curried2<A, B, C>): (fa: HKT<F, A>, fb: HKT<F, B>) => HKT<F, C> {
     return (fa, fb) => apply.ap(apply.map(f, fa), fb)
@@ -54,11 +54,11 @@ export class Ops {
   liftA3<F extends HKT2S, A, B, C, D>(
     apply: Apply<F>,
     f: Curried3<A, B, C, D>
-  ): <L>(fa: URI2HKT2<L, A>[F], fb: URI2HKT2<L, B>[F], fc: URI2HKT2<L, C>[F]) => URI2HKT2<L, D>[F]
+  ): <L>(fa: HKT2As<F, L, A>, fb: HKT2As<F, L, B>, fc: HKT2As<F, L, C>) => HKT2As<F, L, D>
   liftA3<F extends HKTS, A, B, C, D>(
     apply: Apply<F>,
     f: Curried3<A, B, C, D>
-  ): (fa: URI2HKT<A>[F], fb: URI2HKT<B>[F], fc: URI2HKT<C>[F]) => URI2HKT<D>[F]
+  ): (fa: HKTAs<F, A>, fb: HKTAs<F, B>, fc: HKTAs<F, C>) => HKTAs<F, D>
   liftA3<F, A, B, C, D>(
     apply: Apply<F>,
     f: Curried3<A, B, C, D>
@@ -74,15 +74,15 @@ export class Ops {
     apply: Apply<F>,
     f: Curried4<A, B, C, D, E>
   ): <L>(
-    fa: URI2HKT2<L, A>[F],
-    fb: URI2HKT2<L, B>[F],
-    fc: URI2HKT2<L, C>[F],
-    fd: URI2HKT2<L, D>[F]
-  ) => URI2HKT2<L, E>[F]
+    fa: HKT2As<F, L, A>,
+    fb: HKT2As<F, L, B>,
+    fc: HKT2As<F, L, C>,
+    fd: HKT2As<F, L, D>
+  ) => HKT2As<F, L, E>
   liftA4<F extends HKTS, A, B, C, D, E>(
     apply: Apply<F>,
     f: Curried4<A, B, C, D, E>
-  ): (fa: URI2HKT<A>[F], fb: URI2HKT<B>[F], fc: URI2HKT<C>[F], fd: URI2HKT<D>[F]) => URI2HKT<E>[F]
+  ): (fa: HKTAs<F, A>, fb: HKTAs<F, B>, fc: HKTAs<F, C>, fd: HKTAs<F, D>) => HKTAs<F, E>
   liftA4<F, A, B, C, D, E>(
     apply: Apply<F>,
     f: Curried4<A, B, C, D, E>

--- a/src/Apply.ts
+++ b/src/Apply.ts
@@ -20,18 +20,14 @@ export interface FantasyApply<F, A> extends FantasyFunctor<F, A> {
 const constIdentity = () => identity
 
 export class Ops {
-  applyFirst<F extends HKT2S>(
-    apply: Apply<F>
-  ): <L, A, B>(fa: HKT2As<F, L, A>, fb: HKT2As<F, L, B>) => HKT2As<F, L, A>
+  applyFirst<F extends HKT2S>(apply: Apply<F>): <L, A, B>(fa: HKT2As<F, L, A>, fb: HKT2As<F, L, B>) => HKT2As<F, L, A>
   applyFirst<F extends HKTS>(apply: Apply<F>): <A, B>(fa: HKTAs<F, A>, fb: HKTAs<F, B>) => HKTAs<F, A>
   applyFirst<F>(apply: Apply<F>): <A, B>(fa: HKT<F, A>, fb: HKT<F, B>) => HKT<F, A>
   applyFirst<F>(apply: Apply<F>): <A, B>(fa: HKT<F, A>, fb: HKT<F, B>) => HKT<F, A> {
     return (fa, fb) => apply.ap(apply.map(a => constant(a), fa), fb)
   }
 
-  applySecond<F extends HKT2S>(
-    apply: Apply<F>
-  ): <L, A, B>(fa: HKT2As<F, L, A>, fb: HKT2As<F, L, B>) => HKT2As<F, L, B>
+  applySecond<F extends HKT2S>(apply: Apply<F>): <L, A, B>(fa: HKT2As<F, L, A>, fb: HKT2As<F, L, B>) => HKT2As<F, L, B>
   applySecond<F extends HKTS>(apply: Apply<F>): <A, B>(fa: HKTAs<F, A>, fb: HKTAs<F, B>) => HKTAs<F, B>
   applySecond<F>(apply: Apply<F>): <A, B>(fa: HKT<F, A>, fb: HKT<F, B>) => HKT<F, B>
   applySecond<F>(apply: Apply<F>): <A, B>(fa: HKT<F, A>, fb: HKT<F, B>) => HKT<F, B> {
@@ -73,12 +69,7 @@ export class Ops {
   liftA4<F extends HKT2S, A, B, C, D, E>(
     apply: Apply<F>,
     f: Curried4<A, B, C, D, E>
-  ): <L>(
-    fa: HKT2As<F, L, A>,
-    fb: HKT2As<F, L, B>,
-    fc: HKT2As<F, L, C>,
-    fd: HKT2As<F, L, D>
-  ) => HKT2As<F, L, E>
+  ): <L>(fa: HKT2As<F, L, A>, fb: HKT2As<F, L, B>, fc: HKT2As<F, L, C>, fd: HKT2As<F, L, D>) => HKT2As<F, L, E>
   liftA4<F extends HKTS, A, B, C, D, E>(
     apply: Apply<F>,
     f: Curried4<A, B, C, D, E>

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -1,4 +1,4 @@
-import { HKT, HKTS, HKT2S, URI2HKT, URI2HKT2 } from './HKT'
+import { HKT, HKTS, HKT2S, HKTAs, HKT2As } from './HKT'
 import { Monoid } from './Monoid'
 import { Applicative } from './Applicative'
 import { Monad } from './Monad'
@@ -64,8 +64,8 @@ export const curriedSnoc: <A>(a: Array<A>) => (b: A) => Array<A> = curry(snoc)
 export class Ops {
   traverse<F extends HKT2S>(
     F: Applicative<F>
-  ): <L, A, B>(f: (a: A) => URI2HKT2<L, B>[F], ta: Array<A>) => URI2HKT2<L, Array<B>>[F]
-  traverse<F extends HKTS>(F: Applicative<F>): <A, B>(f: (a: A) => URI2HKT<B>[F], ta: Array<A>) => URI2HKT<Array<B>>[F]
+  ): <L, A, B>(f: (a: A) => HKT2As<F, L, B>, ta: Array<A>) => HKT2As<F, L, Array<B>>
+  traverse<F extends HKTS>(F: Applicative<F>): <A, B>(f: (a: A) => HKTAs<F, B>, ta: Array<A>) => HKTAs<F, Array<B>>
   traverse<F>(F: Applicative<F>): <A, B>(f: (a: A) => HKT<F, B>, ta: Array<A>) => HKT<F, Array<B>>
   traverse<F>(F: Applicative<F>): <A, B>(f: (a: A) => HKT<F, B>, ta: Array<A>) => HKT<F, Array<B>> {
     const snocA2: <A>(fa: HKT<F, Array<A>>, fb: HKT<F, A>) => HKT<F, Array<A>> = liftA2(F, curriedSnoc)

--- a/src/Chain.ts
+++ b/src/Chain.ts
@@ -1,4 +1,4 @@
-import { HKT, HKTS, HKT2S, URI2HKT, URI2HKT2 } from './HKT'
+import { HKT, HKTS, HKT2S, HKTAs, HKT2As } from './HKT'
 import { Apply, FantasyApply } from './Apply'
 import { Kleisli } from './function'
 
@@ -11,8 +11,8 @@ export interface FantasyChain<F, A> extends FantasyApply<F, A> {
 }
 
 export class Ops {
-  flatten<F extends HKT2S>(chain: Chain<F>): <L, A>(mma: URI2HKT2<L, URI2HKT2<L, A>[F]>[F]) => URI2HKT2<L, A>[F]
-  flatten<F extends HKTS>(chain: Chain<F>): <A>(mma: URI2HKT<URI2HKT<A>[F]>[F]) => URI2HKT<A>[F]
+  flatten<F extends HKT2S>(chain: Chain<F>): <L, A>(mma: HKT2As<F, L, HKT2As<F, L, A>>) => HKT2As<F, L, A>
+  flatten<F extends HKTS>(chain: Chain<F>): <A>(mma: HKTAs<F, HKTAs<F, A>>) => HKTAs<F, A>
   flatten<F>(chain: Chain<F>): <A>(mma: HKT<F, HKT<F, A>>) => HKT<F, A>
   flatten<F>(chain: Chain<F>): <A>(mma: HKT<F, HKT<F, A>>) => HKT<F, A> {
     return mma => chain.chain(ma => ma, mma)

--- a/src/Contravariant.ts
+++ b/src/Contravariant.ts
@@ -1,4 +1,4 @@
-import { HKT, HKTS, HKT2S, URI2HKT, URI2HKT2 } from './HKT'
+import { HKT, HKTS, HKT2S, HKTAs, HKT2As } from './HKT'
 
 export interface Contravariant<F> {
   readonly URI: F
@@ -13,8 +13,8 @@ export class Ops {
   lift<F extends HKT2S, A, B>(
     contravariant: Contravariant<F>,
     f: (b: B) => A
-  ): <L>(fa: URI2HKT2<L, A>[F]) => URI2HKT2<L, B>[F]
-  lift<F extends HKTS, A, B>(contravariant: Contravariant<F>, f: (b: B) => A): (fa: URI2HKT<A>[F]) => URI2HKT<B>[F]
+  ): <L>(fa: HKT2As<F, L, A>) => HKT2As<F, L, B>
+  lift<F extends HKTS, A, B>(contravariant: Contravariant<F>, f: (b: B) => A): (fa: HKTAs<F, A>) => HKTAs<F, B>
   lift<F, A, B>(contravariant: Contravariant<F>, f: (b: B) => A): (fa: HKT<F, A>) => HKT<F, B>
   lift<F, A, B>(contravariant: Contravariant<F>, f: (b: B) => A): (fa: HKT<F, A>) => HKT<F, B> {
     return fa => contravariant.contramap(fa)(f)

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -1,4 +1,4 @@
-import { HKT, HKTS, HKT2S, HKT2, URI2HKT, URI2HKT2 } from './HKT'
+import { HKT, HKTS, HKT2S, HKT2, HKTAs, HKT2As } from './HKT'
 import { Applicative } from './Applicative'
 import { Monad, FantasyMonad } from './Monad'
 import { Foldable, FantasyFoldable } from './Foldable'
@@ -66,8 +66,8 @@ export class Left<L, A>
   reduce<B>(f: (b: B, a: A) => B, b: B): B {
     return b
   }
-  traverse<F extends HKT2S>(F: Applicative<F>): <M, B>(f: (a: A) => HKT2<F, M, B>) => URI2HKT2<M, Either<L, B>>[F]
-  traverse<F extends HKTS>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => URI2HKT<Either<L, B>>[F]
+  traverse<F extends HKT2S>(F: Applicative<F>): <M, B>(f: (a: A) => HKT2<F, M, B>) => HKT2As<F, M, Either<L, B>>
+  traverse<F extends HKTS>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKTAs<F, Either<L, B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, Either<L, B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, Either<L, B>> {
     return f => F.of(this as any)
@@ -137,8 +137,8 @@ export class Right<L, A>
   reduce<B>(f: (b: B, a: A) => B, b: B): B {
     return f(b, this.value)
   }
-  traverse<F extends HKT2S>(F: Applicative<F>): <M, B>(f: (a: A) => HKT2<F, M, B>) => URI2HKT2<M, Either<L, B>>[F]
-  traverse<F extends HKTS>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => URI2HKT<Either<L, B>>[F]
+  traverse<F extends HKT2S>(F: Applicative<F>): <M, B>(f: (a: A) => HKT2<F, M, B>) => HKT2As<F, M, Either<L, B>>
+  traverse<F extends HKTS>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKTAs<F, Either<L, B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, Either<L, B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, Either<L, B>> {
     return f => F.map(b => of(b), f(this.value))
@@ -219,10 +219,10 @@ export function reduce<L, A, B>(f: (b: B, a: A) => B, b: B, fa: Either<L, A>): B
 export class Ops {
   traverse<F extends HKT2S>(
     F: Applicative<F>
-  ): <M, L, A, B>(f: (a: A) => HKT2<F, M, B>, ta: Either<L, A>) => URI2HKT2<M, Either<L, B>>[F]
+  ): <M, L, A, B>(f: (a: A) => HKT2<F, M, B>, ta: Either<L, A>) => HKT2As<F, M, Either<L, B>>
   traverse<F extends HKTS>(
     F: Applicative<F>
-  ): <L, A, B>(f: (a: A) => HKT<F, B>, ta: Either<L, A>) => URI2HKT<Either<L, B>>[F]
+  ): <L, A, B>(f: (a: A) => HKT<F, B>, ta: Either<L, A>) => HKTAs<F, Either<L, B>>
   traverse<F>(F: Applicative<F>): <L, A, B>(f: (a: A) => HKT<F, B>, ta: Either<L, A>) => HKT<F, Either<L, B>>
   traverse<F>(F: Applicative<F>): <L, A, B>(f: (a: A) => HKT<F, B>, ta: Either<L, A>) => HKT<F, Either<L, B>> {
     return (f, ta) => ta.traverse(F)(f)

--- a/src/EitherT.ts
+++ b/src/EitherT.ts
@@ -22,10 +22,7 @@ export interface EitherT1<F extends HKTS> extends ApplicativeComposition12<F, UR
 }
 
 export interface EitherT2<F extends HKT2S> extends ApplicativeComposition22<F, URIEither> {
-  chain<L, M, A, B>(
-    f: (a: A) => HKT2As<F, M, Either<L, B>>,
-    fa: HKT2As<F, M, Either<L, A>>
-  ): HKT2As<F, M, Either<L, B>>
+  chain<L, M, A, B>(f: (a: A) => HKT2As<F, M, Either<L, B>>, fa: HKT2As<F, M, Either<L, A>>): HKT2As<F, M, Either<L, B>>
 }
 
 export class Ops {

--- a/src/EitherT.ts
+++ b/src/EitherT.ts
@@ -1,4 +1,4 @@
-import { HKT, HKTS, HKT2S, URI2HKT, URI2HKT2 } from './HKT'
+import { HKT, HKTS, HKT2S, HKTAs, HKT2As } from './HKT'
 import { Functor } from './Functor'
 import { Chain } from './Chain'
 import { Monad } from './Monad'
@@ -18,14 +18,14 @@ export interface EitherT<F> extends ApplicativeComposition<F, URIEither> {
 }
 
 export interface EitherT1<F extends HKTS> extends ApplicativeComposition12<F, URIEither> {
-  chain<L, A, B>(f: (a: A) => URI2HKT<Either<L, B>>[F], fa: URI2HKT<Either<L, A>>[F]): URI2HKT<Either<L, B>>[F]
+  chain<L, A, B>(f: (a: A) => HKTAs<F, Either<L, B>>, fa: HKTAs<F, Either<L, A>>): HKTAs<F, Either<L, B>>
 }
 
 export interface EitherT2<F extends HKT2S> extends ApplicativeComposition22<F, URIEither> {
   chain<L, M, A, B>(
-    f: (a: A) => URI2HKT2<M, Either<L, B>>[F],
-    fa: URI2HKT2<M, Either<L, A>>[F]
-  ): URI2HKT2<M, Either<L, B>>[F]
+    f: (a: A) => HKT2As<F, M, Either<L, B>>,
+    fa: HKT2As<F, M, Either<L, A>>
+  ): HKT2As<F, M, Either<L, B>>
 }
 
 export class Ops {
@@ -36,22 +36,22 @@ export class Ops {
     return (f, fa) => F.chain(e => e.fold(() => fa as any, a => f(a)), fa)
   }
 
-  right<F extends HKT2S>(F: Functor<F>): <L, M, A>(fa: URI2HKT2<M, A>[F]) => URI2HKT2<M, Either<L, A>>[F]
-  right<F extends HKTS>(F: Functor<F>): <L, A>(fa: URI2HKT<A>[F]) => URI2HKT<Either<L, A>>[F]
+  right<F extends HKT2S>(F: Functor<F>): <L, M, A>(fa: HKT2As<F, M, A>) => HKT2As<F, M, Either<L, A>>
+  right<F extends HKTS>(F: Functor<F>): <L, A>(fa: HKTAs<F, A>) => HKTAs<F, Either<L, A>>
   right<F>(F: Functor<F>): <L, A>(fa: HKT<F, A>) => HKT<F, Either<L, A>>
   right<F>(F: Functor<F>): <L, A>(fa: HKT<F, A>) => HKT<F, Either<L, A>> {
     return ma => F.map(a => either.right(a), ma)
   }
 
-  left<F extends HKT2S>(F: Functor<F>): <L, M, A>(fl: URI2HKT2<M, L>[F]) => URI2HKT2<M, Either<L, A>>[F]
-  left<F extends HKTS>(F: Functor<F>): <L, A>(fl: URI2HKT<L>[F]) => URI2HKT<Either<L, A>>[F]
+  left<F extends HKT2S>(F: Functor<F>): <L, M, A>(fl: HKT2As<F, M, L>) => HKT2As<F, M, Either<L, A>>
+  left<F extends HKTS>(F: Functor<F>): <L, A>(fl: HKTAs<F, L>) => HKTAs<F, Either<L, A>>
   left<F>(F: Functor<F>): <L, A>(fl: HKT<F, L>) => HKT<F, Either<L, A>>
   left<F>(F: Functor<F>): <L, A>(fl: HKT<F, L>) => HKT<F, Either<L, A>> {
     return ml => F.map(l => either.left(l), ml)
   }
 
-  fromEither<F extends HKT2S>(F: Applicative<F>): <L, M, A>(fa: Either<L, A>) => URI2HKT2<M, Either<L, A>>[F]
-  fromEither<F extends HKTS>(F: Applicative<F>): <L, A>(fa: Either<L, A>) => URI2HKT<Either<L, A>>[F]
+  fromEither<F extends HKT2S>(F: Applicative<F>): <L, M, A>(fa: Either<L, A>) => HKT2As<F, M, Either<L, A>>
+  fromEither<F extends HKTS>(F: Applicative<F>): <L, A>(fa: Either<L, A>) => HKTAs<F, Either<L, A>>
   fromEither<F>(F: Applicative<F>): <L, A>(fa: Either<L, A>) => HKT<F, Either<L, A>>
   fromEither<F>(F: Applicative<F>): <L, A>(fa: Either<L, A>) => HKT<F, Either<L, A>> {
     return oa => F.of(oa)
@@ -59,10 +59,10 @@ export class Ops {
 
   fold<F extends HKT2S>(
     F: Functor<F>
-  ): <R, L, M, A>(left: (l: L) => R, right: (a: A) => R, fa: URI2HKT2<M, Either<L, A>>[F]) => URI2HKT2<M, R>[F]
+  ): <R, L, M, A>(left: (l: L) => R, right: (a: A) => R, fa: HKT2As<F, M, Either<L, A>>) => HKT2As<F, M, R>
   fold<F extends HKTS>(
     F: Functor<F>
-  ): <R, L, A>(left: (l: L) => R, right: (a: A) => R, fa: URI2HKT<Either<L, A>>[F]) => URI2HKT<R>[F]
+  ): <R, L, A>(left: (l: L) => R, right: (a: A) => R, fa: HKTAs<F, Either<L, A>>) => HKTAs<F, R>
   fold<F>(F: Functor<F>): <R, L, A>(left: (l: L) => R, right: (a: A) => R, fa: HKT<F, Either<L, A>>) => HKT<F, R>
   fold<F>(F: Functor<F>): <R, L, A>(left: (l: L) => R, right: (a: A) => R, fa: HKT<F, Either<L, A>>) => HKT<F, R> {
     return (left, right, fa) => F.map(e => e.fold(left, right), fa)
@@ -70,17 +70,17 @@ export class Ops {
 
   mapLeft<F extends HKT2S>(
     F: Functor<F>
-  ): <N, L, M, A>(f: (l: L) => N, fa: URI2HKT2<M, Either<L, A>>[F]) => URI2HKT2<M, Either<N, A>>[F]
+  ): <N, L, M, A>(f: (l: L) => N, fa: HKT2As<F, M, Either<L, A>>) => HKT2As<F, M, Either<N, A>>
   mapLeft<F extends HKTS>(
     F: Functor<F>
-  ): <N, L, A>(f: (l: L) => N, fa: URI2HKT<Either<L, A>>[F]) => URI2HKT<Either<N, A>>[F]
+  ): <N, L, A>(f: (l: L) => N, fa: HKTAs<F, Either<L, A>>) => HKTAs<F, Either<N, A>>
   mapLeft<F>(F: Functor<F>): <N, L, A>(f: (l: L) => N, fa: HKT<F, Either<L, A>>) => HKT<F, Either<N, A>>
   mapLeft<F>(F: Functor<F>): <N, L, A>(f: (l: L) => N, fa: HKT<F, Either<L, A>>) => HKT<F, Either<N, A>> {
     return (f, fa) => F.map(e => e.mapLeft(f), fa)
   }
 
-  toOption<F extends HKT2S>(F: Functor<F>): <L, M, A>(fa: URI2HKT2<M, Either<L, A>>[F]) => URI2HKT2<M, Option<A>>[F]
-  toOption<F extends HKTS>(F: Functor<F>): <L, A>(fa: URI2HKT<Either<L, A>>[F]) => URI2HKT<Option<A>>[F]
+  toOption<F extends HKT2S>(F: Functor<F>): <L, M, A>(fa: HKT2As<F, M, Either<L, A>>) => HKT2As<F, M, Option<A>>
+  toOption<F extends HKTS>(F: Functor<F>): <L, A>(fa: HKTAs<F, Either<L, A>>) => HKTAs<F, Option<A>>
   toOption<F>(F: Functor<F>): <L, A>(fa: HKT<F, Either<L, A>>) => HKT<F, Option<A>>
   toOption<F>(F: Functor<F>): <L, A>(fa: HKT<F, Either<L, A>>) => HKT<F, Option<A>> {
     return fa => F.map(e => e.toOption(), fa)

--- a/src/Extend.ts
+++ b/src/Extend.ts
@@ -1,4 +1,4 @@
-import { HKT, HKTS, HKT2S, URI2HKT, URI2HKT2 } from './HKT'
+import { HKT, HKTS, HKT2S, HKTAs, HKT2As } from './HKT'
 import { Cokleisli } from './function'
 import { Functor, FantasyFunctor } from './Functor'
 
@@ -11,8 +11,8 @@ export interface FantasyExtend<F, A> extends FantasyFunctor<F, A> {
 }
 
 export class Ops {
-  duplicate<F extends HKT2S>(extend: Extend<F>): <L, A>(ma: URI2HKT2<L, A>[F]) => URI2HKT2<L, URI2HKT2<L, A>[F]>[F]
-  duplicate<F extends HKTS>(extend: Extend<F>): <A>(ma: URI2HKT<A>[F]) => URI2HKT<URI2HKT<A>[F]>[F]
+  duplicate<F extends HKT2S>(extend: Extend<F>): <L, A>(ma: HKT2As<F, L, A>) => HKT2As<F, L, HKT2As<F, L, A>>
+  duplicate<F extends HKTS>(extend: Extend<F>): <A>(ma: HKTAs<F, A>) => HKTAs<F, HKTAs<F, A>>
   duplicate<F>(extend: Extend<F>): <A>(ma: HKT<F, A>) => HKT<F, HKT<F, A>>
   duplicate<F>(extend: Extend<F>): <A>(ma: HKT<F, A>) => HKT<F, HKT<F, A>> {
     return ma => extend.extend(ma => ma, ma)

--- a/src/Filterable.ts
+++ b/src/Filterable.ts
@@ -1,4 +1,4 @@
-import { HKT, HKTS, HKT2S, URI2HKT, URI2HKT2 } from './HKT'
+import { HKT, HKTS, HKT2S, HKTAs, HKT2As } from './HKT'
 import { Functor } from './Functor'
 import { Either, fromPredicate, left, right } from './Either'
 import { Option, fromPredicate as optionFromPredicate } from './Option'
@@ -13,10 +13,10 @@ export class Ops {
   /** partition a data structure based on boolean predicate */
   partition<F extends HKT2S>(
     F: Filterable<F>
-  ): <L, A>(predicate: Predicate<A>, fa: URI2HKT2<L, A>[F]) => { no: URI2HKT2<L, A>[F]; yes: URI2HKT2<L, A>[F] }
+  ): <L, A>(predicate: Predicate<A>, fa: HKT2As<F, L, A>) => { no: HKT2As<F, L, A>; yes: HKT2As<F, L, A> }
   partition<F extends HKTS>(
     F: Filterable<F>
-  ): <A>(predicate: Predicate<A>, fa: URI2HKT<A>[F]) => { no: URI2HKT<A>[F]; yes: URI2HKT<A>[F] }
+  ): <A>(predicate: Predicate<A>, fa: HKTAs<F, A>) => { no: HKTAs<F, A>; yes: HKTAs<F, A> }
   partition<F>(F: Filterable<F>): <A>(predicate: Predicate<A>, fa: HKT<F, A>) => { no: HKT<F, A>; yes: HKT<F, A> }
   partition<F>(F: Filterable<F>): <A>(predicate: Predicate<A>, fa: HKT<F, A>) => { no: HKT<F, A>; yes: HKT<F, A> } {
     return (predicate, fa) => {
@@ -28,8 +28,8 @@ export class Ops {
   /** map over a data structure and filter based on a maybe */
   filterMap<F extends HKT2S>(
     F: Filterable<F>
-  ): <L, A, B>(f: (a: A) => Option<B>, fa: URI2HKT2<L, A>[F]) => URI2HKT2<L, B>[F]
-  filterMap<F extends HKTS>(F: Filterable<F>): <A, B>(f: (a: A) => Option<B>, fa: URI2HKT<A>[F]) => URI2HKT<B>[F]
+  ): <L, A, B>(f: (a: A) => Option<B>, fa: HKT2As<F, L, A>) => HKT2As<F, L, B>
+  filterMap<F extends HKTS>(F: Filterable<F>): <A, B>(f: (a: A) => Option<B>, fa: HKTAs<F, A>) => HKTAs<F, B>
   filterMap<F>(F: Filterable<F>): <A, B>(f: (a: A) => Option<B>, fa: HKT<F, A>) => HKT<F, B>
   filterMap<F>(F: Filterable<F>): <A, B>(f: (a: A) => Option<B>, fa: HKT<F, A>) => HKT<F, B> {
     return <A, B>(f: (a: A) => Option<B>, fa: HKT<F, A>) => {
@@ -38,8 +38,8 @@ export class Ops {
   }
 
   /** filter a data structure based on a boolean */
-  filter<F extends HKT2S>(F: Filterable<F>): <L, A>(predicate: Predicate<A>, fa: URI2HKT2<L, A>[F]) => URI2HKT2<L, A>[F]
-  filter<F extends HKTS>(F: Filterable<F>): <A>(predicate: Predicate<A>, fa: URI2HKT<A>[F]) => URI2HKT<A>[F]
+  filter<F extends HKT2S>(F: Filterable<F>): <L, A>(predicate: Predicate<A>, fa: HKT2As<F, L, A>) => HKT2As<F, L, A>
+  filter<F extends HKTS>(F: Filterable<F>): <A>(predicate: Predicate<A>, fa: HKTAs<F, A>) => HKTAs<F, A>
   filter<F>(F: Filterable<F>): <A>(predicate: Predicate<A>, fa: HKT<F, A>) => HKT<F, A>
   filter<F>(F: Filterable<F>): <A>(predicate: Predicate<A>, fa: HKT<F, A>) => HKT<F, A> {
     return <A>(predicate: Predicate<A>, fa: HKT<F, A>) => this.filterMap(F)(optionFromPredicate(predicate), fa)
@@ -47,18 +47,18 @@ export class Ops {
 
   partitioned<F extends HKT2S>(
     F: Filterable<F>
-  ): <L, M, R>(fa: URI2HKT2<M, Either<L, R>>[F]) => { left: URI2HKT2<M, L>[F]; right: URI2HKT2<M, R>[F] }
+  ): <L, M, R>(fa: HKT2As<F, M, Either<L, R>>) => { left: HKT2As<F, M, L>; right: HKT2As<F, M, R> }
   partitioned<F extends HKTS>(
     F: Filterable<F>
-  ): <L, R>(fa: URI2HKT<Either<L, R>>[F]) => { left: URI2HKT<L>[F]; right: URI2HKT<R>[F] }
+  ): <L, R>(fa: HKTAs<F, Either<L, R>>) => { left: HKTAs<F, L>; right: HKTAs<F, R> }
   partitioned<F>(F: Filterable<F>): <L, R>(fa: HKT<F, Either<L, R>>) => { left: HKT<F, L>; right: HKT<F, R> }
   partitioned<F>(F: Filterable<F>): <L, R>(fa: HKT<F, Either<L, R>>) => { left: HKT<F, L>; right: HKT<F, R> } {
     return <L, A>(fa: HKT<F, Either<L, A>>) => F.partitionMap(a => a, fa)
   }
 
   /** Filter out all the `None` values */
-  filtered<F extends HKT2S>(F: Filterable<F>): <L, A>(fa: URI2HKT2<L, Option<A>>[F]) => URI2HKT2<L, A>[F]
-  filtered<F extends HKTS>(F: Filterable<F>): <A>(fa: URI2HKT<Option<A>>[F]) => URI2HKT<A>[F]
+  filtered<F extends HKT2S>(F: Filterable<F>): <L, A>(fa: HKT2As<F, L, Option<A>>) => HKT2As<F, L, A>
+  filtered<F extends HKTS>(F: Filterable<F>): <A>(fa: HKTAs<F, Option<A>>) => HKTAs<F, A>
   filtered<F>(F: Filterable<F>): <A>(fa: HKT<F, Option<A>>) => HKT<F, A>
   filtered<F>(F: Filterable<F>): <A>(fa: HKT<F, Option<A>>) => HKT<F, A> {
     return <A>(fa: HKT<F, Option<A>>) => this.filterMap(F)(a => a, fa)

--- a/src/Foldable.ts
+++ b/src/Foldable.ts
@@ -1,4 +1,4 @@
-import { HKT, HKTS, HKT2S, URI2HKT, URI2HKT2 } from './HKT'
+import { HKT, HKTS, HKT2S, HKTAs, HKT2As } from './HKT'
 import { Monoid } from './Monoid'
 import { Applicative } from './Applicative'
 import { applyFirst } from './Apply'
@@ -52,11 +52,11 @@ export class Ops {
   traverse_<M extends HKT2S, F>(
     M: Applicative<M>,
     F: Foldable<F>
-  ): <L, A, B>(f: (a: A) => URI2HKT2<L, B>[M], fa: HKT<F, A>) => URI2HKT2<L, void>[M]
+  ): <L, A, B>(f: (a: A) => HKT2As<M, L, B>, fa: HKT<F, A>) => HKT2As<M, L, void>
   traverse_<M extends HKTS, F>(
     M: Applicative<M>,
     F: Foldable<F>
-  ): <A, B>(f: (a: A) => URI2HKT<B>[M], fa: HKT<F, A>) => URI2HKT<void>[M]
+  ): <A, B>(f: (a: A) => HKTAs<M, B>, fa: HKT<F, A>) => HKTAs<M, void>
   traverse_<M, F>(M: Applicative<M>, F: Foldable<F>): <A, B>(f: (a: A) => HKT<M, B>, fa: HKT<F, A>) => HKT<M, void>
   traverse_<M, F>(M: Applicative<M>, F: Foldable<F>): <A, B>(f: (a: A) => HKT<M, B>, fa: HKT<F, A>) => HKT<M, void> {
     return (f, fa) => toArray(F)(fa).reduce((mu, a) => applyFirst(M)(mu, f(a)), M.of(undefined))
@@ -65,8 +65,8 @@ export class Ops {
   sequence_<M extends HKT2S, F>(
     M: Applicative<M>,
     F: Foldable<F>
-  ): <L, A>(fa: HKT<F, URI2HKT2<L, A>[M]>) => URI2HKT2<L, void>[M]
-  sequence_<M extends HKTS, F>(M: Applicative<M>, F: Foldable<F>): <A>(fa: HKT<F, URI2HKT<A>[M]>) => URI2HKT<void>[M]
+  ): <L, A>(fa: HKT<F, HKT2As<M, L, A>>) => HKT2As<M, L, void>
+  sequence_<M extends HKTS, F>(M: Applicative<M>, F: Foldable<F>): <A>(fa: HKT<F, HKTAs<M, A>>) => HKTAs<M, void>
   sequence_<M, F>(M: Applicative<M>, F: Foldable<F>): <A>(fa: HKT<F, HKT<M, A>>) => HKT<M, void>
   sequence_<M, F>(M: Applicative<M>, F: Foldable<F>): <A>(fa: HKT<F, HKT<M, A>>) => HKT<M, void> {
     return fa => this.traverse_(M, F)(x => x, fa)

--- a/src/Free.ts
+++ b/src/Free.ts
@@ -1,7 +1,7 @@
 // adapted from http://okmij.org/ftp/Computation/free-monad.html
 // and https://github.com/purescript/purescript-free
 
-import { HKT, HKTS, URI2HKT } from './HKT'
+import { HKT, HKTS, HKTAs } from './HKT'
 import { FantasyMonad, Monad } from './Monad'
 import { NaturalTransformation } from './NaturalTransformation'
 import { toString } from './function'
@@ -34,7 +34,7 @@ export class Pure<F, A> implements FantasyMonad<URI, A> {
   chain<B>(f: (a: A) => Free<F, B>): Free<F, B> {
     return f(this.value)
   }
-  foldFree<M extends HKTS>(M: Monad<M>, f: NaturalTransformation<F, M>): URI2HKT<A>[M]
+  foldFree<M extends HKTS>(M: Monad<M>, f: NaturalTransformation<F, M>): HKTAs<M, A>
   foldFree<M>(M: Monad<M>, f: NaturalTransformation<F, M>): HKT<M, A>
   foldFree<M>(M: Monad<M>, f: NaturalTransformation<F, M>): HKT<M, A> {
     return M.of(this.value)
@@ -69,7 +69,7 @@ export class Impure<F, A, X> implements FantasyMonad<URI, A> {
   chain<B>(f: (a: A) => Free<F, B>): Free<F, B> {
     return new Impure(this.fx, x => this.f(x).chain(f))
   }
-  foldFree<M extends HKTS>(M: Monad<M>, f: NaturalTransformation<F, M>): URI2HKT<A>[M]
+  foldFree<M extends HKTS>(M: Monad<M>, f: NaturalTransformation<F, M>): HKTAs<M, A>
   foldFree<M>(M: Monad<M>, f: NaturalTransformation<F, M>): HKT<M, A>
   foldFree<M>(M: Monad<M>, f: NaturalTransformation<F, M>): HKT<M, A> {
     return M.chain(x => this.f(x).foldFree(M, f), f(this.fx))
@@ -93,7 +93,7 @@ export class Ops {
     return new Impure(fa, a => of(a))
   }
 
-  foldFree<F, M extends HKTS, A>(M: Monad<M>, f: NaturalTransformation<F, M>, fa: Free<F, A>): URI2HKT<A>[M]
+  foldFree<F, M extends HKTS, A>(M: Monad<M>, f: NaturalTransformation<F, M>, fa: Free<F, A>): HKTAs<M, A>
   foldFree<F, M, A>(M: Monad<M>, f: NaturalTransformation<F, M>, fa: Free<F, A>): HKT<M, A>
   foldFree<F, M, A>(M: Monad<M>, f: NaturalTransformation<F, M>, fa: Free<F, A>): HKT<M, A> {
     return fa.foldFree(M, f)

--- a/src/Functor.ts
+++ b/src/Functor.ts
@@ -1,4 +1,4 @@
-import { HKT, URI2HKT, HKTS, URI2HKT2, HKT2S } from './HKT'
+import { HKT, HKTAs, HKTS, HKT2As, HKT2S } from './HKT'
 import { constant } from './function'
 
 export interface Functor<F> {
@@ -15,40 +15,40 @@ export interface FunctorComposition<F, G> {
 }
 
 export interface FunctorComposition11<F extends HKTS, G extends HKTS> {
-  map<A, B>(f: (a: A) => B, fa: URI2HKT<URI2HKT<A>[G]>[F]): URI2HKT<URI2HKT<B>[G]>[F]
+  map<A, B>(f: (a: A) => B, fa: HKTAs<F, HKTAs<G, A>>): HKTAs<F, HKTAs<G, B>>
 }
 
 export interface FunctorComposition12<F extends HKTS, G extends HKT2S> {
-  map<L, A, B>(f: (a: A) => B, fa: URI2HKT<URI2HKT2<L, A>[G]>[F]): URI2HKT<URI2HKT2<L, B>[G]>[F]
+  map<L, A, B>(f: (a: A) => B, fa: HKTAs<F, HKT2As<G, L, A>>): HKTAs<F, HKT2As<G, L, B>>
 }
 
 export interface FunctorComposition21<F extends HKT2S, G extends HKTS> {
-  map<L, A, B>(f: (a: A) => B, fa: URI2HKT2<L, URI2HKT<A>[G]>[F]): URI2HKT2<L, URI2HKT<B>[G]>[F]
+  map<L, A, B>(f: (a: A) => B, fa: HKT2As<F, L, HKTAs<G, A>>): HKT2As<F, L, HKTAs<G, B>>
 }
 
 export interface FunctorComposition22<F extends HKT2S, G extends HKT2S> {
-  map<L, M, A, B>(f: (a: A) => B, fa: URI2HKT2<L, URI2HKT2<M, A>[G]>[F]): URI2HKT2<L, URI2HKT2<M, B>[G]>[F]
+  map<L, M, A, B>(f: (a: A) => B, fa: HKT2As<F, L, HKT2As<G, M, A>>): HKT2As<F, L, HKT2As<G, M, B>>
 }
 
 export class Ops {
-  lift<F extends HKT2S, A, B>(F: Functor<F>, f: (a: A) => B): <L>(fa: URI2HKT2<L, A>[F]) => URI2HKT2<L, B>[F]
-  lift<F extends HKTS, A, B>(F: Functor<F>, f: (a: A) => B): (fa: URI2HKT<A>[F]) => URI2HKT<B>[F]
+  lift<F extends HKT2S, A, B>(F: Functor<F>, f: (a: A) => B): <L>(fa: HKT2As<F, L, A>) => HKT2As<F, L, B>
+  lift<F extends HKTS, A, B>(F: Functor<F>, f: (a: A) => B): (fa: HKTAs<F, A>) => HKTAs<F, B>
   lift<F, A, B>(F: Functor<F>, f: (a: A) => B): (fa: HKT<F, A>) => HKT<F, B>
   lift<F, A, B>(F: Functor<F>, f: (a: A) => B): (fa: HKT<F, A>) => HKT<F, B> {
     return fa => F.map(f, fa)
   }
 
   /** Ignore the return value of a computation, using the specified return value instead (`<$`) */
-  voidRight<F extends HKT2S, L, A, B>(F: Functor<F>, a: A, fb: URI2HKT2<L, B>[F]): URI2HKT2<L, A>[F]
-  voidRight<F extends HKTS, A, B>(F: Functor<F>, a: A, fb: URI2HKT<B>[F]): URI2HKT<A>[F]
+  voidRight<F extends HKT2S, L, A, B>(F: Functor<F>, a: A, fb: HKT2As<F, L, B>): HKT2As<F, L, A>
+  voidRight<F extends HKTS, A, B>(F: Functor<F>, a: A, fb: HKTAs<F, B>): HKTAs<F, A>
   voidRight<F, A, B>(F: Functor<F>, a: A, fb: HKT<F, B>): HKT<F, A>
   voidRight<F, A, B>(F: Functor<F>, a: A, fb: HKT<F, B>): HKT<F, A> {
     return F.map(constant(a), fb)
   }
 
   /** A version of `voidRight` with its arguments flipped (`$>`) */
-  voidLeft<F extends HKT2S, L, A, B>(F: Functor<F>, fa: URI2HKT2<L, A>[F], b: B): URI2HKT2<L, B>[F]
-  voidLeft<F extends HKTS, A, B>(F: Functor<F>, fa: URI2HKT<A>[F], b: B): URI2HKT<B>[F]
+  voidLeft<F extends HKT2S, L, A, B>(F: Functor<F>, fa: HKT2As<F, L, A>, b: B): HKT2As<F, L, B>
+  voidLeft<F extends HKTS, A, B>(F: Functor<F>, fa: HKTAs<F, A>, b: B): HKTAs<F, B>
   voidLeft<F, A, B>(F: Functor<F>, fa: HKT<F, A>, b: B): HKT<F, B>
   voidLeft<F, A, B>(F: Functor<F>, fa: HKT<F, A>, b: B): HKT<F, B> {
     return F.map(constant(b), fa)
@@ -57,8 +57,8 @@ export class Ops {
   /** Apply a value in a computational context to a value in no context.
    * Generalizes `flip`
    */
-  flap<F extends HKT2S>(functor: Functor<F>): <L, A, B>(ff: URI2HKT2<L, (a: A) => B>[F], a: A) => URI2HKT2<L, B>[F]
-  flap<F extends HKTS>(functor: Functor<F>): <A, B>(ff: URI2HKT<(a: A) => B>[F], a: A) => URI2HKT<B>[F]
+  flap<F extends HKT2S>(functor: Functor<F>): <L, A, B>(ff: HKT2As<F, L, (a: A) => B>, a: A) => HKT2As<F, L, B>
+  flap<F extends HKTS>(functor: Functor<F>): <A, B>(ff: HKTAs<F, (a: A) => B>, a: A) => HKTAs<F, B>
   flap<F>(functor: Functor<F>): <A, B>(ff: HKT<F, (a: A) => B>, a: A) => HKT<F, B>
   flap<F>(functor: Functor<F>): <A, B>(ff: HKT<F, (a: A) => B>, a: A) => HKT<F, B> {
     return (ff, a) => functor.map(f => f(a), ff)

--- a/src/HKT.ts
+++ b/src/HKT.ts
@@ -7,21 +7,23 @@ export interface HKT2<URI, L, A> extends HKT<URI, A> {
   readonly _L: L
 }
 
-// type-level dictionary for HKTs with one type parameter
-// export type HKTMap<T extends string> = { [K in T]: HKT<K, any> }
+// type-level dictionaries for HKTs
 
 export interface URI2HKT<A> {}
-
-export type HKTS = keyof URI2HKT<any>
-
-// type-level dictionary for HKTs with two type parameters
-// export type HKTMap2<T extends string> = { [K in T]: HKT2<K, any, any> }
-
 export interface URI2HKT2<L, A> {}
 
-export type HKT2S = keyof URI2HKT2<any, any>
+// URI constrains with dictionary integrity check
 
-/* tslint:disable */
-(null! as URI2HKT<any>) as { [k in keyof URI2HKT<any>]: HKT<k, any> }
-(null! as URI2HKT2<any, any>) as { [k in keyof URI2HKT2<any, any>]: HKT2<k, any, any> }
-/* tslint:enable */
+export type HKTS = keyof {
+  [key in URI2HKT<any>[keyof URI2HKT<any>]['_URI']]: any
+}
+
+export type HKT2S = keyof {
+  [key in URI2HKT2<any, any>[keyof URI2HKT2<any, any>]['_URI']]: any
+}
+
+// HKTAs<U, A> is the same as URI2HKT<A>[U], but checks for URI constraints
+
+export type HKTAs<URI extends HKTS, A> = URI2HKT<A>[URI]
+
+export type HKT2As<URI extends HKT2S, L, A> = URI2HKT2<L, A>[URI]

--- a/src/HKT.ts
+++ b/src/HKT.ts
@@ -14,13 +14,9 @@ export interface URI2HKT2<L, A> {}
 
 // URI constrains with dictionary integrity check
 
-export type HKTS = keyof {
-  [key in URI2HKT<any>[keyof URI2HKT<any>]['_URI']]: any
-}
+export type HKTS = URI2HKT<any>[keyof URI2HKT<any>]['_URI']
 
-export type HKT2S = keyof {
-  [key in URI2HKT2<any, any>[keyof URI2HKT2<any, any>]['_URI']]: any
-}
+export type HKT2S = URI2HKT2<any, any>[keyof URI2HKT2<any, any>]['_URI']
 
 // HKTAs<U, A> is the same as URI2HKT<A>[U], but checks for URI constraints
 

--- a/src/HKT.ts
+++ b/src/HKT.ts
@@ -12,7 +12,7 @@ export interface HKT2<URI, L, A> extends HKT<URI, A> {
 export interface URI2HKT<A> {}
 export interface URI2HKT2<L, A> {}
 
-// URI constrains with dictionary integrity check
+// URI constraints with dictionary integrity constraint
 
 export type HKTS = URI2HKT<any>[keyof URI2HKT<any>]['_URI']
 
@@ -23,3 +23,10 @@ export type HKT2S = URI2HKT2<any, any>[keyof URI2HKT2<any, any>]['_URI']
 export type HKTAs<URI extends HKTS, A> = URI2HKT<A>[URI]
 
 export type HKT2As<URI extends HKT2S, L, A> = URI2HKT2<L, A>[URI]
+
+// Type-level integrity check
+
+/* tslint:disable */
+(null! as URI2HKT<any>) as { [k in keyof URI2HKT<any>]: HKT<k, any> }
+(null! as URI2HKT2<any, any>) as { [k in keyof URI2HKT2<any, any>]: HKT2<k, any, any> }
+/* tslint:enable */

--- a/src/Identity.ts
+++ b/src/Identity.ts
@@ -11,7 +11,7 @@ import { ChainRec, tailRec } from './ChainRec'
 import { toString } from './function'
 
 declare module './HKT' {
-  interface URIHKT<A> {
+  interface URI2HKT<A> {
     Identity: Identity<A>
   }
 }

--- a/src/Identity.ts
+++ b/src/Identity.ts
@@ -1,4 +1,4 @@
-import { HKT, HKTS, HKT2S, URI2HKT, URI2HKT2 } from './HKT'
+import { HKT, HKTS, HKT2S, HKTAs, HKT2As } from './HKT'
 import { Applicative } from './Applicative'
 import { Monad, FantasyMonad } from './Monad'
 import { Foldable, FantasyFoldable } from './Foldable'
@@ -11,7 +11,7 @@ import { ChainRec, tailRec } from './ChainRec'
 import { toString } from './function'
 
 declare module './HKT' {
-  interface URI2HKT<A> {
+  interface URIHKT<A> {
     Identity: Identity<A>
   }
 }
@@ -51,8 +51,8 @@ export class Identity<A>
   }
   traverse<F extends HKT2S>(
     applicative: Applicative<F>
-  ): <L, B>(f: (a: A) => URI2HKT2<L, B>[F]) => URI2HKT2<L, Identity<B>>[F]
-  traverse<F extends HKTS>(applicative: Applicative<F>): <B>(f: (a: A) => URI2HKT<B>[F]) => URI2HKT<Identity<B>>[F]
+  ): <L, B>(f: (a: A) => HKT2As<F, L, B>) => HKT2As<F, L, Identity<B>>
+  traverse<F extends HKTS>(applicative: Applicative<F>): <B>(f: (a: A) => HKTAs<F, B>) => HKTAs<F, Identity<B>>
   traverse<F>(applicative: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, Identity<B>>
   traverse<F>(applicative: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, Identity<B>> {
     return f => applicative.map(a => of(a), f(this.value))
@@ -117,10 +117,10 @@ export function alt<A>(fx: Identity<A>, fy: Identity<A>): Identity<A> {
 export class Ops {
   traverse<F extends HKT2S>(
     F: Applicative<F>
-  ): <L, A, B>(f: (a: A) => URI2HKT2<L, B>[F], ta: Identity<A>) => URI2HKT2<L, Identity<B>>[F]
+  ): <L, A, B>(f: (a: A) => HKT2As<F, L, B>, ta: Identity<A>) => HKT2As<F, L, Identity<B>>
   traverse<F extends HKTS>(
     F: Applicative<F>
-  ): <A, B>(f: (a: A) => URI2HKT<B>[F], ta: Identity<A>) => URI2HKT<Identity<B>>[F]
+  ): <A, B>(f: (a: A) => HKTAs<F, B>, ta: Identity<A>) => HKTAs<F, Identity<B>>
   traverse<F>(F: Applicative<F>): <A, B>(f: (a: A) => HKT<F, B>, ta: Identity<A>) => HKT<F, Identity<B>>
   traverse<F>(F: Applicative<F>): <A, B>(f: (a: A) => HKT<F, B>, ta: Identity<A>) => HKT<F, Identity<B>> {
     return (f, ta) => ta.traverse(F)(f)

--- a/src/NonEmptyArray.ts
+++ b/src/NonEmptyArray.ts
@@ -1,4 +1,4 @@
-import { HKT, HKTS, HKT2S, URI2HKT, URI2HKT2 } from './HKT'
+import { HKT, HKTS, HKT2S, HKTAs, HKT2As } from './HKT'
 import { Monad, FantasyMonad } from './Monad'
 import { Comonad, FantasyComonad } from './Comonad'
 import { Semigroup } from './Semigroup'
@@ -54,8 +54,8 @@ export class NonEmptyArray<A>
   }
   traverse<F extends HKT2S>(
     applicative: Applicative<F>
-  ): <L, B>(f: (a: A) => URI2HKT2<L, B>[F]) => URI2HKT2<L, NonEmptyArray<B>>[F]
-  traverse<F extends HKTS>(applicative: Applicative<F>): <B>(f: (a: A) => URI2HKT<B>[F]) => URI2HKT<NonEmptyArray<B>>[F]
+  ): <L, B>(f: (a: A) => HKT2As<F, L, B>) => HKT2As<F, L, NonEmptyArray<B>>
+  traverse<F extends HKTS>(applicative: Applicative<F>): <B>(f: (a: A) => HKTAs<F, B>) => HKTAs<F, NonEmptyArray<B>>
   traverse<F>(applicative: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, NonEmptyArray<B>>
   traverse<F>(applicative: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, NonEmptyArray<B>> {
     return f => applicative.map(bs => unsafeFromArray(bs), array.traverse(applicative)(f, this.toArray()))
@@ -109,10 +109,10 @@ export function reduce<A, B>(f: (b: B, a: A) => B, b: B, fa: NonEmptyArray<A>): 
 export class Ops {
   traverse<F extends HKT2S>(
     F: Applicative<F>
-  ): <L, A, B>(f: (a: A) => URI2HKT2<L, B>[F], ta: NonEmptyArray<A>) => URI2HKT2<L, NonEmptyArray<B>>[F]
+  ): <L, A, B>(f: (a: A) => HKT2As<F, L, B>, ta: NonEmptyArray<A>) => HKT2As<F, L, NonEmptyArray<B>>
   traverse<F extends HKTS>(
     F: Applicative<F>
-  ): <A, B>(f: (a: A) => URI2HKT<B>[F], ta: NonEmptyArray<A>) => URI2HKT<NonEmptyArray<B>>[F]
+  ): <A, B>(f: (a: A) => HKTAs<F, B>, ta: NonEmptyArray<A>) => HKTAs<F, NonEmptyArray<B>>
   traverse<F>(F: Applicative<F>): <A, B>(f: (a: A) => HKT<F, B>, ta: NonEmptyArray<A>) => HKT<F, NonEmptyArray<B>>
   traverse<F>(F: Applicative<F>): <A, B>(f: (a: A) => HKT<F, B>, ta: NonEmptyArray<A>) => HKT<F, NonEmptyArray<B>> {
     return (f, ta) => ta.traverse(F)(f)

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -229,9 +229,7 @@ export class Ops {
   traverse<F extends HKT2S>(
     F: Applicative<F>
   ): <L, A, B>(f: (a: A) => HKT2As<F, L, B>, ta: Option<A>) => HKT2As<F, L, Option<B>>
-  traverse<F extends HKTS>(
-    F: Applicative<F>
-  ): <A, B>(f: (a: A) => HKTAs<F, B>, ta: Option<A>) => HKTAs<F, Option<B>>
+  traverse<F extends HKTS>(F: Applicative<F>): <A, B>(f: (a: A) => HKTAs<F, B>, ta: Option<A>) => HKTAs<F, Option<B>>
   traverse<F>(F: Applicative<F>): <A, B>(f: (a: A) => HKT<F, B>, ta: Option<A>) => HKT<F, Option<B>>
   traverse<F>(F: Applicative<F>): <A, B>(f: (a: A) => HKT<F, B>, ta: Option<A>) => HKT<F, Option<B>> {
     return (f, ta) => ta.traverse(F)(f)

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -1,4 +1,4 @@
-import { HKT, HKTS, HKT2S, URI2HKT, URI2HKT2 } from './HKT'
+import { HKT, HKTS, HKT2S, HKTAs, HKT2As } from './HKT'
 import { Monoid, getDualMonoid } from './Monoid'
 import { Applicative } from './Applicative'
 import { Semigroup } from './Semigroup'
@@ -58,8 +58,8 @@ export class None<A>
   reduce<B>(f: (b: B, a: A) => B, b: B): B {
     return b
   }
-  traverse<F extends HKT2S>(F: Applicative<F>): <L, B>(f: (a: A) => URI2HKT2<L, B>[F]) => URI2HKT2<L, Option<B>>[F]
-  traverse<F extends HKTS>(F: Applicative<F>): <B>(f: (a: A) => URI2HKT<B>[F]) => URI2HKT<Option<B>>[F]
+  traverse<F extends HKT2S>(F: Applicative<F>): <L, B>(f: (a: A) => HKT2As<F, L, B>) => HKT2As<F, L, Option<B>>
+  traverse<F extends HKTS>(F: Applicative<F>): <B>(f: (a: A) => HKTAs<F, B>) => HKTAs<F, Option<B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, Option<B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, Option<B>> {
     return f => F.of(none)
@@ -137,8 +137,8 @@ export class Some<A>
   reduce<B>(f: (b: B, a: A) => B, b: B): B {
     return this.fold(constant(b), a => f(b, a))
   }
-  traverse<F extends HKT2S>(F: Applicative<F>): <L, B>(f: (a: A) => URI2HKT2<L, B>[F]) => URI2HKT2<L, Option<B>>[F]
-  traverse<F extends HKTS>(F: Applicative<F>): <B>(f: (a: A) => URI2HKT<B>[F]) => URI2HKT<Option<B>>[F]
+  traverse<F extends HKT2S>(F: Applicative<F>): <L, B>(f: (a: A) => HKT2As<F, L, B>) => HKT2As<F, L, Option<B>>
+  traverse<F extends HKTS>(F: Applicative<F>): <B>(f: (a: A) => HKTAs<F, B>) => HKTAs<F, Option<B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, Option<B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, Option<B>> {
     return f => F.map(b => some(b), f(this.value))
@@ -228,10 +228,10 @@ export function reduce<A, B>(f: (b: B, a: A) => B, b: B, fa: Option<A>): B {
 export class Ops {
   traverse<F extends HKT2S>(
     F: Applicative<F>
-  ): <L, A, B>(f: (a: A) => URI2HKT2<L, B>[F], ta: Option<A>) => URI2HKT2<L, Option<B>>[F]
+  ): <L, A, B>(f: (a: A) => HKT2As<F, L, B>, ta: Option<A>) => HKT2As<F, L, Option<B>>
   traverse<F extends HKTS>(
     F: Applicative<F>
-  ): <A, B>(f: (a: A) => URI2HKT<B>[F], ta: Option<A>) => URI2HKT<Option<B>>[F]
+  ): <A, B>(f: (a: A) => HKTAs<F, B>, ta: Option<A>) => HKTAs<F, Option<B>>
   traverse<F>(F: Applicative<F>): <A, B>(f: (a: A) => HKT<F, B>, ta: Option<A>) => HKT<F, Option<B>>
   traverse<F>(F: Applicative<F>): <A, B>(f: (a: A) => HKT<F, B>, ta: Option<A>) => HKT<F, Option<B>> {
     return (f, ta) => ta.traverse(F)(f)

--- a/src/OptionT.ts
+++ b/src/OptionT.ts
@@ -1,4 +1,4 @@
-import { HKT, HKTS, HKT2S, URI2HKT, URI2HKT2 } from './HKT'
+import { HKT, HKTS, HKT2S, HKTAs, HKT2As } from './HKT'
 import { Functor } from './Functor'
 import { Monad } from './Monad'
 import { Chain } from './Chain'
@@ -18,11 +18,11 @@ export interface OptionT<M> extends ApplicativeComposition<M, OptionURI> {
 }
 
 export interface OptionT1<M extends HKTS> extends ApplicativeComposition11<M, OptionURI> {
-  chain<A, B>(f: (a: A) => URI2HKT<Option<B>>[M], fa: URI2HKT<Option<A>>[M]): URI2HKT<Option<B>>[M]
+  chain<A, B>(f: (a: A) => HKTAs<M, Option<B>>, fa: HKTAs<M, Option<A>>): HKTAs<M, Option<B>>
 }
 
 export interface OptionT2<M extends HKT2S> extends ApplicativeComposition21<M, OptionURI> {
-  chain<L, A, B>(f: (a: A) => URI2HKT2<L, Option<B>>[M], fa: URI2HKT2<L, Option<A>>[M]): URI2HKT2<L, Option<B>>[M]
+  chain<L, A, B>(f: (a: A) => HKT2As<M, L, Option<B>>, fa: HKT2As<M, L, Option<A>>): HKT2As<M, L, Option<B>>
 }
 
 export class Ops {
@@ -33,29 +33,29 @@ export class Ops {
     return (f, fa) => F.chain(o => o.fold(() => fa as any, a => f(a)), fa)
   }
 
-  some<F extends HKT2S>(F: Applicative<F>): <L, A>(a: A) => URI2HKT2<L, Option<A>>[F]
-  some<F extends HKTS>(F: Applicative<F>): <A>(a: A) => URI2HKT<Option<A>>[F]
+  some<F extends HKT2S>(F: Applicative<F>): <L, A>(a: A) => HKT2As<F, L, Option<A>>
+  some<F extends HKTS>(F: Applicative<F>): <A>(a: A) => HKTAs<F, Option<A>>
   some<F>(F: Applicative<F>): <A>(a: A) => HKT<F, Option<A>>
   some<F>(F: Applicative<F>): <A>(a: A) => HKT<F, Option<A>> {
     return a => F.of(option.some(a))
   }
 
-  none<F extends HKT2S>(F: Applicative<F>): <L>() => URI2HKT2<L, Option<any>>[F]
-  none<F extends HKTS>(F: Applicative<F>): () => URI2HKT<Option<any>>[F]
+  none<F extends HKT2S>(F: Applicative<F>): <L>() => HKT2As<F, L, Option<any>>
+  none<F extends HKTS>(F: Applicative<F>): () => HKTAs<F, Option<any>>
   none<F>(F: Applicative<F>): () => HKT<F, Option<any>>
   none<F>(F: Applicative<F>): () => HKT<F, Option<any>> {
     return () => F.of(option.none)
   }
 
-  fromOption<F extends HKT2S>(F: Applicative<F>): <L, A>(fa: Option<A>) => URI2HKT2<L, Option<A>>[F]
-  fromOption<F extends HKTS>(F: Applicative<F>): <A>(fa: Option<A>) => URI2HKT<Option<A>>[F]
+  fromOption<F extends HKT2S>(F: Applicative<F>): <L, A>(fa: Option<A>) => HKT2As<F, L, Option<A>>
+  fromOption<F extends HKTS>(F: Applicative<F>): <A>(fa: Option<A>) => HKTAs<F, Option<A>>
   fromOption<F>(F: Applicative<F>): <A>(fa: Option<A>) => HKT<F, Option<A>>
   fromOption<F>(F: Applicative<F>): <A>(fa: Option<A>) => HKT<F, Option<A>> {
     return oa => F.of(oa)
   }
 
-  liftF<F extends HKT2S>(F: Functor<F>): <L, A>(fa: URI2HKT2<L, A>[F]) => URI2HKT2<L, Option<A>>[F]
-  liftF<F extends HKTS>(F: Functor<F>): <A>(fa: URI2HKT<A>[F]) => URI2HKT<Option<A>>[F]
+  liftF<F extends HKT2S>(F: Functor<F>): <L, A>(fa: HKT2As<F, L, A>) => HKT2As<F, L, Option<A>>
+  liftF<F extends HKTS>(F: Functor<F>): <A>(fa: HKTAs<F, A>) => HKTAs<F, Option<A>>
   liftF<F>(F: Functor<F>): <A>(fa: HKT<F, A>) => HKT<F, Option<A>>
   liftF<F>(F: Functor<F>): <A>(fa: HKT<F, A>) => HKT<F, Option<A>> {
     return fa => F.map(a => option.some(a), fa)
@@ -63,17 +63,17 @@ export class Ops {
 
   fold<F extends HKT2S>(
     F: Functor<F>
-  ): <L, R, A>(none: Lazy<R>, some: (a: A) => R, fa: URI2HKT2<L, Option<A>>[F]) => URI2HKT2<L, R>[F]
+  ): <L, R, A>(none: Lazy<R>, some: (a: A) => R, fa: HKT2As<F, L, Option<A>>) => HKT2As<F, L, R>
   fold<F extends HKTS>(
     F: Functor<F>
-  ): <R, A>(none: Lazy<R>, some: (a: A) => R, fa: URI2HKT<Option<A>>[F]) => URI2HKT<R>[F]
+  ): <R, A>(none: Lazy<R>, some: (a: A) => R, fa: HKTAs<F, Option<A>>) => HKTAs<F, R>
   fold<F>(F: Functor<F>): <R, A>(none: Lazy<R>, some: (a: A) => R, fa: HKT<F, Option<A>>) => HKT<F, R>
   fold<F>(F: Functor<F>): <R, A>(none: Lazy<R>, some: (a: A) => R, fa: HKT<F, Option<A>>) => HKT<F, R> {
     return (none, some, fa) => F.map(o => o.fold(none, some), fa)
   }
 
-  getOrElse<F extends HKT2S>(F: Functor<F>): <L, A>(f: Lazy<A>, fa: URI2HKT2<L, Option<A>>[F]) => URI2HKT2<L, A>[F]
-  getOrElse<F extends HKTS>(F: Functor<F>): <A>(f: Lazy<A>, fa: URI2HKT<Option<A>>[F]) => URI2HKT<A>[F]
+  getOrElse<F extends HKT2S>(F: Functor<F>): <L, A>(f: Lazy<A>, fa: HKT2As<F, L, Option<A>>) => HKT2As<F, L, A>
+  getOrElse<F extends HKTS>(F: Functor<F>): <A>(f: Lazy<A>, fa: HKTAs<F, Option<A>>) => HKTAs<F, A>
   getOrElse<F>(F: Functor<F>): <A>(f: Lazy<A>, fa: HKT<F, Option<A>>) => HKT<F, A>
   getOrElse<F>(F: Functor<F>): <A>(f: Lazy<A>, fa: HKT<F, Option<A>>) => HKT<F, A> {
     return (f, fa) => F.map(o => o.getOrElse(f), fa)

--- a/src/OptionT.ts
+++ b/src/OptionT.ts
@@ -64,9 +64,7 @@ export class Ops {
   fold<F extends HKT2S>(
     F: Functor<F>
   ): <L, R, A>(none: Lazy<R>, some: (a: A) => R, fa: HKT2As<F, L, Option<A>>) => HKT2As<F, L, R>
-  fold<F extends HKTS>(
-    F: Functor<F>
-  ): <R, A>(none: Lazy<R>, some: (a: A) => R, fa: HKTAs<F, Option<A>>) => HKTAs<F, R>
+  fold<F extends HKTS>(F: Functor<F>): <R, A>(none: Lazy<R>, some: (a: A) => R, fa: HKTAs<F, Option<A>>) => HKTAs<F, R>
   fold<F>(F: Functor<F>): <R, A>(none: Lazy<R>, some: (a: A) => R, fa: HKT<F, Option<A>>) => HKT<F, R>
   fold<F>(F: Functor<F>): <R, A>(none: Lazy<R>, some: (a: A) => R, fa: HKT<F, Option<A>>) => HKT<F, R> {
     return (none, some, fa) => F.map(o => o.fold(none, some), fa)

--- a/src/ReaderT.ts
+++ b/src/ReaderT.ts
@@ -21,14 +21,8 @@ export interface ReaderT1<M extends HKTS> {
 export interface ReaderT2<M extends HKT2S> {
   map<L, E, A, B>(f: (a: A) => B, fa: (e: E) => HKT2As<M, L, A>): (e: E) => HKT2As<M, L, B>
   of<L, E, A>(a: A): (e: E) => HKT2As<M, L, A>
-  ap<L, E, A, B>(
-    fab: (e: E) => HKT2As<M, L, (a: A) => B>,
-    fa: (e: E) => HKT2As<M, L, A>
-  ): (e: E) => HKT2As<M, L, B>
-  chain<L, E, A, B>(
-    f: (a: A) => (e: E) => HKT2As<M, L, B>,
-    fa: (e: E) => HKT2As<M, L, A>
-  ): (e: E) => HKT2As<M, L, B>
+  ap<L, E, A, B>(fab: (e: E) => HKT2As<M, L, (a: A) => B>, fa: (e: E) => HKT2As<M, L, A>): (e: E) => HKT2As<M, L, B>
+  chain<L, E, A, B>(f: (a: A) => (e: E) => HKT2As<M, L, B>, fa: (e: E) => HKT2As<M, L, A>): (e: E) => HKT2As<M, L, B>
 }
 
 export class Ops {
@@ -50,10 +44,7 @@ export class Ops {
 
   ap<F extends HKT2S>(
     F: Applicative<F>
-  ): <L, E, A, B>(
-    fab: (e: E) => HKT2As<F, L, (a: A) => B>,
-    fa: (e: E) => HKT2As<F, L, A>
-  ) => (e: E) => HKT2As<F, L, B>
+  ): <L, E, A, B>(fab: (e: E) => HKT2As<F, L, (a: A) => B>, fa: (e: E) => HKT2As<F, L, A>) => (e: E) => HKT2As<F, L, B>
   ap<F extends HKTS>(
     F: Applicative<F>
   ): <E, A, B>(fab: (e: E) => HKTAs<F, (a: A) => B>, fa: (e: E) => HKTAs<F, A>) => (e: E) => HKTAs<F, B>
@@ -68,10 +59,7 @@ export class Ops {
 
   chain<F extends HKT2S>(
     F: Chain<F>
-  ): <L, E, A, B>(
-    f: (a: A) => (e: E) => HKT2As<F, L, B>,
-    fa: (e: E) => HKT2As<F, L, A>
-  ) => (e: E) => HKT2As<F, L, B>
+  ): <L, E, A, B>(f: (a: A) => (e: E) => HKT2As<F, L, B>, fa: (e: E) => HKT2As<F, L, A>) => (e: E) => HKT2As<F, L, B>
   chain<F extends HKTS>(
     F: Chain<F>
   ): <E, A, B>(f: (a: A) => (e: E) => HKTAs<F, B>, fa: (e: E) => HKTAs<F, A>) => (e: E) => HKTAs<F, B>

--- a/src/ReaderT.ts
+++ b/src/ReaderT.ts
@@ -1,4 +1,4 @@
-import { HKT, HKTS, HKT2S, URI2HKT, URI2HKT2 } from './HKT'
+import { HKT, HKTS, HKT2S, HKTAs, HKT2As } from './HKT'
 import { Functor } from './Functor'
 import { Applicative } from './Applicative'
 import { Chain } from './Chain'
@@ -12,37 +12,37 @@ export interface ReaderT<M> {
 }
 
 export interface ReaderT1<M extends HKTS> {
-  map<E, A, B>(f: (a: A) => B, fa: (e: E) => URI2HKT<A>[M]): (e: E) => URI2HKT<B>[M]
-  of<E, A>(a: A): (e: E) => URI2HKT<A>[M]
-  ap<E, A, B>(fab: (e: E) => URI2HKT<(a: A) => B>[M], fa: (e: E) => URI2HKT<A>[M]): (e: E) => URI2HKT<B>[M]
-  chain<E, A, B>(f: (a: A) => (e: E) => URI2HKT<B>[M], fa: (e: E) => URI2HKT<A>[M]): (e: E) => URI2HKT<B>[M]
+  map<E, A, B>(f: (a: A) => B, fa: (e: E) => HKTAs<M, A>): (e: E) => HKTAs<M, B>
+  of<E, A>(a: A): (e: E) => HKTAs<M, A>
+  ap<E, A, B>(fab: (e: E) => HKTAs<M, (a: A) => B>, fa: (e: E) => HKTAs<M, A>): (e: E) => HKTAs<M, B>
+  chain<E, A, B>(f: (a: A) => (e: E) => HKTAs<M, B>, fa: (e: E) => HKTAs<M, A>): (e: E) => HKTAs<M, B>
 }
 
 export interface ReaderT2<M extends HKT2S> {
-  map<L, E, A, B>(f: (a: A) => B, fa: (e: E) => URI2HKT2<L, A>[M]): (e: E) => URI2HKT2<L, B>[M]
-  of<L, E, A>(a: A): (e: E) => URI2HKT2<L, A>[M]
+  map<L, E, A, B>(f: (a: A) => B, fa: (e: E) => HKT2As<M, L, A>): (e: E) => HKT2As<M, L, B>
+  of<L, E, A>(a: A): (e: E) => HKT2As<M, L, A>
   ap<L, E, A, B>(
-    fab: (e: E) => URI2HKT2<L, (a: A) => B>[M],
-    fa: (e: E) => URI2HKT2<L, A>[M]
-  ): (e: E) => URI2HKT2<L, B>[M]
+    fab: (e: E) => HKT2As<M, L, (a: A) => B>,
+    fa: (e: E) => HKT2As<M, L, A>
+  ): (e: E) => HKT2As<M, L, B>
   chain<L, E, A, B>(
-    f: (a: A) => (e: E) => URI2HKT2<L, B>[M],
-    fa: (e: E) => URI2HKT2<L, A>[M]
-  ): (e: E) => URI2HKT2<L, B>[M]
+    f: (a: A) => (e: E) => HKT2As<M, L, B>,
+    fa: (e: E) => HKT2As<M, L, A>
+  ): (e: E) => HKT2As<M, L, B>
 }
 
 export class Ops {
   map<F extends HKT2S>(
     F: Functor<F>
-  ): <L, E, A, B>(f: (a: A) => B, fa: (e: E) => URI2HKT2<L, A>[F]) => (e: E) => URI2HKT2<L, B>[F]
-  map<F extends HKTS>(F: Functor<F>): <E, A, B>(f: (a: A) => B, fa: (e: E) => URI2HKT<A>[F]) => (e: E) => URI2HKT<B>[F]
+  ): <L, E, A, B>(f: (a: A) => B, fa: (e: E) => HKT2As<F, L, A>) => (e: E) => HKT2As<F, L, B>
+  map<F extends HKTS>(F: Functor<F>): <E, A, B>(f: (a: A) => B, fa: (e: E) => HKTAs<F, A>) => (e: E) => HKTAs<F, B>
   map<F>(F: Functor<F>): <E, A, B>(f: (a: A) => B, fa: (e: E) => HKT<F, A>) => (e: E) => HKT<F, B>
   map<F>(F: Functor<F>): <E, A, B>(f: (a: A) => B, fa: (e: E) => HKT<F, A>) => (e: E) => HKT<F, B> {
     return (f, fa) => e => F.map(f, fa(e))
   }
 
-  of<F extends HKT2S>(F: Applicative<F>): <L, E, A>(a: A) => (e: E) => URI2HKT2<L, A>[F]
-  of<F extends HKTS>(F: Applicative<F>): <E, A>(a: A) => (e: E) => URI2HKT<A>[F]
+  of<F extends HKT2S>(F: Applicative<F>): <L, E, A>(a: A) => (e: E) => HKT2As<F, L, A>
+  of<F extends HKTS>(F: Applicative<F>): <E, A>(a: A) => (e: E) => HKTAs<F, A>
   of<F>(F: Applicative<F>): <E, A>(a: A) => (e: E) => HKT<F, A>
   of<F>(F: Applicative<F>): <E, A>(a: A) => (e: E) => HKT<F, A> {
     return <A>(a: A) => <E>(e: E) => F.of(a)
@@ -51,12 +51,12 @@ export class Ops {
   ap<F extends HKT2S>(
     F: Applicative<F>
   ): <L, E, A, B>(
-    fab: (e: E) => URI2HKT2<L, (a: A) => B>[F],
-    fa: (e: E) => URI2HKT2<L, A>[F]
-  ) => (e: E) => URI2HKT2<L, B>[F]
+    fab: (e: E) => HKT2As<F, L, (a: A) => B>,
+    fa: (e: E) => HKT2As<F, L, A>
+  ) => (e: E) => HKT2As<F, L, B>
   ap<F extends HKTS>(
     F: Applicative<F>
-  ): <E, A, B>(fab: (e: E) => URI2HKT<(a: A) => B>[F], fa: (e: E) => URI2HKT<A>[F]) => (e: E) => URI2HKT<B>[F]
+  ): <E, A, B>(fab: (e: E) => HKTAs<F, (a: A) => B>, fa: (e: E) => HKTAs<F, A>) => (e: E) => HKTAs<F, B>
   ap<F>(
     F: Applicative<F>
   ): <E, A, B>(fab: (e: E) => HKT<F, (a: A) => B>, fa: (e: E) => HKT<F, A>) => (e: E) => HKT<F, B>
@@ -69,26 +69,26 @@ export class Ops {
   chain<F extends HKT2S>(
     F: Chain<F>
   ): <L, E, A, B>(
-    f: (a: A) => (e: E) => URI2HKT2<L, B>[F],
-    fa: (e: E) => URI2HKT2<L, A>[F]
-  ) => (e: E) => URI2HKT2<L, B>[F]
+    f: (a: A) => (e: E) => HKT2As<F, L, B>,
+    fa: (e: E) => HKT2As<F, L, A>
+  ) => (e: E) => HKT2As<F, L, B>
   chain<F extends HKTS>(
     F: Chain<F>
-  ): <E, A, B>(f: (a: A) => (e: E) => URI2HKT<B>[F], fa: (e: E) => URI2HKT<A>[F]) => (e: E) => URI2HKT<B>[F]
+  ): <E, A, B>(f: (a: A) => (e: E) => HKTAs<F, B>, fa: (e: E) => HKTAs<F, A>) => (e: E) => HKTAs<F, B>
   chain<F>(F: Chain<F>): <E, A, B>(f: (a: A) => (e: E) => HKT<F, B>, fa: (e: E) => HKT<F, A>) => (e: E) => HKT<F, B>
   chain<F>(F: Chain<F>): <E, A, B>(f: (a: A) => (e: E) => HKT<F, B>, fa: (e: E) => HKT<F, A>) => (e: E) => HKT<F, B> {
     return (f, fa) => e => F.chain(a => f(a)(e), fa(e))
   }
 
-  ask<F extends HKT2S>(F: Applicative<F>): <L, E>() => (e: E) => URI2HKT2<L, E>[F]
-  ask<F extends HKTS>(F: Applicative<F>): <E>() => (e: E) => URI2HKT<E>[F]
+  ask<F extends HKT2S>(F: Applicative<F>): <L, E>() => (e: E) => HKT2As<F, L, E>
+  ask<F extends HKTS>(F: Applicative<F>): <E>() => (e: E) => HKTAs<F, E>
   ask<F>(F: Applicative<F>): <E>() => (e: E) => HKT<F, E>
   ask<F>(F: Applicative<F>): <E>() => (e: E) => HKT<F, E> {
     return () => e => F.of(e)
   }
 
-  asks<F extends HKT2S>(F: Applicative<F>): <L, E, A>(f: (e: E) => A) => (e: E) => URI2HKT2<L, A>[F]
-  asks<F extends HKTS>(F: Applicative<F>): <E, A>(f: (e: E) => A) => (e: E) => URI2HKT<A>[F]
+  asks<F extends HKT2S>(F: Applicative<F>): <L, E, A>(f: (e: E) => A) => (e: E) => HKT2As<F, L, A>
+  asks<F extends HKTS>(F: Applicative<F>): <E, A>(f: (e: E) => A) => (e: E) => HKTAs<F, A>
   asks<F>(F: Applicative<F>): <E, A>(f: (e: E) => A) => (e: E) => HKT<F, A>
   asks<F>(F: Applicative<F>): <E, A>(f: (e: E) => A) => (e: E) => HKT<F, A> {
     return f => e => F.of(f(e))

--- a/src/StateT.ts
+++ b/src/StateT.ts
@@ -1,4 +1,4 @@
-import { HKT, HKTS, HKT2S, URI2HKT, URI2HKT2 } from './HKT'
+import { HKT, HKTS, HKT2S, HKTAs, HKT2As } from './HKT'
 import { Functor } from './Functor'
 import { Applicative } from './Applicative'
 import { Chain } from './Chain'
@@ -13,45 +13,45 @@ export interface StateT<M> {
 }
 
 export interface StateT1<M extends HKTS> {
-  map<S, A, B>(f: (a: A) => B, fa: (s: S) => URI2HKT<[A, S]>[M]): (s: S) => URI2HKT<[B, S]>[M]
-  of<S, A>(a: A): (s: S) => URI2HKT<[A, S]>[M]
+  map<S, A, B>(f: (a: A) => B, fa: (s: S) => HKTAs<M, [A, S]>): (s: S) => HKTAs<M, [B, S]>
+  of<S, A>(a: A): (s: S) => HKTAs<M, [A, S]>
   ap<S, A, B>(
-    fab: (s: S) => URI2HKT<[(a: A) => B, S]>[M],
-    fa: (s: S) => URI2HKT<[A, S]>[M]
-  ): (s: S) => URI2HKT<[B, S]>[M]
+    fab: (s: S) => HKTAs<M, [(a: A) => B, S]>,
+    fa: (s: S) => HKTAs<M, [A, S]>
+  ): (s: S) => HKTAs<M, [B, S]>
   chain<S, A, B>(
-    f: (a: A) => (s: S) => URI2HKT<[B, S]>[M],
-    fa: (s: S) => URI2HKT<[A, S]>[M]
-  ): (s: S) => URI2HKT<[B, S]>[M]
+    f: (a: A) => (s: S) => HKTAs<M, [B, S]>,
+    fa: (s: S) => HKTAs<M, [A, S]>
+  ): (s: S) => HKTAs<M, [B, S]>
 }
 
 export interface StateT2<M extends HKT2S> {
-  map<L, S, A, B>(f: (a: A) => B, fa: (s: S) => URI2HKT2<L, [A, S]>[M]): (s: S) => URI2HKT2<L, [B, S]>[M]
-  of<L, S, A>(a: A): (s: S) => URI2HKT2<L, [A, S]>[M]
+  map<L, S, A, B>(f: (a: A) => B, fa: (s: S) => HKT2As<M, L, [A, S]>): (s: S) => HKT2As<M, L, [B, S]>
+  of<L, S, A>(a: A): (s: S) => HKT2As<M, L, [A, S]>
   ap<L, S, A, B>(
-    fab: (s: S) => URI2HKT2<L, [(a: A) => B, S]>[M],
-    fa: (s: S) => URI2HKT2<L, [A, S]>[M]
-  ): (s: S) => URI2HKT2<L, [B, S]>[M]
+    fab: (s: S) => HKT2As<M, L, [(a: A) => B, S]>,
+    fa: (s: S) => HKT2As<M, L, [A, S]>
+  ): (s: S) => HKT2As<M, L, [B, S]>
   chain<L, S, A, B>(
-    f: (a: A) => (s: S) => URI2HKT2<L, [B, S]>[M],
-    fa: (s: S) => URI2HKT2<L, [A, S]>[M]
-  ): (s: S) => URI2HKT2<L, [B, S]>[M]
+    f: (a: A) => (s: S) => HKT2As<M, L, [B, S]>,
+    fa: (s: S) => HKT2As<M, L, [A, S]>
+  ): (s: S) => HKT2As<M, L, [B, S]>
 }
 
 export class Ops {
   map<F extends HKT2S>(
     F: Functor<F>
-  ): <L, S, A, B>(f: (a: A) => B, fa: (s: S) => URI2HKT2<L, [A, S]>[F]) => (s: S) => URI2HKT2<L, [B, S]>[F]
+  ): <L, S, A, B>(f: (a: A) => B, fa: (s: S) => HKT2As<F, L, [A, S]>) => (s: S) => HKT2As<F, L, [B, S]>
   map<F extends HKTS>(
     F: Functor<F>
-  ): <S, A, B>(f: (a: A) => B, fa: (s: S) => URI2HKT<[A, S]>[F]) => (s: S) => URI2HKT<[B, S]>[F]
+  ): <S, A, B>(f: (a: A) => B, fa: (s: S) => HKTAs<F, [A, S]>) => (s: S) => HKTAs<F, [B, S]>
   map<F>(F: Functor<F>): <S, A, B>(f: (a: A) => B, fa: (s: S) => HKT<F, [A, S]>) => (s: S) => HKT<F, [B, S]>
   map<F>(F: Functor<F>): <S, A, B>(f: (a: A) => B, fa: (s: S) => HKT<F, [A, S]>) => (s: S) => HKT<F, [B, S]> {
     return (f, fa) => s => F.map(([a, s1]) => tuple(f(a), s1), fa(s))
   }
 
-  of<F extends HKT2S>(F: Applicative<F>): <L, S, A>(a: A) => (s: S) => URI2HKT2<L, [A, S]>[F]
-  of<F extends HKTS>(F: Applicative<F>): <S, A>(a: A) => (s: S) => URI2HKT<[A, S]>[F]
+  of<F extends HKT2S>(F: Applicative<F>): <L, S, A>(a: A) => (s: S) => HKT2As<F, L, [A, S]>
+  of<F extends HKTS>(F: Applicative<F>): <S, A>(a: A) => (s: S) => HKTAs<F, [A, S]>
   of<F>(F: Applicative<F>): <S, A>(a: A) => (s: S) => HKT<F, [A, S]>
   of<F>(F: Applicative<F>): <S, A>(a: A) => (s: S) => HKT<F, [A, S]> {
     return a => s => F.of(tuple(a, s))
@@ -60,15 +60,15 @@ export class Ops {
   ap<F extends HKT2S>(
     F: Chain<F>
   ): <L, S, A, B>(
-    fab: (s: S) => URI2HKT2<L, [(a: A) => B, S]>[F],
-    fa: (s: S) => URI2HKT2<L, [A, S]>[F]
-  ) => (s: S) => URI2HKT2<L, [B, S]>[F]
+    fab: (s: S) => HKT2As<F, L, [(a: A) => B, S]>,
+    fa: (s: S) => HKT2As<F, L, [A, S]>
+  ) => (s: S) => HKT2As<F, L, [B, S]>
   ap<F extends HKTS>(
     F: Chain<F>
   ): <S, A, B>(
-    fab: (s: S) => URI2HKT<[(a: A) => B, S]>[F],
-    fa: (s: S) => URI2HKT<[A, S]>[F]
-  ) => (s: S) => URI2HKT<[B, S]>[F]
+    fab: (s: S) => HKTAs<F, [(a: A) => B, S]>,
+    fa: (s: S) => HKTAs<F, [A, S]>
+  ) => (s: S) => HKTAs<F, [B, S]>
   ap<F>(
     F: Chain<F>
   ): <S, A, B>(fab: (s: S) => HKT<F, [(a: A) => B, S]>, fa: (s: S) => HKT<F, [A, S]>) => (s: S) => HKT<F, [B, S]>
@@ -81,15 +81,15 @@ export class Ops {
   chain<F extends HKT2S>(
     F: Chain<F>
   ): <L, S, A, B>(
-    f: (a: A) => (s: S) => URI2HKT2<L, [B, S]>[F],
-    fa: (s: S) => URI2HKT2<L, [A, S]>[F]
-  ) => (s: S) => URI2HKT2<L, [B, S]>[F]
+    f: (a: A) => (s: S) => HKT2As<F, L, [B, S]>,
+    fa: (s: S) => HKT2As<F, L, [A, S]>
+  ) => (s: S) => HKT2As<F, L, [B, S]>
   chain<F extends HKTS>(
     F: Chain<F>
   ): <S, A, B>(
-    f: (a: A) => (s: S) => URI2HKT<[B, S]>[F],
-    fa: (s: S) => URI2HKT<[A, S]>[F]
-  ) => (s: S) => URI2HKT<[B, S]>[F]
+    f: (a: A) => (s: S) => HKTAs<F, [B, S]>,
+    fa: (s: S) => HKTAs<F, [A, S]>
+  ) => (s: S) => HKTAs<F, [B, S]>
   chain<F>(
     F: Chain<F>
   ): <S, A, B>(f: (a: A) => (s: S) => HKT<F, [B, S]>, fa: (s: S) => HKT<F, [A, S]>) => (s: S) => HKT<F, [B, S]>
@@ -99,29 +99,29 @@ export class Ops {
     return (f, fa) => s => F.chain(([a, s1]) => f(a)(s1), fa(s))
   }
 
-  get<F extends HKT2S>(F: Applicative<F>): <L, S>() => (s: S) => URI2HKT2<L, [S, S]>[F]
-  get<F extends HKTS>(F: Applicative<F>): <S>() => (s: S) => URI2HKT<[S, S]>[F]
+  get<F extends HKT2S>(F: Applicative<F>): <L, S>() => (s: S) => HKT2As<F, L, [S, S]>
+  get<F extends HKTS>(F: Applicative<F>): <S>() => (s: S) => HKTAs<F, [S, S]>
   get<F>(F: Applicative<F>): <S>() => (s: S) => HKT<F, [S, S]>
   get<F>(F: Applicative<F>): <S>() => (s: S) => HKT<F, [S, S]> {
     return () => s => F.of(tuple(s, s))
   }
 
-  put<F extends HKT2S>(F: Applicative<F>): <L, S>(s: S) => (s: S) => URI2HKT2<L, [void, S]>[F]
-  put<F extends HKTS>(F: Applicative<F>): <S>(s: S) => (s: S) => URI2HKT<[void, S]>[F]
+  put<F extends HKT2S>(F: Applicative<F>): <L, S>(s: S) => (s: S) => HKT2As<F, L, [void, S]>
+  put<F extends HKTS>(F: Applicative<F>): <S>(s: S) => (s: S) => HKTAs<F, [void, S]>
   put<F>(F: Applicative<F>): <S>(s: S) => (s: S) => HKT<F, [void, S]>
   put<F>(F: Applicative<F>): <S>(s: S) => (s: S) => HKT<F, [void, S]> {
     return s => () => F.of(tuple(undefined, s))
   }
 
-  modify<F extends HKT2S>(F: Applicative<F>): <L, S>(f: Endomorphism<S>) => (s: S) => URI2HKT2<L, [void, S]>[F]
-  modify<F extends HKTS>(F: Applicative<F>): <S>(f: Endomorphism<S>) => (s: S) => URI2HKT<[void, S]>[F]
+  modify<F extends HKT2S>(F: Applicative<F>): <L, S>(f: Endomorphism<S>) => (s: S) => HKT2As<F, L, [void, S]>
+  modify<F extends HKTS>(F: Applicative<F>): <S>(f: Endomorphism<S>) => (s: S) => HKTAs<F, [void, S]>
   modify<F>(F: Applicative<F>): <S>(f: Endomorphism<S>) => (s: S) => HKT<F, [void, S]>
   modify<F>(F: Applicative<F>): <S>(f: Endomorphism<S>) => (s: S) => HKT<F, [void, S]> {
     return f => s => F.of(tuple(undefined, f(s)))
   }
 
-  gets<F extends HKT2S>(F: Applicative<F>): <L, S, A>(f: (s: S) => A) => (s: S) => URI2HKT2<L, [A, S]>[F]
-  gets<F extends HKTS>(F: Applicative<F>): <S, A>(f: (s: S) => A) => (s: S) => URI2HKT<[A, S]>[F]
+  gets<F extends HKT2S>(F: Applicative<F>): <L, S, A>(f: (s: S) => A) => (s: S) => HKT2As<F, L, [A, S]>
+  gets<F extends HKTS>(F: Applicative<F>): <S, A>(f: (s: S) => A) => (s: S) => HKTAs<F, [A, S]>
   gets<F>(F: Applicative<F>): <S, A>(f: (s: S) => A) => (s: S) => HKT<F, [A, S]>
   gets<F>(F: Applicative<F>): <S, A>(f: (s: S) => A) => (s: S) => HKT<F, [A, S]> {
     return f => s => F.of(tuple(f(s), s))

--- a/src/StateT.ts
+++ b/src/StateT.ts
@@ -15,14 +15,8 @@ export interface StateT<M> {
 export interface StateT1<M extends HKTS> {
   map<S, A, B>(f: (a: A) => B, fa: (s: S) => HKTAs<M, [A, S]>): (s: S) => HKTAs<M, [B, S]>
   of<S, A>(a: A): (s: S) => HKTAs<M, [A, S]>
-  ap<S, A, B>(
-    fab: (s: S) => HKTAs<M, [(a: A) => B, S]>,
-    fa: (s: S) => HKTAs<M, [A, S]>
-  ): (s: S) => HKTAs<M, [B, S]>
-  chain<S, A, B>(
-    f: (a: A) => (s: S) => HKTAs<M, [B, S]>,
-    fa: (s: S) => HKTAs<M, [A, S]>
-  ): (s: S) => HKTAs<M, [B, S]>
+  ap<S, A, B>(fab: (s: S) => HKTAs<M, [(a: A) => B, S]>, fa: (s: S) => HKTAs<M, [A, S]>): (s: S) => HKTAs<M, [B, S]>
+  chain<S, A, B>(f: (a: A) => (s: S) => HKTAs<M, [B, S]>, fa: (s: S) => HKTAs<M, [A, S]>): (s: S) => HKTAs<M, [B, S]>
 }
 
 export interface StateT2<M extends HKT2S> {
@@ -65,10 +59,7 @@ export class Ops {
   ) => (s: S) => HKT2As<F, L, [B, S]>
   ap<F extends HKTS>(
     F: Chain<F>
-  ): <S, A, B>(
-    fab: (s: S) => HKTAs<F, [(a: A) => B, S]>,
-    fa: (s: S) => HKTAs<F, [A, S]>
-  ) => (s: S) => HKTAs<F, [B, S]>
+  ): <S, A, B>(fab: (s: S) => HKTAs<F, [(a: A) => B, S]>, fa: (s: S) => HKTAs<F, [A, S]>) => (s: S) => HKTAs<F, [B, S]>
   ap<F>(
     F: Chain<F>
   ): <S, A, B>(fab: (s: S) => HKT<F, [(a: A) => B, S]>, fa: (s: S) => HKT<F, [A, S]>) => (s: S) => HKT<F, [B, S]>
@@ -86,10 +77,7 @@ export class Ops {
   ) => (s: S) => HKT2As<F, L, [B, S]>
   chain<F extends HKTS>(
     F: Chain<F>
-  ): <S, A, B>(
-    f: (a: A) => (s: S) => HKTAs<F, [B, S]>,
-    fa: (s: S) => HKTAs<F, [A, S]>
-  ) => (s: S) => HKTAs<F, [B, S]>
+  ): <S, A, B>(f: (a: A) => (s: S) => HKTAs<F, [B, S]>, fa: (s: S) => HKTAs<F, [A, S]>) => (s: S) => HKTAs<F, [B, S]>
   chain<F>(
     F: Chain<F>
   ): <S, A, B>(f: (a: A) => (s: S) => HKT<F, [B, S]>, fa: (s: S) => HKT<F, [A, S]>) => (s: S) => HKT<F, [B, S]>

--- a/src/StrMap.ts
+++ b/src/StrMap.ts
@@ -46,9 +46,7 @@ export class StrMap<A> implements FantasyFunctor<URI, A>, FantasyFoldable<A>, Fa
   traverseWithKey<F extends HKT2S>(
     F: Applicative<F>
   ): <L, B>(f: (k: string, a: A) => HKT2As<F, L, B>) => HKT2As<F, L, StrMap<B>>
-  traverseWithKey<F extends HKTS>(
-    F: Applicative<F>
-  ): <B>(f: (k: string, a: A) => HKTAs<F, B>) => HKTAs<F, StrMap<B>>
+  traverseWithKey<F extends HKTS>(F: Applicative<F>): <B>(f: (k: string, a: A) => HKTAs<F, B>) => HKTAs<F, StrMap<B>>
   traverseWithKey<F>(F: Applicative<F>): <B>(f: (k: string, a: A) => HKT<F, B>) => HKT<F, StrMap<B>>
   traverseWithKey<F>(F: Applicative<F>): <B>(f: (k: string, a: A) => HKT<F, B>) => HKT<F, StrMap<B>> {
     const concatA2 = liftA2(F, curriedConcat)
@@ -99,9 +97,7 @@ export class Ops {
   traverse<F extends HKT2S>(
     F: Applicative<F>
   ): <L, A, B>(f: (a: A) => HKT2As<F, L, B>, ta: StrMap<A>) => HKT2As<F, L, StrMap<B>>
-  traverse<F extends HKTS>(
-    F: Applicative<F>
-  ): <A, B>(f: (a: A) => HKTAs<F, B>, ta: StrMap<A>) => HKTAs<F, StrMap<B>>
+  traverse<F extends HKTS>(F: Applicative<F>): <A, B>(f: (a: A) => HKTAs<F, B>, ta: StrMap<A>) => HKTAs<F, StrMap<B>>
   traverse<F>(F: Applicative<F>): <A, B>(f: (a: A) => HKT<F, B>, ta: StrMap<A>) => HKT<F, StrMap<B>>
   traverse<F>(F: Applicative<F>): <A, B>(f: (a: A) => HKT<F, B>, ta: StrMap<A>) => HKT<F, StrMap<B>> {
     return (f, ta) => ta.traverse(F)(f)

--- a/src/StrMap.ts
+++ b/src/StrMap.ts
@@ -1,4 +1,4 @@
-import { HKT, HKTS, HKT2S, URI2HKT, URI2HKT2 } from './HKT'
+import { HKT, HKTS, HKT2S, HKTAs, HKT2As } from './HKT'
 import { Monoid } from './Monoid'
 import { Functor, FantasyFunctor } from './Functor'
 import { Applicative } from './Applicative'
@@ -45,10 +45,10 @@ export class StrMap<A> implements FantasyFunctor<URI, A>, FantasyFoldable<A>, Fa
   }
   traverseWithKey<F extends HKT2S>(
     F: Applicative<F>
-  ): <L, B>(f: (k: string, a: A) => URI2HKT2<L, B>[F]) => URI2HKT2<L, StrMap<B>>[F]
+  ): <L, B>(f: (k: string, a: A) => HKT2As<F, L, B>) => HKT2As<F, L, StrMap<B>>
   traverseWithKey<F extends HKTS>(
     F: Applicative<F>
-  ): <B>(f: (k: string, a: A) => URI2HKT<B>[F]) => URI2HKT<StrMap<B>>[F]
+  ): <B>(f: (k: string, a: A) => HKTAs<F, B>) => HKTAs<F, StrMap<B>>
   traverseWithKey<F>(F: Applicative<F>): <B>(f: (k: string, a: A) => HKT<F, B>) => HKT<F, StrMap<B>>
   traverseWithKey<F>(F: Applicative<F>): <B>(f: (k: string, a: A) => HKT<F, B>) => HKT<F, StrMap<B>> {
     const concatA2 = liftA2(F, curriedConcat)
@@ -60,8 +60,8 @@ export class StrMap<A> implements FantasyFunctor<URI, A>, FantasyFoldable<A>, Fa
       return out
     }
   }
-  traverse<F extends HKT2S>(F: Applicative<F>): <L, B>(f: (a: A) => URI2HKT2<L, B>[F]) => URI2HKT2<L, StrMap<B>>[F]
-  traverse<F extends HKTS>(F: Applicative<F>): <B>(f: (a: A) => URI2HKT<B>[F]) => URI2HKT<StrMap<B>>[F]
+  traverse<F extends HKT2S>(F: Applicative<F>): <L, B>(f: (a: A) => HKT2As<F, L, B>) => HKT2As<F, L, StrMap<B>>
+  traverse<F extends HKTS>(F: Applicative<F>): <B>(f: (a: A) => HKTAs<F, B>) => HKTAs<F, StrMap<B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, StrMap<B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, StrMap<B>> {
     return f => this.traverseWithKey(F)((_, a) => f(a))
@@ -87,10 +87,10 @@ export const curriedConcat: <A>(x: StrMap<A>) => (y: StrMap<A>) => StrMap<A> = c
 export class Ops {
   traverseWithKey<F extends HKT2S>(
     F: Applicative<F>
-  ): <L, A, B>(f: (k: string, a: A) => URI2HKT2<L, B>[F], ta: StrMap<A>) => URI2HKT2<L, StrMap<B>>[F]
+  ): <L, A, B>(f: (k: string, a: A) => HKT2As<F, L, B>, ta: StrMap<A>) => HKT2As<F, L, StrMap<B>>
   traverseWithKey<F extends HKTS>(
     F: Applicative<F>
-  ): <A, B>(f: (k: string, a: A) => URI2HKT<B>[F], ta: StrMap<A>) => URI2HKT<StrMap<B>>[F]
+  ): <A, B>(f: (k: string, a: A) => HKTAs<F, B>, ta: StrMap<A>) => HKTAs<F, StrMap<B>>
   traverseWithKey<F>(F: Applicative<F>): <A, B>(f: (k: string, a: A) => HKT<F, B>, ta: StrMap<A>) => HKT<F, StrMap<B>>
   traverseWithKey<F>(F: Applicative<F>): <A, B>(f: (k: string, a: A) => HKT<F, B>, ta: StrMap<A>) => HKT<F, StrMap<B>> {
     return (f, ta) => ta.traverseWithKey(F)(f)
@@ -98,10 +98,10 @@ export class Ops {
 
   traverse<F extends HKT2S>(
     F: Applicative<F>
-  ): <L, A, B>(f: (a: A) => URI2HKT2<L, B>[F], ta: StrMap<A>) => URI2HKT2<L, StrMap<B>>[F]
+  ): <L, A, B>(f: (a: A) => HKT2As<F, L, B>, ta: StrMap<A>) => HKT2As<F, L, StrMap<B>>
   traverse<F extends HKTS>(
     F: Applicative<F>
-  ): <A, B>(f: (a: A) => URI2HKT<B>[F], ta: StrMap<A>) => URI2HKT<StrMap<B>>[F]
+  ): <A, B>(f: (a: A) => HKTAs<F, B>, ta: StrMap<A>) => HKTAs<F, StrMap<B>>
   traverse<F>(F: Applicative<F>): <A, B>(f: (a: A) => HKT<F, B>, ta: StrMap<A>) => HKT<F, StrMap<B>>
   traverse<F>(F: Applicative<F>): <A, B>(f: (a: A) => HKT<F, B>, ta: StrMap<A>) => HKT<F, StrMap<B>> {
     return (f, ta) => ta.traverse(F)(f)

--- a/src/These.ts
+++ b/src/These.ts
@@ -1,4 +1,4 @@
-import { HKT, HKTS, HKT2S, URI2HKT, URI2HKT2 } from './HKT'
+import { HKT, HKTS, HKT2S, HKTAs, HKT2As } from './HKT'
 import { Applicative } from './Applicative'
 import { Functor, FantasyFunctor } from './Functor'
 import { Bifunctor, FantasyBifunctor } from './Bifunctor'
@@ -47,8 +47,8 @@ export class This<L, A>
   reduce<B>(f: (b: B, a: A) => B, b: B): B {
     return b
   }
-  traverse<F extends HKT2S>(F: Applicative<F>): <M, B>(f: (a: A) => URI2HKT2<M, B>[F]) => URI2HKT2<M, These<L, B>>[F]
-  traverse<F extends HKTS>(F: Applicative<F>): <B>(f: (a: A) => URI2HKT<B>[F]) => URI2HKT<These<L, B>>[F]
+  traverse<F extends HKT2S>(F: Applicative<F>): <M, B>(f: (a: A) => HKT2As<F, M, B>) => HKT2As<F, M, These<L, B>>
+  traverse<F extends HKTS>(F: Applicative<F>): <B>(f: (a: A) => HKTAs<F, B>) => HKTAs<F, These<L, B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, These<L, B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, These<L, B>> {
     return f => F.of(this as any)
@@ -97,8 +97,8 @@ export class That<L, A>
   reduce<B>(f: (b: B, a: A) => B, b: B): B {
     return f(b, this.value)
   }
-  traverse<F extends HKT2S>(F: Applicative<F>): <M, B>(f: (a: A) => URI2HKT2<M, B>[F]) => URI2HKT2<M, These<L, B>>[F]
-  traverse<F extends HKTS>(F: Applicative<F>): <B>(f: (a: A) => URI2HKT<B>[F]) => URI2HKT<These<L, B>>[F]
+  traverse<F extends HKT2S>(F: Applicative<F>): <M, B>(f: (a: A) => HKT2As<F, M, B>) => HKT2As<F, M, These<L, B>>
+  traverse<F extends HKTS>(F: Applicative<F>): <B>(f: (a: A) => HKTAs<F, B>) => HKTAs<F, These<L, B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, These<L, B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, These<L, B>> {
     return f => F.map(b => that(b), f(this.value))
@@ -151,8 +151,8 @@ export class Both<L, A>
   reduce<B>(f: (b: B, a: A) => B, b: B): B {
     return f(b, this.a)
   }
-  traverse<F extends HKT2S>(F: Applicative<F>): <M, B>(f: (a: A) => URI2HKT2<M, B>[F]) => URI2HKT2<M, These<L, B>>[F]
-  traverse<F extends HKTS>(F: Applicative<F>): <B>(f: (a: A) => URI2HKT<B>[F]) => URI2HKT<These<L, B>>[F]
+  traverse<F extends HKT2S>(F: Applicative<F>): <M, B>(f: (a: A) => HKT2As<F, M, B>) => HKT2As<F, M, These<L, B>>
+  traverse<F extends HKTS>(F: Applicative<F>): <B>(f: (a: A) => HKTAs<F, B>) => HKTAs<F, These<L, B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, These<L, B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, These<L, B>> {
     return f => F.map(b => both(this.l, b), f(this.a))
@@ -229,10 +229,10 @@ export function reduce<L, A, B>(f: (b: B, a: A) => B, b: B, fa: These<L, A>): B 
 export class Ops {
   traverse<F extends HKT2S>(
     F: Applicative<F>
-  ): <M, L, A, B>(f: (a: A) => URI2HKT2<M, B>[F], ta: These<L, A>) => URI2HKT2<M, These<L, B>>[F]
+  ): <M, L, A, B>(f: (a: A) => HKT2As<F, M, B>, ta: These<L, A>) => HKT2As<F, M, These<L, B>>
   traverse<F extends HKTS>(
     F: Applicative<F>
-  ): <L, A, B>(f: (a: A) => URI2HKT<B>[F], ta: These<L, A>) => URI2HKT<These<L, B>>[F]
+  ): <L, A, B>(f: (a: A) => HKTAs<F, B>, ta: These<L, A>) => HKTAs<F, These<L, B>>
   traverse<F>(F: Applicative<F>): <L, A, B>(f: (a: A) => HKT<F, B>, ta: These<L, A>) => HKT<F, These<L, B>>
   traverse<F>(F: Applicative<F>): <L, A, B>(f: (a: A) => HKT<F, B>, ta: These<L, A>) => HKT<F, These<L, B>> {
     return <L, A, B>(f: (a: A) => HKT<F, B>, ta: These<L, A>) => ta.traverse(F)(f)

--- a/src/Traversable.ts
+++ b/src/Traversable.ts
@@ -1,4 +1,4 @@
-import { HKT, HKTS, HKT2S, URI2HKT, URI2HKT2 } from './HKT'
+import { HKT, HKTS, HKT2S, HKTAs, HKT2As } from './HKT'
 import { Functor, FantasyFunctor, FunctorComposition, getFunctorComposition } from './Functor'
 import { Foldable, FantasyFoldable, FoldableComposition, getFoldableComposition } from './Foldable'
 import { Applicative } from './Applicative'
@@ -21,21 +21,21 @@ export interface TraversableComposition11<F extends HKTS, G extends HKTS>
     FunctorComposition<F, G> {
   traverse<H extends HKTS>(
     H: Applicative<H>
-  ): <A, B>(f: (a: A) => HKT<H, B>, fga: URI2HKT<URI2HKT<A>[G]>[F]) => URI2HKT<URI2HKT<URI2HKT<B>[G]>[F]>[H]
+  ): <A, B>(f: (a: A) => HKT<H, B>, fga: HKTAs<F, HKTAs<G, A>>) => HKTAs<H, HKTAs<F, HKTAs<G, B>>>
   traverse<H>(
     H: Applicative<H>
-  ): <A, B>(f: (a: A) => HKT<H, B>, fga: URI2HKT<URI2HKT<A>[G]>[F]) => HKT<H, URI2HKT<URI2HKT<B>[G]>[F]>
+  ): <A, B>(f: (a: A) => HKT<H, B>, fga: HKTAs<F, HKTAs<G, A>>) => HKT<H, HKTAs<F, HKTAs<G, B>>>
 }
 
 export class Ops {
   sequence<F extends HKT2S, T extends HKTS>(
     F: Applicative<F>,
     T: Traversable<T>
-  ): <L, A>(tfa: URI2HKT<URI2HKT2<L, A>[F]>[T]) => URI2HKT2<L, URI2HKT<A>[T]>[F]
+  ): <L, A>(tfa: HKTAs<T, HKT2As<F, L, A>>) => HKT2As<F, L, HKTAs<T, A>>
   sequence<F extends HKTS, T extends HKTS>(
     F: Applicative<F>,
     T: Traversable<T>
-  ): <A>(tfa: URI2HKT<URI2HKT<A>[F]>[T]) => URI2HKT<URI2HKT<A>[T]>[F]
+  ): <A>(tfa: HKTAs<T, HKTAs<F, A>>) => HKTAs<F, HKTAs<T, A>>
   sequence<F, T>(F: Applicative<F>, T: Traversable<T>): <A>(tfa: HKT<T, HKT<F, A>>) => HKT<F, HKT<T, A>>
   sequence<F, T>(F: Applicative<F>, T: Traversable<T>): <A>(tfa: HKT<T, HKT<F, A>>) => HKT<F, HKT<T, A>> {
     return tfa => T.traverse(F)(fa => fa, tfa)

--- a/src/Validation.ts
+++ b/src/Validation.ts
@@ -1,4 +1,4 @@
-import { HKT, HKTS, HKT2S, URI2HKT, URI2HKT2 } from './HKT'
+import { HKT, HKTS, HKT2S, HKTAs, HKT2As } from './HKT'
 import { Functor } from './Functor'
 import { Applicative } from './Applicative'
 import { Semigroup } from './Semigroup'
@@ -58,8 +58,8 @@ export class Failure<L, A>
   }
   traverse<F extends HKT2S>(
     F: Applicative<F>
-  ): <M, B>(f: (a: A) => URI2HKT2<M, B>[F]) => URI2HKT2<M, Validation<L, B>>[F]
-  traverse<F extends HKTS>(F: Applicative<F>): <B>(f: (a: A) => URI2HKT<B>[F]) => URI2HKT<Validation<L, B>>[F]
+  ): <M, B>(f: (a: A) => HKT2As<F, M, B>) => HKT2As<F, M, Validation<L, B>>
+  traverse<F extends HKTS>(F: Applicative<F>): <B>(f: (a: A) => HKTAs<F, B>) => HKTAs<F, Validation<L, B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, Validation<L, B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, Validation<L, B>> {
     return f => F.of(this as any)
@@ -131,8 +131,8 @@ export class Success<L, A>
   }
   traverse<F extends HKT2S>(
     F: Applicative<F>
-  ): <M, B>(f: (a: A) => URI2HKT2<M, B>[F]) => URI2HKT2<M, Validation<L, B>>[F]
-  traverse<F extends HKTS>(F: Applicative<F>): <B>(f: (a: A) => URI2HKT<B>[F]) => URI2HKT<Validation<L, B>>[F]
+  ): <M, B>(f: (a: A) => HKT2As<F, M, B>) => HKT2As<F, M, Validation<L, B>>
+  traverse<F extends HKTS>(F: Applicative<F>): <B>(f: (a: A) => HKTAs<F, B>) => HKTAs<F, Validation<L, B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, Validation<L, B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, Validation<L, B>> {
     return f => F.map(b => of(b), f(this.value))
@@ -216,10 +216,10 @@ export function reduce<L, A, B>(f: (b: B, a: A) => B, b: B, fa: Validation<L, A>
 export class Ops {
   traverse<F extends HKT2S>(
     F: Applicative<F>
-  ): <M, L, A, B>(f: (a: A) => URI2HKT2<M, B>[F], ta: Validation<L, A>) => URI2HKT2<M, Validation<L, B>>[F]
+  ): <M, L, A, B>(f: (a: A) => HKT2As<F, M, B>, ta: Validation<L, A>) => HKT2As<F, M, Validation<L, B>>
   traverse<F extends HKTS>(
     F: Applicative<F>
-  ): <L, A, B>(f: (a: A) => URI2HKT<B>[F], ta: Validation<L, A>) => URI2HKT<Validation<L, B>>[F]
+  ): <L, A, B>(f: (a: A) => HKTAs<F, B>, ta: Validation<L, A>) => HKTAs<F, Validation<L, B>>
   traverse<F>(F: Applicative<F>): <L, A, B>(f: (a: A) => HKT<F, B>, ta: Validation<L, A>) => HKT<F, Validation<L, B>>
   traverse<F>(F: Applicative<F>): <L, A, B>(f: (a: A) => HKT<F, B>, ta: Validation<L, A>) => HKT<F, Validation<L, B>> {
     return (f, ta) => ta.traverse(F)(f)

--- a/src/Validation.ts
+++ b/src/Validation.ts
@@ -56,9 +56,7 @@ export class Failure<L, A>
   reduce<B>(f: (b: B, a: A) => B, b: B): B {
     return b
   }
-  traverse<F extends HKT2S>(
-    F: Applicative<F>
-  ): <M, B>(f: (a: A) => HKT2As<F, M, B>) => HKT2As<F, M, Validation<L, B>>
+  traverse<F extends HKT2S>(F: Applicative<F>): <M, B>(f: (a: A) => HKT2As<F, M, B>) => HKT2As<F, M, Validation<L, B>>
   traverse<F extends HKTS>(F: Applicative<F>): <B>(f: (a: A) => HKTAs<F, B>) => HKTAs<F, Validation<L, B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, Validation<L, B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, Validation<L, B>> {
@@ -129,9 +127,7 @@ export class Success<L, A>
   reduce<B>(f: (b: B, a: A) => B, b: B): B {
     return f(b, this.value)
   }
-  traverse<F extends HKT2S>(
-    F: Applicative<F>
-  ): <M, B>(f: (a: A) => HKT2As<F, M, B>) => HKT2As<F, M, Validation<L, B>>
+  traverse<F extends HKT2S>(F: Applicative<F>): <M, B>(f: (a: A) => HKT2As<F, M, B>) => HKT2As<F, M, Validation<L, B>>
   traverse<F extends HKTS>(F: Applicative<F>): <B>(f: (a: A) => HKTAs<F, B>) => HKTAs<F, Validation<L, B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, Validation<L, B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, Validation<L, B>> {

--- a/src/Witherable.ts
+++ b/src/Witherable.ts
@@ -1,4 +1,4 @@
-import { HKT, HKTS, URI2HKT } from './HKT'
+import { HKT, HKTS, HKTAs } from './HKT'
 import { Traversable } from './Traversable'
 import { Filterable } from './Filterable'
 import { Applicative } from './Applicative'
@@ -11,8 +11,8 @@ export type Wilt<T, L, R> = {
 }
 
 export type Wilt1<T extends HKTS, L, R> = {
-  left: URI2HKT<L>[T]
-  right: URI2HKT<R>[T]
+  left: HKTAs<T, L>
+  right: HKTAs<T, R>
 }
 
 export interface Witherable<T> extends Traversable<T>, Filterable<T> {
@@ -24,7 +24,7 @@ export class Ops {
   wither<F extends HKTS, T extends HKTS>(
     F: Applicative<F>,
     T: Witherable<T>
-  ): <A, B>(f: (a: A) => HKT<F, Option<B>>, ta: HKT<T, A>) => URI2HKT<URI2HKT<B>[T]>[F]
+  ): <A, B>(f: (a: A) => HKT<F, Option<B>>, ta: HKT<T, A>) => HKTAs<F, HKTAs<T, B>>
   wither<F, T>(
     F: Applicative<F>,
     T: Witherable<T>
@@ -46,7 +46,7 @@ export class Ops {
   wilted<F extends HKTS, T extends HKTS>(
     F: Applicative<F>,
     T: Witherable<T>
-  ): <L, R>(tm: HKT<T, HKT<F, Either<L, R>>>) => URI2HKT<Wilt1<T, L, R>>[F]
+  ): <L, R>(tm: HKT<T, HKT<F, Either<L, R>>>) => HKTAs<F, Wilt1<T, L, R>>
   wilted<F, T>(F: Applicative<F>, T: Witherable<T>): <L, R>(tm: HKT<T, HKT<F, Either<L, R>>>) => HKT<F, Wilt<T, L, R>>
   wilted<F, T>(F: Applicative<F>, T: Witherable<T>): <L, R>(tm: HKT<T, HKT<F, Either<L, R>>>) => HKT<F, Wilt<T, L, R>> {
     return tm => T.wilt(F)(me => me, tm)
@@ -56,7 +56,7 @@ export class Ops {
   withered<F extends HKTS, T extends HKTS>(
     F: Applicative<F>,
     T: Witherable<T>
-  ): <A>(tm: HKT<T, HKT<F, Option<A>>>) => URI2HKT<URI2HKT<A>[T]>[F]
+  ): <A>(tm: HKT<T, HKT<F, Option<A>>>) => HKTAs<F, HKTAs<T, A>>
   withered<F, T>(F: Applicative<F>, T: Witherable<T>): <A>(tm: HKT<T, HKT<F, Option<A>>>) => HKT<F, HKT<T, A>>
   withered<F, T>(F: Applicative<F>, T: Witherable<T>): <A>(tm: HKT<T, HKT<F, Option<A>>>) => HKT<F, HKT<T, A>> {
     return tm => this.wither(F, T)(moa => moa, tm)


### PR DESCRIPTION
Here's the POC for HKTAs. It's a very simple replacement for URI2HKT. It's just a bit more typesafe (forces use of HKTS) and stops you from using wrongly defined URI2HKT mappings. It also means users don't have to use indexers anymore, but just plain generics, to access the URI2HKT map.