### PR TITLE
add generic function

### DIFF
--- a/src/function.ts
+++ b/src/function.ts
@@ -228,3 +228,18 @@ export function toString(x: any): string {
 export function tuple<A, B>(a: A, b: B): [A, B] {
   return [a, b]
 }
+
+export type NumberToString = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10'];
+export type GFunction<I extends number, A, R=void> = {
+    0: Lazy<R>;
+    1: Function1<A[0], R>
+    2: Function2<A[0], A[1], R>
+    3: Function3<A[0], A[1], A[2], R>
+    4: Function4<A[0], A[1], A[2], A[3], R>
+    5: Function5<A[0], A[1], A[2], A[3], A[4], R>
+    6: Function6<A[0], A[1], A[2], A[3], A[4], A[5], R>
+    7: Function7<A[0], A[1], A[2], A[3], A[4], A[5], A[6], R>
+    8: Function8<A[0], A[1], A[2], A[3], A[4], A[5], A[6], A[7], R>
+    9: Function9<A[0], A[1], A[2], A[3], A[4], A[5], A[6], A[7], A[8], R>
+    10: Function10<A[0], A[1], A[2], A[3], A[4], A[5], A[6], A[7], A[8], A[9], R>
+}[NumberToString[I]];


### PR DESCRIPTION
I've added a generic function with variable amount of arguments. It's something I need in my work for function chaining, adaptors and such.

Issues:
1. type `NumberToString` should move to `typelevel-ts` project IMO
2. I couldn't find a way to get rid of the first generic param `I`. It looks like it's redundant, as the size of the tuple is already in the `A` param. 
I've tried these things:
```ts
type TupleLength<T, I = 0> = {
    'true': TupleLength<T, Increment[I]>
    'false': I
}[ObjectHasKey<T, I>]
type GFunction2<A, R=void> = GFunction<TupleLength<A>, A, number>;
type GFunction3<A, R=void, I=0> = GFunction<TupleLength<A, I>, A, number>;
```
and also
```ts
export type GFunction<A extends Array<any>, R=void> =
    If<ObjectHasKey<A, '1'>,
        Function2<A[0], A[1], R>,
        If<ObjectHasKey<A, '0'>,
            Function1<A[0], R>,
            Lazy<R>>>
```
would welcome any ideas...