### PR TITLE
add Representable functor type-class

### DIFF
--- a/src/Representable.ts
+++ b/src/Representable.ts
@@ -1,0 +1,8 @@
+import { HKT } from './HKT'
+import { Functor } from './Functor'
+
+/** A Functor f is Representable if tabulate and index witness an isomorphism to Reader. */
+export interface Representable<F, R> extends Functor<F> {
+  tabulate<A>(f: (rep: R) => A): HKT<F, A>
+  index<A>(fa: HKT<F, A>, rep: R): A
+}


### PR DESCRIPTION
Inspired by

- (1) https://medium.com/@drboolean/laziness-with-representable-functors-9bd506eae83f
- (2) https://bartoszmilewski.com/2015/07/29/representable-functors/
- (3) https://hackage.haskell.org/package/representable-functors-3.2.0.2/docs/Data-Functor-Representable.html
- http://chrispenner.ca/posts/representable-discrimination

Is this a good model of a representable functor? Or should I add a `Distributive` constraint as in (3)

```ts
/** A Functor f is Representable if tabulate and index witness an isomorphism to Reader. */
export interface Representable<F, R> extends Functor<F> {
  tabulate<A>(f: (rep: R) => A): HKT<F, A>
  index<A>(fa: HKT<F, A>, rep: R): A
}
```

Usage

```ts
import * as pair from './Pair' // <= PR #172

export const representablePair: Representable<pair.URI, boolean> = {
  URI: pair.URI,
  map: pair.map,
  tabulate<A>(f: (rep: boolean) => A): pair.Pair<A> {
    return new pair.Pair([f(true), f(false)])
  },
  index<A>(fa: pair.Pair<A>, rep: boolean): A {
    return rep ? fa.fst() : fa.snd()
  }
}
```