### PR TITLE
add Distributive functor

### DIFF
--- a/src/Distributive.ts
+++ b/src/Distributive.ts
@@ -1,0 +1,56 @@
+import { HKT, HKTS, HKT2S, HKTAs, HKT2As } from './HKT'
+import { Functor } from './Functor'
+
+// adapted from https://github.com/purescript/purescript-distributive
+
+/** Categorical dual of `Traversable`:
+ *
+ * - `distribute` is the dual of `sequence` - it zips an arbitrary collection of containers.
+ * - `collect` is the dual of `traverse` - it traverses an arbitrary collection of values.
+ *
+ * Laws:
+ *
+ * - `distribute = collect id`
+ * - `distribute <<< distribute = id`
+ * - `collect f = distribute <<< map f`
+ * - `map f = unwrap <<< collect (Identity <<< f)`
+ * - `map distribute <<< collect f = unwrap <<< collect (Compose <<< f)`
+ */
+export interface Distributive<F> extends Functor<F> {
+  distribute<G>(G: Functor<G>): <A>(gfa: HKT<G, HKT<F, A>>) => HKT<F, HKT<G, A>>
+}
+
+export class Ops {
+  /** A default implementation of `collect`, based on `distribute` */
+  collect<G extends HKTS, F extends HKT2S>(
+    G: Functor<G>,
+    F: Distributive<F>
+  ): <L, A, B>(f: (a: A) => HKT2As<F, L, B>, ga: HKTAs<G, A>) => HKT2As<F, L, HKTAs<G, B>>
+  collect<G extends HKTS, F extends HKTS>(
+    G: Functor<G>,
+    F: Distributive<F>
+  ): <A, B>(f: (a: A) => HKTAs<F, B>, ga: HKTAs<G, A>) => HKTAs<F, HKTAs<G, B>>
+  collect<G, F>(G: Functor<G>, F: Distributive<F>): <A, B>(f: (a: A) => HKT<F, B>, ga: HKT<G, A>) => HKT<F, HKT<G, B>> {
+    return (f, ga) => F.distribute(G)(G.map(f, ga))
+  }
+
+  /** Zip an arbitrary collection of containers and summarize the results */
+  cotraverse<G extends HKTS, F extends HKT2S>(
+    G: Functor<G>,
+    F: Distributive<F>
+  ): <L, A, B>(f: (ga: HKTAs<G, A>) => B, gfa: HKTAs<G, HKT2As<F, L, A>>) => HKT2As<F, L, B>
+  cotraverse<G extends HKTS, F extends HKTS>(
+    G: Functor<G>,
+    F: Distributive<F>
+  ): <A, B>(f: (ga: HKTAs<G, A>) => B, gfa: HKTAs<G, HKTAs<F, A>>) => HKTAs<F, B>
+  cotraverse<G, F>(
+    G: Functor<G>,
+    F: Distributive<F>
+  ): <A, B>(f: (ga: HKT<G, A>) => B, gfa: HKT<G, HKT<F, A>>) => HKT<F, B> {
+    return (f, gfa) => F.map(ga => f(ga), F.distribute(G)(gfa))
+  }
+}
+
+const ops = new Ops()
+export const collect: Ops['collect'] = ops.collect
+export const cotraverse: Ops['cotraverse'] = ops.cotraverse

--- a/src/Identity.ts
+++ b/src/Identity.ts
@@ -8,7 +8,9 @@ import { Alt, FantasyAlt } from './Alt'
 import { Comonad, FantasyComonad } from './Comonad'
 import { Either } from './Either'
 import { ChainRec, tailRec } from './ChainRec'
+import { Distributive } from './Distributive'
 import { toString } from './function'
+import { Functor } from './Functor'
 
 declare module './HKT' {
   interface URI2HKT<A> {
@@ -125,10 +127,17 @@ export class Ops {
   traverse<F>(F: Applicative<F>): <A, B>(f: (a: A) => HKT<F, B>, ta: Identity<A>) => HKT<F, Identity<B>> {
     return (f, ta) => ta.traverse(F)(f)
   }
+
+  distribute<G extends HKT2S>(G: Functor<G>): <L, A>(gfa: HKT2As<G, L, Identity<A>>) => Identity<HKT2As<G, L, A>>
+  distribute<G extends HKTS>(G: Functor<G>): <A>(gfa: HKTAs<G, Identity<A>>) => Identity<HKTAs<G, A>>
+  distribute<G>(G: Functor<G>): <A>(gfa: HKT<G, Identity<A>>) => Identity<HKT<G, A>> {
+    return gfa => new Identity(G.map(fa => fa.value, gfa))
+  }
 }
 
 const ops = new Ops()
 export const traverse: Ops['traverse'] = ops.traverse
+export const distribute: Ops['distribute'] = ops.distribute
 
 export function extend<A, B>(f: (ea: Identity<A>) => B, ea: Identity<A>): Identity<B> {
   return ea.extend(f)
@@ -142,7 +151,13 @@ export function chainRec<A, B>(f: (a: A) => Identity<Either<A, B>>, a: A): Ident
   return new Identity(tailRec(a => f(a).extract(), a))
 }
 
-export const identity: Monad<URI> & Foldable<URI> & Traversable<URI> & Alt<URI> & Comonad<URI> & ChainRec<URI> = {
+export const identity: Monad<URI> &
+  Foldable<URI> &
+  Traversable<URI> &
+  Alt<URI> &
+  Comonad<URI> &
+  ChainRec<URI> &
+  Distributive<URI> = {
   URI,
   map,
   of,
@@ -153,5 +168,6 @@ export const identity: Monad<URI> & Foldable<URI> & Traversable<URI> & Alt<URI> 
   alt,
   extract,
   extend,
-  chainRec
+  chainRec,
+  distribute
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,8 @@ import * as const_ from './Const'
 export { const_ as const }
 import * as contravariant from './Contravariant'
 export { contravariant }
+import * as distributive from './Distributive'
+export { distributive }
 import * as either from './Either'
 export { either }
 import * as eitherT from './EitherT'

--- a/test/Identity.ts
+++ b/test/Identity.ts
@@ -1,0 +1,9 @@
+import * as assert from 'assert'
+import * as array from '../src/Array'
+import { Identity, distribute } from '../src/Identity'
+
+describe('Identity', () => {
+  it('distribute', () => {
+    assert.deepEqual(distribute(array)([new Identity(1), new Identity(2)]), new Identity([1, 2]))
+  })
+})

--- a/test/Reader.ts
+++ b/test/Reader.ts
@@ -1,0 +1,12 @@
+import * as assert from 'assert'
+import * as array from '../src/Array'
+import { Reader, distribute } from '../src/Reader'
+
+describe('Reader', () => {
+  it('distribute', () => {
+    assert.deepEqual(distribute(array)([new Reader((n: number) => n + 1), new Reader((n: number) => n * 2)]).run(2), [
+      3,
+      4
+    ])
+  })
+})


### PR DESCRIPTION
This PR provides the notion that is categorically dual to `Traversable`.

A `Distributive` Functor is one that you can push any functor inside of.

```purescript
distribute :: (Functor f, Distributive g) => f (g a) -> g (f a)
```

Compare this with the corresponding `Traversable` notion, `sequence`.

```purescript
sequence :: (Applicative f, Traversable g) => g (f a) -> f (g a)
```