### PR TITLE
Fr/migrate to curried

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 lib
 dev
+.idea

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
-    "typescript.tsdk": "./node_modules/typescript/lib",
-    "prettier.printWidth": 120
+  "typescript.tsdk": "./node_modules/typescript/lib",
+  "prettier.printWidth": 120,
+  "prettier.semi": false,
+  "prettier.singleQuote": true,
+  "tslint.enable": true
 }

--- a/examples/ArrayOption.ts
+++ b/examples/ArrayOption.ts
@@ -17,15 +17,11 @@ export const URI = 'ArrayOption'
 export type URI = typeof URI
 
 export class ArrayOption<A> implements FantasyMonad<URI, A> {
-  static of = of
   readonly _A: A
   readonly _URI = URI
-  constructor(public readonly value: Array<Option<A>>) {}
+  constructor(readonly value: Array<Option<A>>) {}
   map<B>(f: (a: A) => B): ArrayOption<B> {
     return new ArrayOption(optionTArray.map(f, this.value))
-  }
-  of<B>(b: B): ArrayOption<B> {
-    return of(b)
   }
   ap<B>(fab: ArrayOption<(a: A) => B>): ArrayOption<B> {
     return new ArrayOption(optionTArray.ap(fab.value, this.value))
@@ -37,40 +33,28 @@ export class ArrayOption<A> implements FantasyMonad<URI, A> {
     return new ArrayOption(optionTArray.chain(a => f(a).value, this.value))
   }
   getOrElse(f: Lazy<A>): Array<A> {
-    return optionT.getOrElse(array)(f, this.value)
+    return optionT.getOrElse(array)(f)(this.value)
   }
   fold<R>(none: Lazy<R>, some: (a: A) => R): Array<R> {
     return optionT.fold(array)(none, some, this.value)
   }
 }
 
-export function map<A, B>(f: (a: A) => B, fa: ArrayOption<A>): ArrayOption<B> {
-  return fa.map(f)
-}
+export const map = <A, B>(f: (a: A) => B, fa: ArrayOption<A>): ArrayOption<B> => fa.map(f)
 
-export function of<A>(a: A): ArrayOption<A> {
-  return new ArrayOption(optionT.some(array)(a))
-}
+export const of = <A>(a: A): ArrayOption<A> => new ArrayOption(optionT.some(array)(a))
 
-export function ap<A, B>(fab: ArrayOption<(a: A) => B>, fa: ArrayOption<A>): ArrayOption<B> {
-  return fa.ap(fab)
-}
+export const ap = <A, B>(fab: ArrayOption<(a: A) => B>, fa: ArrayOption<A>): ArrayOption<B> => fa.ap(fab)
 
-export function chain<A, B>(f: (a: A) => ArrayOption<B>, fa: ArrayOption<A>): ArrayOption<B> {
-  return fa.chain(f)
-}
+export const chain = <A, B>(f: (a: A) => ArrayOption<B>, fa: ArrayOption<A>): ArrayOption<B> => fa.chain(f)
 
 export const some = of
 
 export const none = new ArrayOption(optionT.none(array)())
 
-export function fromOption<A>(oa: Option<A>): ArrayOption<A> {
-  return new ArrayOption(optionT.fromOption(array)(oa))
-}
+export const fromOption = <A>(oa: Option<A>): ArrayOption<A> => new ArrayOption(optionT.fromOption(array)(oa))
 
-export function liftF<A>(ma: Array<A>): ArrayOption<A> {
-  return new ArrayOption(optionT.liftF(array)(ma))
-}
+export const liftF = <A>(ma: Array<A>): ArrayOption<A> => new ArrayOption(optionT.liftF(array)(ma))
 
 export const arrayOption: Monad<URI> = {
   URI,

--- a/examples/EitherOption.ts
+++ b/examples/EitherOption.ts
@@ -17,16 +17,12 @@ export const URI = 'EitherOption'
 export type URI = typeof URI
 
 export class EitherOption<L, A> implements FantasyMonad<URI, A> {
-  static of = of
   readonly _A: A
   readonly _L: L
   readonly _URI = URI
-  constructor(public readonly value: either.Either<L, Option<A>>) {}
+  constructor(readonly value: either.Either<L, Option<A>>) {}
   map<B>(f: (a: A) => B): EitherOption<L, B> {
     return new EitherOption(optionTEither.map(f, this.value))
-  }
-  of<M, B>(b: B): EitherOption<M, B> {
-    return of(b)
   }
   ap<B>(fab: EitherOption<L, (a: A) => B>): EitherOption<L, B> {
     return new EitherOption(optionTEither.ap(fab.value, this.value))
@@ -38,40 +34,29 @@ export class EitherOption<L, A> implements FantasyMonad<URI, A> {
     return new EitherOption(optionTEither.chain(a => f(a).value, this.value))
   }
   getOrElse(f: Lazy<A>): either.Either<L, A> {
-    return optionT.getOrElse(either)(f, this.value)
+    return optionT.getOrElse(either)(f)(this.value)
   }
   fold<R>(none: Lazy<R>, some: (a: A) => R): either.Either<L, R> {
     return optionT.fold(either)(none, some, this.value)
   }
 }
 
-export function map<L, A, B>(f: (a: A) => B, fa: EitherOption<L, A>): EitherOption<L, B> {
-  return fa.map(f)
-}
+export const map = <L, A, B>(f: (a: A) => B, fa: EitherOption<L, A>): EitherOption<L, B> => fa.map(f)
 
-export function of<L, A>(a: A): EitherOption<L, A> {
-  return new EitherOption(optionT.some(either)(a))
-}
+export const of = <L, A>(a: A): EitherOption<L, A> => new EitherOption(optionT.some(either)(a))
 
-export function ap<L, A, B>(fab: EitherOption<L, (a: A) => B>, fa: EitherOption<L, A>): EitherOption<L, B> {
-  return fa.ap(fab)
-}
+export const ap = <L, A, B>(fab: EitherOption<L, (a: A) => B>, fa: EitherOption<L, A>): EitherOption<L, B> => fa.ap(fab)
 
-export function chain<L, A, B>(f: (a: A) => EitherOption<L, B>, fa: EitherOption<L, A>): EitherOption<L, B> {
-  return fa.chain(f)
-}
+export const chain = <L, A, B>(f: (a: A) => EitherOption<L, B>, fa: EitherOption<L, A>): EitherOption<L, B> =>
+  fa.chain(f)
 
 export const some = of
 
 export const none = new EitherOption(optionT.none(either)())
 
-export function fromOption<L, A>(oa: Option<A>): EitherOption<L, A> {
-  return new EitherOption(optionT.fromOption(either)(oa))
-}
+export const fromOption = <L, A>(oa: Option<A>): EitherOption<L, A> => new EitherOption(optionT.fromOption(either)(oa))
 
-export function liftF<L, A>(ma: either.Either<L, A>): EitherOption<L, A> {
-  return new EitherOption(optionT.liftF(either)(ma))
-}
+export const liftF = <L, A>(ma: either.Either<L, A>): EitherOption<L, A> => new EitherOption(optionT.liftF(either)(ma))
 
 export const eitherOption: Monad<URI> = {
   URI,

--- a/examples/Free.ts
+++ b/examples/Free.ts
@@ -106,7 +106,7 @@ const program1 = (start: Position) => {
 }
 
 console.log('--program1--')
-const result1 = program1(start).foldFree(identity, interpretIdentity) // interpretIdentity Position { x: 10, y: 10, heading: Degree { value: 0 } }
+const result1 = program1(start).foldFree(identity)(interpretIdentity) // interpretIdentity Position { x: 10, y: 10, heading: Degree { value: 0 } }
 console.log(result1.value) // undefined
 
 import * as option from 'fp-ts/lib/Option'
@@ -138,7 +138,7 @@ const program2 = (start: Position) => {
 }
 
 // console.log('--program2--')
-const result2 = program2(start).foldFree(option, interpretOption)
+const result2 = program2(start).foldFree(option)(interpretOption)
 console.log(result2) // none
 
 // Composing
@@ -222,7 +222,7 @@ export function logoAppInterpretIdentity<A>(fa: LogoAppF<A>): identity.Identity<
 }
 
 console.log('--program3--')
-program3(start).foldFree(identity, logoAppInterpretIdentity)
+program3(start).foldFree(identity)(logoAppInterpretIdentity)
 /*
 stop drawing at position {"x":0,"y":10,"heading":{"value":0}}
 start drawing at position {"x":10,"y":10,"heading":{"value":0}}

--- a/examples/Free.ts
+++ b/examples/Free.ts
@@ -13,47 +13,35 @@ export const InstructionFURI = 'Instruction'
 export type InstructionFURI = typeof InstructionFURI
 
 export class Position {
-  constructor(public readonly x: number, public readonly y: number, public readonly heading: Degree) {}
+  constructor(readonly x: number, readonly y: number, readonly heading: Degree) {}
 }
 
 export class Forward<A> {
   readonly _tag: 'Forward' = 'Forward'
   readonly _A: A
   readonly _URI: InstructionFURI
-  constructor(
-    public readonly position: Position,
-    public readonly length: number,
-    public readonly more: (p: Position) => A
-  ) {}
+  constructor(readonly position: Position, readonly length: number, readonly more: (p: Position) => A) {}
 }
 
 export class Backward<A> {
   readonly _tag: 'Backward' = 'Backward'
   readonly _A: A
   readonly _URI: InstructionFURI
-  constructor(
-    public readonly position: Position,
-    public readonly length: number,
-    public readonly more: (p: Position) => A
-  ) {}
+  constructor(readonly position: Position, readonly length: number, readonly more: (p: Position) => A) {}
 }
 
 export class RotateRight<A> {
   readonly _tag: 'RotateRight' = 'RotateRight'
   readonly _A: A
   readonly _URI: InstructionFURI
-  constructor(
-    public readonly position: Position,
-    public readonly degree: Degree,
-    public readonly more: (p: Position) => A
-  ) {}
+  constructor(readonly position: Position, readonly degree: Degree, readonly more: (p: Position) => A) {}
 }
 
 export class Show<A> {
   readonly _tag: 'Show' = 'Show'
   readonly _A: A
   readonly _URI: InstructionFURI
-  constructor(public readonly position: Position, public readonly more: A) {}
+  constructor(readonly position: Position, readonly more: A) {}
 }
 
 export type InstructionF<A> = Forward<A> | Backward<A> | RotateRight<A> | Show<A>
@@ -151,14 +139,14 @@ export class PencilUp<A> {
   readonly _tag: 'PencilUp' = 'PencilUp'
   readonly _A: A
   readonly _URI: PencilInstructionFURI
-  constructor(public readonly position: Position, public readonly more: A) {}
+  constructor(readonly position: Position, readonly more: A) {}
 }
 
 export class PencilDown<A> {
   readonly _tag: 'PencilDown' = 'PencilDown'
   readonly _A: A
   readonly _URI: PencilInstructionFURI
-  constructor(public readonly position: Position, public readonly more: A) {}
+  constructor(readonly position: Position, readonly more: A) {}
 }
 
 export type PencilInstructionF<A> = PencilUp<A> | PencilDown<A>
@@ -176,14 +164,14 @@ export class Instruction<A> {
   readonly _tag: InstructionFURI = InstructionFURI
   readonly _A: A
   readonly _URI: LogoAppFURI
-  constructor(public readonly value: InstructionF<A>) {}
+  constructor(readonly value: InstructionF<A>) {}
 }
 
 export class PencilInstruction<A> {
   readonly _tag: PencilInstructionFURI = PencilInstructionFURI
   readonly _A: A
   readonly _URI: LogoAppFURI
-  constructor(public readonly value: PencilInstructionF<A>) {}
+  constructor(readonly value: PencilInstructionF<A>) {}
 }
 
 export type LogoAppF<A> = Instruction<A> | PencilInstruction<A>

--- a/examples/ReaderIO.ts
+++ b/examples/ReaderIO.ts
@@ -18,7 +18,7 @@ export class ReaderIO<E, A> implements FantasyMonad<URI, A> {
   readonly _A: A
   readonly _L: E
   readonly _URI: URI
-  constructor(public readonly value: (e: E) => io.IO<A>) {}
+  constructor(readonly value: (e: E) => io.IO<A>) {}
   map<B>(f: (a: A) => B): ReaderIO<E, B> {
     return new ReaderIO(readerTIO.map(f, this.value))
   }
@@ -36,29 +36,17 @@ export class ReaderIO<E, A> implements FantasyMonad<URI, A> {
   }
 }
 
-export function map<E, A, B>(f: (a: A) => B, fa: ReaderIO<E, A>): ReaderIO<E, B> {
-  return fa.map(f)
-}
+export const map = <E, A, B>(f: (a: A) => B, fa: ReaderIO<E, A>): ReaderIO<E, B> => fa.map(f)
 
-export function of<E, A>(a: A): ReaderIO<E, A> {
-  return new ReaderIO(readerTIO.of(a))
-}
+export const of = <E, A>(a: A): ReaderIO<E, A> => new ReaderIO(readerTIO.of(a))
 
-export function ap<E, A, B>(fab: ReaderIO<E, (a: A) => B>, fa: ReaderIO<E, A>): ReaderIO<E, B> {
-  return fa.ap(fab)
-}
+export const ap = <E, A, B>(fab: ReaderIO<E, (a: A) => B>, fa: ReaderIO<E, A>): ReaderIO<E, B> => fa.ap(fab)
 
-export function chain<E, A, B>(f: (a: A) => ReaderIO<E, B>, fa: ReaderIO<E, A>): ReaderIO<E, B> {
-  return fa.chain(f)
-}
+export const chain = <E, A, B>(f: (a: A) => ReaderIO<E, B>, fa: ReaderIO<E, A>): ReaderIO<E, B> => fa.chain(f)
 
-export function ask<E>(e: E): ReaderIO<E, E> {
-  return new ReaderIO(readerT.ask(io)())
-}
+export const ask = <E>(e: E): ReaderIO<E, E> => new ReaderIO(readerT.ask(io)())
 
-export function asks<E, A>(f: (e: E) => A): ReaderIO<E, A> {
-  return new ReaderIO(readerT.asks(io)(f))
-}
+export const asks = <E, A>(f: (e: E) => A): ReaderIO<E, A> => new ReaderIO(readerT.asks(io)(f))
 
 export const readerIO: Monad<URI> = {
   URI,

--- a/examples/StateIO.ts
+++ b/examples/StateIO.ts
@@ -139,7 +139,7 @@ function guessSession(answer: number): StateIO<number, void> {
   })
 }
 
-const program2 = randomInt(1, 100).chain(answer =>
+const program2 = randomInt(1)(100).chain(answer =>
   log(`I'm thinking of a number between 1 and 100, can you guess it? `).chain(() => {
     const guesses = guessSession(answer).exec(0)
     return log(`Success in ${guesses} tries.`)

--- a/examples/StateIO.ts
+++ b/examples/StateIO.ts
@@ -127,7 +127,7 @@ function guessSession(answer: number): StateIO<number, void> {
   return lift<number, string>(readLine('')).chain(gs => {
     const g = parseInt(gs, 10)
     return modify<number>(s => s + 1).chain(() => {
-      switch (numberOrd.compare(g, answer)) {
+      switch (numberOrd.compare(g)(answer)) {
         case 'LT':
           return lift<number, void>(log('Too low')).chain(() => guessSession(answer))
         case 'GT':

--- a/examples/StateIO.ts
+++ b/examples/StateIO.ts
@@ -20,7 +20,7 @@ export class StateIO<S, A> implements FantasyMonad<URI, A> {
   readonly _A: A
   readonly _L: S
   readonly _URI: URI
-  constructor(public readonly value: (s: S) => IO<[A, S]>) {}
+  constructor(readonly value: (s: S) => IO<[A, S]>) {}
   run(s: S): [A, S] {
     return this.value(s).run()
   }
@@ -47,41 +47,23 @@ export class StateIO<S, A> implements FantasyMonad<URI, A> {
   }
 }
 
-export function map<S, A, B>(f: (a: A) => B, fa: StateIO<S, A>): StateIO<S, B> {
-  return fa.map(f)
-}
+export const map = <S, A, B>(f: (a: A) => B, fa: StateIO<S, A>): StateIO<S, B> => fa.map(f)
 
-export function of<S, A>(a: A): StateIO<S, A> {
-  return new StateIO(stateTIO.of(a))
-}
+export const of = <S, A>(a: A): StateIO<S, A> => new StateIO(stateTIO.of(a))
 
-export function ap<S, A, B>(fab: StateIO<S, (a: A) => B>, fa: StateIO<S, A>): StateIO<S, B> {
-  return fa.ap(fab)
-}
+export const ap = <S, A, B>(fab: StateIO<S, (a: A) => B>, fa: StateIO<S, A>): StateIO<S, B> => fa.ap(fab)
 
-export function chain<S, A, B>(f: (a: A) => StateIO<S, B>, fa: StateIO<S, A>): StateIO<S, B> {
-  return fa.chain(f)
-}
+export const chain = <S, A, B>(f: (a: A) => StateIO<S, B>, fa: StateIO<S, A>): StateIO<S, B> => fa.chain(f)
 
-export function get<S>(): StateIO<S, S> {
-  return new StateIO(stateT.get(io)())
-}
+export const get = <S>(): StateIO<S, S> => new StateIO(stateT.get(io)())
 
-export function put<S>(s: S): StateIO<S, void> {
-  return new StateIO(stateT.put(io)(s))
-}
+export const put = <S>(s: S): StateIO<S, void> => new StateIO(stateT.put(io)(s))
 
-export function modify<S>(f: Endomorphism<S>): StateIO<S, void> {
-  return new StateIO(stateT.modify(io)(f))
-}
+export const modify = <S>(f: Endomorphism<S>): StateIO<S, void> => new StateIO(stateT.modify(io)(f))
 
-export function gets<S, A>(f: (s: S) => A): StateIO<S, A> {
-  return new StateIO(stateT.gets(io)(f))
-}
+export const gets = <S, A>(f: (s: S) => A): StateIO<S, A> => new StateIO(stateT.gets(io)(f))
 
-export function lift<S, A>(fa: IO<A>): StateIO<S, A> {
-  return new StateIO(s => new IO(() => tuple(fa.run(), s)))
-}
+export const lift = <S, A>(fa: IO<A>): StateIO<S, A> => new StateIO(s => new IO(() => tuple(fa.run(), s)))
 
 export const stateIO: Monad<URI> = {
   URI,
@@ -116,7 +98,7 @@ program1.run([1, 2, 3])
 
 // Example 2: a guessing game
 
-import { numberOrd } from 'fp-ts/lib/Ord'
+import { ordNumber } from 'fp-ts/lib/Ord'
 import { randomInt } from 'fp-ts/lib/Random'
 
 function readLine(s: string): IO<string> {
@@ -127,7 +109,7 @@ function guessSession(answer: number): StateIO<number, void> {
   return lift<number, string>(readLine('')).chain(gs => {
     const g = parseInt(gs, 10)
     return modify<number>(s => s + 1).chain(() => {
-      switch (numberOrd.compare(g)(answer)) {
+      switch (ordNumber.compare(g)(answer)) {
         case 'LT':
           return lift<number, void>(log('Too low')).chain(() => guessSession(answer))
         case 'GT':
@@ -139,7 +121,7 @@ function guessSession(answer: number): StateIO<number, void> {
   })
 }
 
-const program2 = randomInt(1)(100).chain(answer =>
+const program2 = randomInt(1, 100).chain(answer =>
   log(`I'm thinking of a number between 1 and 100, can you guess it? `).chain(() => {
     const guesses = guessSession(answer).exec(0)
     return log(`Success in ${guesses} tries.`)

--- a/examples/TaskEither.ts
+++ b/examples/TaskEither.ts
@@ -44,7 +44,7 @@ export class TaskEither<L, A> implements FantasyMonad<URI, A> {
     return eitherT.fold(task)(left, right, this.value)
   }
   mapLeft<M>(f: (l: L) => M): TaskEither<M, A> {
-    return new TaskEither(eitherT.mapLeft(task)(f, this.value))
+    return new TaskEither(eitherT.mapLeft(task)(f)(this.value))
   }
   toOption(): task.Task<Option<A>> {
     return eitherT.toOption(task)(this.value)

--- a/examples/TaskEither.ts
+++ b/examples/TaskEither.ts
@@ -80,7 +80,7 @@ export function fromEither<L, A>(fa: either.Either<L, A>): TaskEither<L, A> {
 }
 
 export function tryCatch<L, A>(f: Lazy<Promise<A>>, onrejected: (reason: any) => L): TaskEither<L, A> {
-  return new TaskEither(task.tryCatch(f, onrejected))
+  return new TaskEither(task.tryCatch(f)(onrejected))
 }
 
 export const taskEither: Monad<URI> = {

--- a/examples/TaskEither.ts
+++ b/examples/TaskEither.ts
@@ -20,16 +20,12 @@ export const URI = 'TaskEither'
 export type URI = typeof URI
 
 export class TaskEither<L, A> implements FantasyMonad<URI, A> {
-  static of = of
   readonly _A: A
   readonly _L: L
   readonly _URI: URI
-  constructor(public readonly value: task.Task<either.Either<L, A>>) {}
+  constructor(readonly value: task.Task<either.Either<L, A>>) {}
   map<B>(f: (a: A) => B): TaskEither<L, B> {
     return new TaskEither(eitherTTask.map(f, this.value))
-  }
-  of<M, B>(b: B): TaskEither<M, B> {
-    return of(b)
   }
   ap<B>(fab: TaskEither<L, (a: A) => B>): TaskEither<L, B> {
     return new TaskEither(eitherTTask.ap(fab.value, this.value))
@@ -51,37 +47,23 @@ export class TaskEither<L, A> implements FantasyMonad<URI, A> {
   }
 }
 
-export function map<L, A, B>(f: (a: A) => B, fa: TaskEither<L, A>): TaskEither<L, B> {
-  return fa.map(f)
-}
+export const map = <L, A, B>(f: (a: A) => B, fa: TaskEither<L, A>): TaskEither<L, B> => fa.map(f)
 
-export function of<L, A>(a: A): TaskEither<L, A> {
-  return new TaskEither(eitherTTask.of(a))
-}
+export const of = <L, A>(a: A): TaskEither<L, A> => new TaskEither(eitherTTask.of(a))
 
-export function ap<L, A, B>(fab: TaskEither<L, (a: A) => B>, fa: TaskEither<L, A>): TaskEither<L, B> {
-  return fa.ap(fab)
-}
+export const ap = <L, A, B>(fab: TaskEither<L, (a: A) => B>, fa: TaskEither<L, A>): TaskEither<L, B> => fa.ap(fab)
 
-export function chain<L, A, B>(f: (a: A) => TaskEither<L, B>, fa: TaskEither<L, A>): TaskEither<L, B> {
-  return fa.chain(f)
-}
+export const chain = <L, A, B>(f: (a: A) => TaskEither<L, B>, fa: TaskEither<L, A>): TaskEither<L, B> => fa.chain(f)
 
-export function right<L, A>(fa: task.Task<A>): TaskEither<L, A> {
-  return new TaskEither(eitherT.right(task)(fa))
-}
+export const right = <L, A>(fa: task.Task<A>): TaskEither<L, A> => new TaskEither(eitherT.right(task)(fa))
 
-export function left<L, A>(fa: task.Task<L>): TaskEither<L, A> {
-  return new TaskEither(eitherT.left(task)(fa))
-}
+export const left = <L, A>(fa: task.Task<L>): TaskEither<L, A> => new TaskEither(eitherT.left(task)(fa))
 
-export function fromEither<L, A>(fa: either.Either<L, A>): TaskEither<L, A> {
-  return new TaskEither(eitherT.fromEither(task)(fa))
-}
+export const fromEither = <L, A>(fa: either.Either<L, A>): TaskEither<L, A> =>
+  new TaskEither(eitherT.fromEither(task)(fa))
 
-export function tryCatch<L, A>(f: Lazy<Promise<A>>, onrejected: (reason: any) => L): TaskEither<L, A> {
-  return new TaskEither(task.tryCatch(f)(onrejected))
-}
+export const tryCatch = <L, A>(f: Lazy<Promise<A>>, onrejected: (reason: any) => L): TaskEither<L, A> =>
+  new TaskEither(task.tryCatch(f)(onrejected))
 
 export const taskEither: Monad<URI> = {
   URI,

--- a/examples/TaskValidation.ts
+++ b/examples/TaskValidation.ts
@@ -9,7 +9,7 @@ declare module '../src/HKT' {
   }
 }
 
-const taskValidationApplicative = getApplicativeComposition(task)(validation)
+const taskValidationApplicative = getApplicativeComposition(task, validation)
 
 export const URI = 'TaskValidation'
 

--- a/examples/TaskValidation.ts
+++ b/examples/TaskValidation.ts
@@ -9,7 +9,7 @@ declare module '../src/HKT' {
   }
 }
 
-const taskValidationApplicative = getApplicativeComposition(task, validation)
+const taskValidationApplicative = getApplicativeComposition(task)(validation)
 
 export const URI = 'TaskValidation'
 

--- a/examples/TaskValidation.ts
+++ b/examples/TaskValidation.ts
@@ -16,16 +16,12 @@ export const URI = 'TaskValidation'
 export type URI = typeof URI
 
 export class TaskValidation<L, A> implements FantasyApplicative<URI, A> {
-  static of = of
   readonly _A: A
   readonly _L: L
   readonly _URI: URI
-  constructor(public readonly value: task.Task<validation.Validation<L, A>>) {}
+  constructor(readonly value: task.Task<validation.Validation<L, A>>) {}
   map<B>(f: (a: A) => B): TaskValidation<L, B> {
     return new TaskValidation(taskValidationApplicative.map(f, this.value))
-  }
-  of<M, B>(b: B): TaskValidation<M, B> {
-    return of(b)
   }
   ap<B>(fab: TaskValidation<L, (a: A) => B>): TaskValidation<L, B> {
     return new TaskValidation(taskValidationApplicative.ap(fab.value, this.value))
@@ -41,17 +37,12 @@ export class TaskValidation<L, A> implements FantasyApplicative<URI, A> {
   }
 }
 
-export function map<L, A, B>(f: (a: A) => B, fa: TaskValidation<L, A>): TaskValidation<L, B> {
-  return fa.map(f)
-}
+export const map = <L, A, B>(f: (a: A) => B, fa: TaskValidation<L, A>): TaskValidation<L, B> => fa.map(f)
 
-export function of<L, A>(a: A): TaskValidation<L, A> {
-  return new TaskValidation(taskValidationApplicative.of(a))
-}
+export const of = <L, A>(a: A): TaskValidation<L, A> => new TaskValidation(taskValidationApplicative.of(a))
 
-export function ap<L, A, B>(fab: TaskValidation<L, (a: A) => B>, fa: TaskValidation<L, A>): TaskValidation<L, B> {
-  return fa.ap(fab)
-}
+export const ap = <L, A, B>(fab: TaskValidation<L, (a: A) => B>, fa: TaskValidation<L, A>): TaskValidation<L, B> =>
+  fa.ap(fab)
 
 export const taskValidation: Applicative<URI> = {
   URI,

--- a/examples/debugging-with-Trace.ts
+++ b/examples/debugging-with-Trace.ts
@@ -15,7 +15,7 @@ const bar = spy(foo.mapLeft(s => s.length))
 // trace
 //
 
-const bar2 = foo.mapLeft(s => trace('mapping the left side', () => s.length))
+const bar2 = foo.mapLeft(s => trace('mapping the left side')(() => s.length))
 // => 'mapping the left side'
 
 //

--- a/examples/debugging-with-Trace.ts
+++ b/examples/debugging-with-Trace.ts
@@ -15,7 +15,7 @@ const bar = spy(foo.mapLeft(s => s.length))
 // trace
 //
 
-const bar2 = foo.mapLeft(s => trace('mapping the left side')(() => s.length))
+const bar2 = foo.mapLeft(s => trace('mapping the left side', () => s.length))
 // => 'mapping the left side'
 
 //

--- a/examples/ixIO.ts
+++ b/examples/ixIO.ts
@@ -74,7 +74,7 @@ export const x2: Operation<'Closed', 'Closed', void> = new Open().ichain(() => n
 // ok
 export const x4 = new Open().ichain(() => new Close()).ichain(() => new RingBell())
 
-x4.value.run()
+x4.run()
 /*
 Opening the door
 Closing the door

--- a/exercises/answer1.ts
+++ b/exercises/answer1.ts
@@ -8,10 +8,10 @@ export function binarySearch<A>(xs: Array<A>, x: A, ord: Ord<A>): number {
     }
     const mid2 = Math.floor((low + high) / 2)
     const d = xs[mid2]
-    if (ord.equals(d, x)) {
+    if (ord.equals(d)(x)) {
       return mid2
     }
-    if (ord.compare(d, x) === 'GT') {
+    if (ord.compare(d)(x) === 'GT') {
       return go(low, mid2, mid2 - 1)
     }
     return go(mid2 + 1, mid2, high)

--- a/exercises/answer1.ts
+++ b/exercises/answer1.ts
@@ -1,5 +1,5 @@
 import { Ord } from 'fp-ts/lib/Ord'
-import { numberOrd, stringOrd } from 'fp-ts/lib/Ord'
+import { ordNumber, ordString } from 'fp-ts/lib/Ord'
 
 export function binarySearch<A>(xs: Array<A>, x: A, ord: Ord<A>): number {
   function go(low: number, mid: number, high: number): number {
@@ -19,5 +19,5 @@ export function binarySearch<A>(xs: Array<A>, x: A, ord: Ord<A>): number {
   return go(0, 0, xs.length - 1)
 }
 
-console.log(binarySearch([1, 2, 3, 4, 5, 6], 3, numberOrd)) // => 2
-console.log(binarySearch(['a', 'b', 'c', 'd', 'e', 'f'], 'c', stringOrd)) // => 2
+console.log(binarySearch([1, 2, 3, 4, 5, 6], 3, ordNumber)) // => 2
+console.log(binarySearch(['a', 'b', 'c', 'd', 'e', 'f'], 'c', ordString)) // => 2

--- a/exercises/answer2.ts
+++ b/exercises/answer2.ts
@@ -1,5 +1,5 @@
 import { Ord } from 'fp-ts/lib/Ord'
-import { greaterThan, numberOrd } from 'fp-ts/lib/Ord'
+import { greaterThan, ordNumber } from 'fp-ts/lib/Ord'
 
 export function isSorted<A>(xs: Array<A>, ord: Ord<A>): boolean {
   const len = xs.length
@@ -15,5 +15,5 @@ export function isSorted<A>(xs: Array<A>, ord: Ord<A>): boolean {
   return go(0)
 }
 
-console.log(isSorted([1, 2, 3, 4, 5, 6], numberOrd)) // => true
-console.log(isSorted([1, 2, 3, 4, 6, 5], numberOrd)) // => false
+console.log(isSorted([1, 2, 3, 4, 5, 6], ordNumber)) // => true
+console.log(isSorted([1, 2, 3, 4, 6, 5], ordNumber)) // => false

--- a/exercises/answer2.ts
+++ b/exercises/answer2.ts
@@ -7,7 +7,7 @@ export function isSorted<A>(xs: Array<A>, ord: Ord<A>): boolean {
     if (n >= len) {
       return true
     }
-    if (greaterThan(ord, xs[n], xs[n + 1])) {
+    if (greaterThan(ord)(xs[n])(xs[n + 1])) {
       return false
     }
     return go(n + 1)

--- a/exercises/answer3.ts
+++ b/exercises/answer3.ts
@@ -25,7 +25,7 @@ export class Nil<A> implements FantasyFunctor<URI, A> {
 export class Cons<A> implements FantasyFunctor<URI, A> {
   readonly _A: A
   readonly _URI: URI
-  constructor(public readonly head: A, public readonly tail: List<A>) {}
+  constructor(readonly head: A, readonly tail: List<A>) {}
   map<B>(f: (a: A) => B): List<B> {
     return new Cons(f(this.head), this.tail.map(f))
   }

--- a/src/Alt.ts
+++ b/src/Alt.ts
@@ -2,7 +2,7 @@ import { HKT } from './HKT'
 import { Functor, FantasyFunctor } from './Functor'
 
 export interface Alt<F> extends Functor<F> {
-  alt<A>(fx: HKT<F, A>, fy: HKT<F, A>): HKT<F, A>
+  alt: <A>(fx: HKT<F, A>) => (fy: HKT<F, A>) => HKT<F, A>
 }
 
 export interface FantasyAlt<F, A> extends FantasyFunctor<F, A> {

--- a/src/Alt.ts
+++ b/src/Alt.ts
@@ -6,5 +6,5 @@ export interface Alt<F> extends Functor<F> {
 }
 
 export interface FantasyAlt<F, A> extends FantasyFunctor<F, A> {
-  alt(fy: HKT<F, A>): HKT<F, A>
+  alt: (fy: HKT<F, A>) => HKT<F, A>
 }

--- a/src/Applicative.ts
+++ b/src/Applicative.ts
@@ -10,39 +10,37 @@ import {
 } from './Functor'
 
 export interface Applicative<F> extends Apply<F> {
-  of<A>(a: A): HKT<F, A>
+  of: <A>(a: A) => HKT<F, A>
 }
 
-export interface FantasyApplicative<F, A> extends FantasyApply<F, A> {
-  of<A>(a: A): HKT<F, A>
-}
+export interface FantasyApplicative<F, A> extends FantasyApply<F, A> {}
 
 export interface ApplicativeComposition<F, G> extends FunctorComposition<F, G> {
-  of<A>(a: A): HKT<F, HKT<G, A>>
-  ap<A, B>(fgab: HKT<F, HKT<G, (a: A) => B>>, fga: HKT<F, HKT<G, A>>): HKT<F, HKT<G, B>>
+  of: <A>(a: A) => HKT<F, HKT<G, A>>
+  ap: <A, B>(fgab: HKT<F, HKT<G, (a: A) => B>>, fga: HKT<F, HKT<G, A>>) => HKT<F, HKT<G, B>>
 }
 
 export interface ApplicativeComposition11<F extends HKTS, G extends HKTS> extends FunctorComposition11<F, G> {
-  of<A>(a: A): HKTAs<F, HKTAs<G, A>>
-  ap<A, B>(fgab: HKTAs<F, HKTAs<G, (a: A) => B>>, fga: HKTAs<F, HKTAs<G, A>>): HKTAs<F, HKTAs<G, B>>
+  of: <A>(a: A) => HKTAs<F, HKTAs<G, A>>
+  ap: <A, B>(fgab: HKTAs<F, HKTAs<G, (a: A) => B>>, fga: HKTAs<F, HKTAs<G, A>>) => HKTAs<F, HKTAs<G, B>>
 }
 
 export interface ApplicativeComposition12<F extends HKTS, G extends HKT2S> extends FunctorComposition12<F, G> {
-  of<L, A>(a: A): HKTAs<F, HKT2As<G, L, A>>
-  ap<L, A, B>(fgab: HKTAs<F, HKT2As<G, L, (a: A) => B>>, fga: HKTAs<F, HKT2As<G, L, A>>): HKTAs<F, HKT2As<G, L, B>>
+  of: <L, A>(a: A) => HKTAs<F, HKT2As<G, L, A>>
+  ap: <L, A, B>(fgab: HKTAs<F, HKT2As<G, L, (a: A) => B>>, fga: HKTAs<F, HKT2As<G, L, A>>) => HKTAs<F, HKT2As<G, L, B>>
 }
 
 export interface ApplicativeComposition21<F extends HKT2S, G extends HKTS> extends FunctorComposition21<F, G> {
-  of<L, A>(a: A): HKT2As<F, L, HKTAs<G, A>>
-  ap<L, A, B>(fgab: HKT2As<F, L, HKTAs<G, (a: A) => B>>, fga: HKT2As<F, L, HKTAs<G, A>>): HKT2As<F, L, HKTAs<G, B>>
+  of: <L, A>(a: A) => HKT2As<F, L, HKTAs<G, A>>
+  ap: <L, A, B>(fgab: HKT2As<F, L, HKTAs<G, (a: A) => B>>, fga: HKT2As<F, L, HKTAs<G, A>>) => HKT2As<F, L, HKTAs<G, B>>
 }
 
 export interface ApplicativeComposition22<F extends HKT2S, G extends HKT2S> extends FunctorComposition22<F, G> {
-  of<L, M, A>(a: A): HKT2As<F, L, HKT2As<G, M, A>>
-  ap<L, M, A, B>(
+  of: <L, M, A>(a: A) => HKT2As<F, L, HKT2As<G, M, A>>
+  ap: <L, M, A, B>(
     fgab: HKT2As<F, L, HKT2As<G, M, (a: A) => B>>,
     fga: HKT2As<F, L, HKT2As<G, M, A>>
-  ): HKT2As<F, L, HKT2As<G, M, B>>
+  ) => HKT2As<F, L, HKT2As<G, M, B>>
 }
 
 export class Ops {
@@ -72,20 +70,11 @@ export class Ops {
   ): ApplicativeComposition11<F, G>
   getApplicativeComposition<F, G>(F: Applicative<F>, G: Applicative<G>): ApplicativeComposition<F, G>
   getApplicativeComposition<F, G>(F: Applicative<F>, G: Applicative<G>): ApplicativeComposition<F, G> {
-    const { map } = getFunctorComposition(F, G)
-
-    function of<A>(a: A): HKT<F, HKT<G, A>> {
-      return F.of(G.of(a))
-    }
-
-    function ap<A, B>(fgab: HKT<F, HKT<G, (a: A) => B>>, fga: HKT<F, HKT<G, A>>): HKT<F, HKT<G, B>> {
-      return F.ap(F.map(h => (ga: HKT<G, A>) => G.ap<A, B>(h, ga), fgab), fga)
-    }
-
     return {
-      map,
-      of,
-      ap
+      ...getFunctorComposition(F, G),
+      of: a => F.of(G.of(a)),
+      ap: <A, B>(fgab: HKT<F, HKT<G, (a: A) => B>>, fga: HKT<F, HKT<G, A>>): HKT<F, HKT<G, B>> =>
+        F.ap(F.map(h => (ga: HKT<G, A>) => G.ap<A, B>(h, ga), fgab), fga)
     }
   }
 }

--- a/src/Applicative.ts
+++ b/src/Applicative.ts
@@ -54,36 +54,38 @@ export class Ops {
     return condition => fu => (condition ? fu : F.of(undefined))
   }
 
-  getApplicativeComposition<F extends HKT2S>(
-    F: Applicative<F>
-  ): <G extends HKT2S>(G: Applicative<G>) => ApplicativeComposition22<F, G>
-  getApplicativeComposition<F extends HKT2S>(
-    F: Applicative<F>
-  ): <G extends HKTS>(G: Applicative<G>) => ApplicativeComposition21<F, G>
-  getApplicativeComposition<F extends HKTS>(
-    F: Applicative<F>
-  ): <G extends HKT2S>(G: Applicative<G>) => ApplicativeComposition12<F, G>
-  getApplicativeComposition<F extends HKTS>(
-    F: Applicative<F>
-  ): <G extends HKTS>(G: Applicative<G>) => ApplicativeComposition11<F, G>
-  getApplicativeComposition<F>(F: Applicative<F>): <G>(G: Applicative<G>) => ApplicativeComposition<F, G>
-  getApplicativeComposition<F>(F: Applicative<F>): <G>(G: Applicative<G>) => ApplicativeComposition<F, G> {
-    return <G>(G: Applicative<G>) => {
-      const { map } = getFunctorComposition(F, G)
+  getApplicativeComposition<F extends HKT2S, G extends HKT2S>(
+    F: Applicative<F>,
+    G: Applicative<G>
+  ): ApplicativeComposition22<F, G>
+  getApplicativeComposition<F extends HKT2S, G extends HKTS>(
+    F: Applicative<F>,
+    G: Applicative<G>
+  ): ApplicativeComposition21<F, G>
+  getApplicativeComposition<F extends HKTS, G extends HKT2S>(
+    F: Applicative<F>,
+    G: Applicative<G>
+  ): ApplicativeComposition12<F, G>
+  getApplicativeComposition<F extends HKTS, G extends HKTS>(
+    F: Applicative<F>,
+    G: Applicative<G>
+  ): ApplicativeComposition11<F, G>
+  getApplicativeComposition<F, G>(F: Applicative<F>, G: Applicative<G>): ApplicativeComposition<F, G>
+  getApplicativeComposition<F, G>(F: Applicative<F>, G: Applicative<G>): ApplicativeComposition<F, G> {
+    const { map } = getFunctorComposition(F, G)
 
-      function of<A>(a: A): HKT<F, HKT<G, A>> {
-        return F.of(G.of(a))
-      }
+    function of<A>(a: A): HKT<F, HKT<G, A>> {
+      return F.of(G.of(a))
+    }
 
-      function ap<A, B>(fgab: HKT<F, HKT<G, (a: A) => B>>, fga: HKT<F, HKT<G, A>>): HKT<F, HKT<G, B>> {
-        return F.ap(F.map(h => (ga: HKT<G, A>) => G.ap<A, B>(h, ga), fgab), fga)
-      }
+    function ap<A, B>(fgab: HKT<F, HKT<G, (a: A) => B>>, fga: HKT<F, HKT<G, A>>): HKT<F, HKT<G, B>> {
+      return F.ap(F.map(h => (ga: HKT<G, A>) => G.ap<A, B>(h, ga), fgab), fga)
+    }
 
-      return {
-        map,
-        of,
-        ap
-      }
+    return {
+      map,
+      of,
+      ap
     }
   }
 }

--- a/src/Applicative.ts
+++ b/src/Applicative.ts
@@ -47,45 +47,43 @@ export interface ApplicativeComposition22<F extends HKT2S, G extends HKT2S> exte
 
 export class Ops {
   /** Perform a applicative action when a condition is true */
-  when<F extends HKT2S>(F: Applicative<F>): <L>(condition: boolean, fu: HKT2As<F, L, void>) => HKT2As<F, L, void>
-  when<F extends HKTS>(F: Applicative<F>): (condition: boolean, fu: HKTAs<F, void>) => HKTAs<F, void>
-  when<F>(F: Applicative<F>): (condition: boolean, fu: HKT<F, void>) => HKT<F, void>
-  when<F>(F: Applicative<F>): (condition: boolean, fu: HKT<F, void>) => HKT<F, void> {
-    return (condition, fu) => (condition ? fu : F.of(undefined))
+  when<F extends HKT2S>(F: Applicative<F>): (condition: boolean) => <L>(fu: HKT2As<F, L, void>) => HKT2As<F, L, void>
+  when<F extends HKTS>(F: Applicative<F>): (condition: boolean) => (fu: HKTAs<F, void>) => HKTAs<F, void>
+  when<F>(F: Applicative<F>): (condition: boolean) => (fu: HKT<F, void>) => HKT<F, void>
+  when<F>(F: Applicative<F>): (condition: boolean) => (fu: HKT<F, void>) => HKT<F, void> {
+    return condition => fu => (condition ? fu : F.of(undefined))
   }
 
-  getApplicativeComposition<F extends HKT2S, G extends HKT2S>(
-    F: Applicative<F>,
-    G: Applicative<G>
-  ): ApplicativeComposition22<F, G>
-  getApplicativeComposition<F extends HKT2S, G extends HKTS>(
-    F: Applicative<F>,
-    G: Applicative<G>
-  ): ApplicativeComposition21<F, G>
-  getApplicativeComposition<F extends HKTS, G extends HKT2S>(
-    F: Applicative<F>,
-    G: Applicative<G>
-  ): ApplicativeComposition12<F, G>
-  getApplicativeComposition<F extends HKTS, G extends HKTS>(
-    F: Applicative<F>,
-    G: Applicative<G>
-  ): ApplicativeComposition11<F, G>
-  getApplicativeComposition<F, G>(F: Applicative<F>, G: Applicative<G>): ApplicativeComposition<F, G>
-  getApplicativeComposition<F, G>(F: Applicative<F>, G: Applicative<G>): ApplicativeComposition<F, G> {
-    const { map } = getFunctorComposition(F, G)
+  getApplicativeComposition<F extends HKT2S>(
+    F: Applicative<F>
+  ): <G extends HKT2S>(G: Applicative<G>) => ApplicativeComposition22<F, G>
+  getApplicativeComposition<F extends HKT2S>(
+    F: Applicative<F>
+  ): <G extends HKTS>(G: Applicative<G>) => ApplicativeComposition21<F, G>
+  getApplicativeComposition<F extends HKTS>(
+    F: Applicative<F>
+  ): <G extends HKT2S>(G: Applicative<G>) => ApplicativeComposition12<F, G>
+  getApplicativeComposition<F extends HKTS>(
+    F: Applicative<F>
+  ): <G extends HKTS>(G: Applicative<G>) => ApplicativeComposition11<F, G>
+  getApplicativeComposition<F>(F: Applicative<F>): <G>(G: Applicative<G>) => ApplicativeComposition<F, G>
+  getApplicativeComposition<F>(F: Applicative<F>): <G>(G: Applicative<G>) => ApplicativeComposition<F, G> {
+    return <G>(G: Applicative<G>) => {
+      const { map } = getFunctorComposition(F, G)
 
-    function of<A>(a: A): HKT<F, HKT<G, A>> {
-      return F.of(G.of(a))
-    }
+      function of<A>(a: A): HKT<F, HKT<G, A>> {
+        return F.of(G.of(a))
+      }
 
-    function ap<A, B>(fgab: HKT<F, HKT<G, (a: A) => B>>, fga: HKT<F, HKT<G, A>>): HKT<F, HKT<G, B>> {
-      return F.ap(F.map(h => (ga: HKT<G, A>) => G.ap<A, B>(h, ga), fgab), fga)
-    }
+      function ap<A, B>(fgab: HKT<F, HKT<G, (a: A) => B>>, fga: HKT<F, HKT<G, A>>): HKT<F, HKT<G, B>> {
+        return F.ap(F.map(h => (ga: HKT<G, A>) => G.ap<A, B>(h, ga), fgab), fga)
+      }
 
-    return {
-      map,
-      of,
-      ap
+      return {
+        map,
+        of,
+        ap
+      }
     }
   }
 }

--- a/src/Apply.ts
+++ b/src/Apply.ts
@@ -21,82 +21,84 @@ const constIdentity = () => identity
 
 export class Ops {
   /** Combine two effectful actions, keeping only the result of the first */
-  applyFirst<F extends HKT2S>(apply: Apply<F>): <L, A, B>(fa: HKT2As<F, L, A>, fb: HKT2As<F, L, B>) => HKT2As<F, L, A>
-  applyFirst<F extends HKTS>(apply: Apply<F>): <A, B>(fa: HKTAs<F, A>, fb: HKTAs<F, B>) => HKTAs<F, A>
-  applyFirst<F>(apply: Apply<F>): <A, B>(fa: HKT<F, A>, fb: HKT<F, B>) => HKT<F, A>
-  applyFirst<F>(apply: Apply<F>): <A, B>(fa: HKT<F, A>, fb: HKT<F, B>) => HKT<F, A> {
-    return (fa, fb) => apply.ap(apply.map(a => constant(a), fa), fb)
+  applyFirst<F extends HKT2S>(
+    apply: Apply<F>
+  ): <L, A>(fa: HKT2As<F, L, A>) => <B>(fb: HKT2As<F, L, B>) => HKT2As<F, L, A>
+  applyFirst<F extends HKTS>(apply: Apply<F>): <A>(fa: HKTAs<F, A>) => <B>(fb: HKTAs<F, B>) => HKTAs<F, A>
+  applyFirst<F>(apply: Apply<F>): <A>(fa: HKT<F, A>) => <B>(fb: HKT<F, B>) => HKT<F, A>
+  applyFirst<F>(apply: Apply<F>): <A>(fa: HKT<F, A>) => <B>(fb: HKT<F, B>) => HKT<F, A> {
+    return fa => fb => apply.ap(apply.map(a => constant(a), fa), fb)
   }
 
   /** Combine two effectful actions, keeping only the result of the second */
-  applySecond<F extends HKT2S>(apply: Apply<F>): <L, A, B>(fa: HKT2As<F, L, A>, fb: HKT2As<F, L, B>) => HKT2As<F, L, B>
-  applySecond<F extends HKTS>(apply: Apply<F>): <A, B>(fa: HKTAs<F, A>, fb: HKTAs<F, B>) => HKTAs<F, B>
-  applySecond<F>(apply: Apply<F>): <A, B>(fa: HKT<F, A>, fb: HKT<F, B>) => HKT<F, B>
-  applySecond<F>(apply: Apply<F>): <A, B>(fa: HKT<F, A>, fb: HKT<F, B>) => HKT<F, B> {
-    return <A, B>(fa: HKT<F, A>, fb: HKT<F, B>) => apply.ap(apply.map(constIdentity, fa), fb)
+  applySecond<F extends HKT2S>(
+    apply: Apply<F>
+  ): <L, A>(fa: HKT2As<F, L, A>) => <B>(fb: HKT2As<F, L, B>) => HKT2As<F, L, B>
+  applySecond<F extends HKTS>(apply: Apply<F>): <A>(fa: HKTAs<F, A>) => <B>(fb: HKTAs<F, B>) => HKTAs<F, B>
+  applySecond<F>(apply: Apply<F>): <A>(fa: HKT<F, A>) => <B>(fb: HKT<F, B>) => HKT<F, B>
+  applySecond<F>(apply: Apply<F>): <A>(fa: HKT<F, A>) => <B>(fb: HKT<F, B>) => HKT<F, B> {
+    return fa => fb => apply.ap(apply.map(constIdentity, fa), fb)
   }
 
   /**
    * Lift a function of two arguments to a function which accepts and returns
    * values wrapped with the type constructor `F`
    */
-  liftA2<F extends HKT2S, A, B, C>(
-    apply: Apply<F>,
-    f: Curried2<A, B, C>
-  ): <L>(fa: HKT2As<F, L, A>, fb: HKT2As<F, L, B>) => HKT2As<F, L, C>
-  liftA2<F extends HKTS, A, B, C>(
-    apply: Apply<F>,
-    f: Curried2<A, B, C>
-  ): (fa: HKTAs<F, A>, fb: HKTAs<F, B>) => HKTAs<F, C>
-  liftA2<F, A, B, C>(apply: Apply<F>, f: Curried2<A, B, C>): (fa: HKT<F, A>, fb: HKT<F, B>) => HKT<F, C>
-  liftA2<F, A, B, C>(apply: Apply<F>, f: Curried2<A, B, C>): (fa: HKT<F, A>, fb: HKT<F, B>) => HKT<F, C> {
-    return (fa, fb) => apply.ap(apply.map(f, fa), fb)
+  liftA2<F extends HKT2S>(
+    apply: Apply<F>
+  ): <A, B, C>(f: Curried2<A, B, C>) => <L>(fa: HKT2As<F, L, A>) => (fb: HKT2As<F, L, B>) => HKT2As<F, L, C>
+  liftA2<F extends HKTS>(
+    apply: Apply<F>
+  ): <A, B, C>(f: Curried2<A, B, C>) => Curried2<HKTAs<F, A>, HKTAs<F, B>, HKTAs<F, C>>
+  liftA2<F>(apply: Apply<F>): <A, B, C>(f: Curried2<A, B, C>) => Curried2<HKT<F, A>, HKT<F, B>, HKT<F, C>>
+  liftA2<F>(apply: Apply<F>): <A, B, C>(f: Curried2<A, B, C>) => Curried2<HKT<F, A>, HKT<F, B>, HKT<F, C>> {
+    return f => fa => fb => apply.ap(apply.map(f, fa), fb)
   }
 
   /**
    * Lift a function of three arguments to a function which accepts and returns
    * values wrapped with the type constructor `F`
    */
-  liftA3<F extends HKT2S, A, B, C, D>(
-    apply: Apply<F>,
+  liftA3<F extends HKT2S>(
+    apply: Apply<F>
+  ): <A, B, C, D>(
     f: Curried3<A, B, C, D>
-  ): <L>(fa: HKT2As<F, L, A>, fb: HKT2As<F, L, B>, fc: HKT2As<F, L, C>) => HKT2As<F, L, D>
-  liftA3<F extends HKTS, A, B, C, D>(
-    apply: Apply<F>,
-    f: Curried3<A, B, C, D>
-  ): (fa: HKTAs<F, A>, fb: HKTAs<F, B>, fc: HKTAs<F, C>) => HKTAs<F, D>
-  liftA3<F, A, B, C, D>(
-    apply: Apply<F>,
-    f: Curried3<A, B, C, D>
-  ): (fa: HKT<F, A>, fb: HKT<F, B>, fc: HKT<F, C>) => HKT<F, D>
-  liftA3<F, A, B, C, D>(
-    apply: Apply<F>,
-    f: Curried3<A, B, C, D>
-  ): (fa: HKT<F, A>, fb: HKT<F, B>, fc: HKT<F, C>) => HKT<F, D> {
-    return (fa, fb, fc) => apply.ap(apply.ap(apply.map(f, fa), fb), fc)
+  ) => <L>(fa: HKT2As<F, L, A>) => (fb: HKT2As<F, L, B>) => (fc: HKT2As<F, L, C>) => HKT2As<F, L, D>
+  liftA3<F extends HKTS>(
+    apply: Apply<F>
+  ): <A, B, C, D>(f: Curried3<A, B, C, D>) => Curried3<HKTAs<F, A>, HKTAs<F, B>, HKTAs<F, C>, HKTAs<F, D>>
+  liftA3<F>(
+    apply: Apply<F>
+  ): <A, B, C, D>(f: Curried3<A, B, C, D>) => Curried3<HKT<F, A>, HKT<F, B>, HKT<F, C>, HKT<F, D>>
+  liftA3<F>(
+    apply: Apply<F>
+  ): <A, B, C, D>(f: Curried3<A, B, C, D>) => Curried3<HKT<F, A>, HKT<F, B>, HKT<F, C>, HKT<F, D>> {
+    return f => fa => fb => fc => apply.ap(apply.ap(apply.map(f, fa), fb), fc)
   }
 
   /**
    * Lift a function of four arguments to a function which accepts and returns
    * values wrapped with the type constructor `F`
    */
-  liftA4<F extends HKT2S, A, B, C, D, E>(
-    apply: Apply<F>,
+  liftA4<F extends HKT2S>(
+    apply: Apply<F>
+  ): <A, B, C, D, E>(
     f: Curried4<A, B, C, D, E>
-  ): <L>(fa: HKT2As<F, L, A>, fb: HKT2As<F, L, B>, fc: HKT2As<F, L, C>, fd: HKT2As<F, L, D>) => HKT2As<F, L, E>
-  liftA4<F extends HKTS, A, B, C, D, E>(
-    apply: Apply<F>,
+  ) => <L>(
+    fa: HKT2As<F, L, A>
+  ) => (fb: HKT2As<F, L, B>) => (fc: HKT2As<F, L, C>) => (fd: HKT2As<F, L, D>) => HKT2As<F, L, E>
+  liftA4<F extends HKTS>(
+    apply: Apply<F>
+  ): <A, B, C, D, E>(
     f: Curried4<A, B, C, D, E>
-  ): (fa: HKTAs<F, A>, fb: HKTAs<F, B>, fc: HKTAs<F, C>, fd: HKTAs<F, D>) => HKTAs<F, E>
-  liftA4<F, A, B, C, D, E>(
-    apply: Apply<F>,
-    f: Curried4<A, B, C, D, E>
-  ): (fa: HKT<F, A>, fb: HKT<F, B>, fc: HKT<F, C>, fd: HKT<F, D>) => HKT<F, E>
-  liftA4<F, A, B, C, D, E>(
-    apply: Apply<F>,
-    f: Curried4<A, B, C, D, E>
-  ): (fa: HKT<F, A>, fb: HKT<F, B>, fc: HKT<F, C>, fd: HKT<F, D>) => HKT<F, E> {
-    return (fa, fb, fc, fd) => apply.ap(apply.ap(apply.ap(apply.map(f, fa), fb), fc), fd)
+  ) => Curried4<HKTAs<F, A>, HKTAs<F, B>, HKTAs<F, C>, HKTAs<F, D>, HKTAs<F, E>>
+  liftA4<F>(
+    apply: Apply<F>
+  ): <A, B, C, D, E>(f: Curried4<A, B, C, D, E>) => Curried4<HKT<F, A>, HKT<F, B>, HKT<F, C>, HKT<F, D>, HKT<F, E>>
+  liftA4<F>(
+    apply: Apply<F>
+  ): <A, B, C, D, E>(f: Curried4<A, B, C, D, E>) => Curried4<HKT<F, A>, HKT<F, B>, HKT<F, C>, HKT<F, D>, HKT<F, E>> {
+    return f => fa => fb => fc => fd => apply.ap(apply.ap(apply.ap(apply.map(f, fa), fb), fc), fd)
   }
 }
 

--- a/src/Apply.ts
+++ b/src/Apply.ts
@@ -3,21 +3,19 @@ import { Functor, FantasyFunctor } from './Functor'
 import { Curried2, Curried3, Curried4, identity, constant } from './function'
 
 export interface Apply<F> extends Functor<F> {
-  ap<A, B>(fab: HKT<F, (a: A) => B>, fa: HKT<F, A>): HKT<F, B>
+  ap: <A, B>(fab: HKT<F, (a: A) => B>, fa: HKT<F, A>) => HKT<F, B>
 }
 
 /*
 
   Implementations of FantasyApply may choose to also implement
 
-  ap_<B, C>(this: HKT<F, (a: A) => B>, fb: HKT<F, B>): HKT<F, C>
+  ap_: <B, C>(this: HKT<F, (a: A) => B>, fb: HKT<F, B>) => HKT<F, C>
 
 */
 export interface FantasyApply<F, A> extends FantasyFunctor<F, A> {
-  ap<B>(fab: HKT<F, (a: A) => B>): HKT<F, B>
+  ap: <B>(fab: HKT<F, (a: A) => B>) => HKT<F, B>
 }
-
-const constIdentity = () => identity
 
 export class Ops {
   /** Combine two effectful actions, keeping only the result of the first */
@@ -37,7 +35,7 @@ export class Ops {
   applySecond<F extends HKTS>(apply: Apply<F>): <A>(fa: HKTAs<F, A>) => <B>(fb: HKTAs<F, B>) => HKTAs<F, B>
   applySecond<F>(apply: Apply<F>): <A>(fa: HKT<F, A>) => <B>(fb: HKT<F, B>) => HKT<F, B>
   applySecond<F>(apply: Apply<F>): <A>(fa: HKT<F, A>) => <B>(fb: HKT<F, B>) => HKT<F, B> {
-    return fa => fb => apply.ap(apply.map(constIdentity, fa), fb)
+    return fa => fb => apply.ap(apply.map(() => identity, fa), fb)
   }
 
   /**

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -37,7 +37,7 @@ export type URI = typeof URI
 
 export const empty: Lazy<Array<any>> = constant([])
 
-export function concat<A>(x: Array<A>, y: Array<A>): Array<A> {
+export const concat = <A>(x: Array<A>) => (y: Array<A>): Array<A> => {
   return x.concat(y)
 }
 

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -3,6 +3,7 @@ import { Monoid } from './Monoid'
 import { Applicative } from './Applicative'
 import { Monad } from './Monad'
 import { Foldable } from './Foldable'
+import { Unfoldable } from './Unfoldable'
 import { Traversable } from './Traversable'
 import { Alternative } from './Alternative'
 import { Plus } from './Plus'
@@ -14,7 +15,7 @@ import { Extend } from './Extend'
 import { Filterable } from './Filterable'
 import { Either } from './Either'
 import { Witherable } from './Witherable'
-import { Predicate, identity, constant, curry, Lazy, Endomorphism, Refinement, tuple } from './function'
+import { Predicate, identity, constant, Lazy, Endomorphism, Refinement, tuple, not } from './function'
 
 // Adapted from https://github.com/purescript/purescript-arrays
 
@@ -37,31 +38,19 @@ export type URI = typeof URI
 
 export const empty: Lazy<Array<any>> = constant([])
 
-export const concat = <A>(x: Array<A>) => (y: Array<A>): Array<A> => {
-  return x.concat(y)
-}
+export const concat = <A>(x: Array<A>) => (y: Array<A>): Array<A> => x.concat(y)
 
-export function map<A, B>(f: (a: A) => B, fa: Array<A>): Array<B> {
-  return fa.map(f)
-}
+export const map = <A, B>(f: (a: A) => B, fa: Array<A>): Array<B> => fa.map(f)
 
-export function of<A>(a: A): Array<A> {
-  return [a]
-}
+export const of = <A>(a: A): Array<A> => [a]
 
-export function ap<A, B>(fab: Array<(a: A) => B>, fa: Array<A>): Array<B> {
-  return fab.reduce((acc: Array<B>, f) => acc.concat(fa.map(f)), [])
-}
+export const ap = <A, B>(fab: Array<(a: A) => B>, fa: Array<A>): Array<B> =>
+  fab.reduce((acc, f) => acc.concat(fa.map(f)), [] as Array<B>)
 
-export function chain<A, B>(f: (a: A) => Array<B>, fa: Array<A>): Array<B> {
-  return fa.reduce((acc: Array<B>, a) => acc.concat(f(a)), [])
-}
+export const chain = <A, B>(f: (a: A) => Array<B>, fa: Array<A>): Array<B> =>
+  fa.reduce((acc, a) => acc.concat(f(a)), [] as Array<B>)
 
-export function reduce<A, B>(f: (b: B, a: A) => B, b: B, fa: Array<A>): B {
-  return fa.reduce(f, b)
-}
-
-export const curriedSnoc: <A>(a: Array<A>) => (b: A) => Array<A> = curry(snoc)
+export const reduce = <A, B>(f: (b: B, a: A) => B, b: B, fa: Array<A>): B => fa.reduce(f, b)
 
 export class Ops {
   traverse<F extends HKT2S>(
@@ -70,8 +59,8 @@ export class Ops {
   traverse<F extends HKTS>(F: Applicative<F>): <A, B>(f: (a: A) => HKTAs<F, B>, ta: Array<A>) => HKTAs<F, Array<B>>
   traverse<F>(F: Applicative<F>): <A, B>(f: (a: A) => HKT<F, B>, ta: Array<A>) => HKT<F, Array<B>>
   traverse<F>(F: Applicative<F>): <A, B>(f: (a: A) => HKT<F, B>, ta: Array<A>) => HKT<F, Array<B>> {
-    const snocA2: <A>(fa: HKT<F, Array<A>>, fb: HKT<F, A>) => HKT<F, Array<A>> = liftA2(F, curriedSnoc)
-    return (f, ta) => reduce((fab, a) => snocA2(fab, f(a)), F.of(empty()), ta)
+    const liftedSnoc: <A>(fa: HKT<F, Array<A>>, fb: HKT<F, A>) => HKT<F, Array<A>> = liftA2(F, snoc)
+    return (f, ta) => reduce((fab, a) => liftedSnoc(fab, f(a)), F.of(empty()), ta)
   }
 }
 
@@ -82,7 +71,7 @@ export const zero = empty
 
 export const alt = <A>(x: Array<A>) => (y: Array<A>): Array<A> => x.concat(y)
 
-export function unfoldr<A, B>(f: (b: B) => Option<[A, B]>, b: B): Array<A> {
+export const unfoldr = <A, B>(f: (b: B) => Option<[A, B]>, b: B): Array<A> => {
   const ret: Array<A> = []
   let bb = b
   while (true) {
@@ -98,77 +87,92 @@ export function unfoldr<A, B>(f: (b: B) => Option<[A, B]>, b: B): Array<A> {
   return ret
 }
 
-export function extend<A, B>(f: (fa: Array<A>) => B, fa: Array<A>): Array<B> {
-  return fa.map((_, i, as) => f(as.slice(i)))
+export const extend = <A, B>(f: (fa: Array<A>) => B, fa: Array<A>): Array<B> => fa.map((_, i, as) => f(as.slice(i)))
+
+export const partitionMap = <A, L, R>(f: (a: A) => Either<L, R>, fa: Array<A>): { left: Array<L>; right: Array<R> } => {
+  const left: Array<L> = []
+  const right: Array<R> = []
+  for (let i = 0; i < fa.length; i++) {
+    f(fa[i]).fold(l => left.push(l), r => right.push(r))
+  }
+  return { left, right }
 }
 
-export function fold<A, B>(nil: Lazy<B>, cons: (head: A, tail: Array<A>) => B, as: Array<A>): B {
-  return as.length === 0 ? nil() : cons(as[0], as.slice(1))
-}
+export const wilt = <M>(M: Applicative<M>) => <A, L, R>(
+  f: (a: A) => HKT<M, Either<L, R>>,
+  ta: Array<A>
+): HKT<M, { left: Array<L>; right: Array<R> }> => M.map(es => partitionMap(e => e, es), traverse(M)(f, ta))
 
-export function length<A>(as: Array<A>): number {
-  return as.length
-}
+/** Break an array into its first element and remaining elements */
+export const fold = <A, B>(nil: Lazy<B>, cons: (head: A, tail: Array<A>) => B, as: Array<A>): B =>
+  as.length === 0 ? nil() : cons(as[0], as.slice(1))
 
-export function isEmpty<A>(as: Array<A>): boolean {
-  return length(as) === 0
-}
+/** Get the number of elements in an array */
+export const length = <A>(as: Array<A>): number => as.length
 
-export function isOutOfBound<A>(i: number, as: Array<A>): boolean {
-  return i < 0 || i >= as.length
-}
+/** Test whether an array is empty */
+export const isEmpty = <A>(as: Array<A>): boolean => length(as) === 0
 
-export function index<A>(as: Array<A>, i: number): Option<A> {
-  return isOutOfBound(i, as) ? option.none : option.some(as[i])
-}
+/** Test whether an array contains a particular index */
+export const isOutOfBound = (i: number) => <A>(as: Array<A>): boolean => i < 0 || i >= as.length
 
-export function cons<A>(a: A, as: Array<A>): Array<A> {
-  return [a].concat(as)
-}
+/** This function provides a safe way to read a value at a particular index from an array */
+export const index = (i: number) => <A>(as: Array<A>): Option<A> =>
+  isOutOfBound(i)(as) ? option.none : option.some(as[i])
 
-export function snoc<A>(as: Array<A>, a: A): Array<A> {
-  return as.concat([a])
-}
+/** Attaches an element to the front of an array, creating a new array */
+export const cons = <A>(a: A) => (as: Array<A>): Array<A> => [a].concat(as)
 
-export function head<A>(as: Array<A>): Option<A> {
-  return isEmpty(as) ? option.none : option.some(as[0])
-}
+/** Append an element to the end of an array, creating a new array */
+export const snoc = <A>(as: Array<A>) => (a: A): Array<A> => as.concat([a])
 
-export function last<A>(as: Array<A>): Option<A> {
-  return index(as, length(as) - 1)
-}
+/** Get the first element in an array, or `None` if the array is empty */
+export const head = <A>(as: Array<A>): Option<A> => (isEmpty(as) ? option.none : option.some(as[0]))
 
-export function tail<A>(as: Array<A>): Option<Array<A>> {
+/** Get the last element in an array, or `None` if the array is empty */
+export const last = <A>(as: Array<A>): Option<A> => index(length(as) - 1)(as)
+
+/**
+ * Get all but the first element of an array, creating a new array, or
+ * `None` if the array is empty
+ */
+export const tail = <A>(as: Array<A>): Option<Array<A>> => {
   const len = as.length
   return len === 0 ? option.none : option.some(as.slice(1))
 }
 
-export function slice<A>(start: number, end: number, as: Array<A>): Array<A> {
-  return as.slice(start, end)
-}
+/** Extract a subarray by a start and end index */
+export const slice = (start: number, end: number) => <A>(as: Array<A>): Array<A> => as.slice(start, end)
 
-export function init<A>(as: Array<A>): Option<Array<A>> {
+/**
+ * Get all but the last element of an array, creating a new array, or
+ * `None` if the array is empty
+ */
+export const init = <A>(as: Array<A>): Option<Array<A>> => {
   const len = as.length
   return len === 0 ? option.none : option.some(as.slice(0, len - 1))
 }
 
-export function take<A>(n: number, as: Array<A>): Array<A> {
-  return slice(0, n, as)
-}
+/** Keep only a number of elements from the start of an array, creating a new array */
+export const take = (n: number) => <A>(as: Array<A>): Array<A> => slice(0, n)(as)
 
-export function takeWhile<A>(predicate: Predicate<A>, as: Array<A>): Array<A> {
-  return as.slice().filter(predicate)
-}
+/**
+ * Calculate the longest initial subarray for which all element satisfy the
+ * specified predicate, creating a new array
+ */
+export const takeWhile = <A>(predicate: Predicate<A>) => (as: Array<A>): Array<A> => as.slice().filter(predicate)
 
-export function drop<A>(n: number, as: Array<A>): Array<A> {
-  return slice(n, length(as), as)
-}
+/** Drop a number of elements from the start of an array, creating a new array */
+export const drop = (n: number) => <A>(as: Array<A>): Array<A> => slice(n, length(as))(as)
 
-export function dropWhile<A>(predicate: Predicate<A>, as: Array<A>): Array<A> {
-  return takeWhile(a => !predicate(a), as)
-}
+/**
+ * Remove the longest initial subarray for which all element satisfy the
+ * specified predicate, creating a new array
+ */
+export const dropWhile = <A>(predicate: Predicate<A>) => (as: Array<A>): Array<A> => takeWhile(not(predicate))(as)
 
-export function findIndex<A>(predicate: Predicate<A>, as: Array<A>): Option<number> {
+/** Find the first index for which a predicate holds */
+export const findIndex = <A>(predicate: Predicate<A>) => (as: Array<A>): Option<number> => {
   const len = as.length
   for (let i = 0; i < len; i++) {
     if (predicate(as[i])) {
@@ -178,89 +182,85 @@ export function findIndex<A>(predicate: Predicate<A>, as: Array<A>): Option<numb
   return option.none
 }
 
-export function filter<A>(predicate: Predicate<A>, as: Array<A>): Array<A> {
-  return as.filter(predicate)
-}
+/** Filter an array, keeping the elements which satisfy a predicate function, creating a new array */
+export const filter = <A>(predicate: Predicate<A>) => (as: Array<A>): Array<A> => as.filter(predicate)
 
-export function refine<A>(as: Array<A>): <B extends A>(refinement: Refinement<A, B>) => Array<B> {
-  return <B extends A>(refinement: Refinement<A, B>) => as.filter(refinement) as Array<B>
-}
+export const refine = <A>(as: Array<A>) => <B extends A>(refinement: Refinement<A, B>): Array<B> =>
+  as.filter(refinement)
 
-export function copy<A>(as: Array<A>): Array<A> {
-  return as.slice()
-}
+export const copy = <A>(as: Array<A>): Array<A> => as.slice()
 
-export function unsafeInsertAt<A>(i: number, a: A, as: Array<A>): Array<A> {
+export const unsafeInsertAt = (i: number) => <A>(a: A) => (as: Array<A>): Array<A> => {
   const xs = copy(as)
   xs.splice(i, 0, a)
   return xs
 }
 
-export function insertAt<A>(i: number, a: A, as: Array<A>): Option<Array<A>> {
-  return i < 0 || i > as.length ? option.none : option.some(unsafeInsertAt(i, a, as))
-}
+/**
+ * Insert an element at the specified index, creating a new array, or
+ * returning `None` if the index is out of bounds
+ */
+export const insertAt = (i: number) => <A>(a: A) => (as: Array<A>): Option<Array<A>> =>
+  i < 0 || i > as.length ? option.none : option.some(unsafeInsertAt(i)(a)(as))
 
-export function unsafeUpdateAt<A>(i: number, a: A, as: Array<A>): Array<A> {
+export const unsafeUpdateAt = (i: number) => <A>(a: A) => (as: Array<A>): Array<A> => {
   const xs = copy(as)
   xs[i] = a
   return xs
 }
 
-export function updateAt<A>(i: number, a: A, as: Array<A>): Option<Array<A>> {
-  return isOutOfBound(i, as) ? option.none : option.some(unsafeUpdateAt(i, a, as))
-}
+/**
+ * Change the element at the specified index, creating a new array, or
+ * returning `None` if the index is out of bounds
+ */
+export const updateAt = (i: number) => <A>(a: A) => (as: Array<A>): Option<Array<A>> =>
+  isOutOfBound(i)(as) ? option.none : option.some(unsafeUpdateAt(i)(a)(as))
 
-export function unsafeDeleteAt<A>(i: number, as: Array<A>): Array<A> {
+export const unsafeDeleteAt = (i: number) => <A>(as: Array<A>): Array<A> => {
   const xs = copy(as)
   xs.splice(i, 1)
   return xs
 }
 
-export function deleteAt<A>(i: number, as: Array<A>): Option<Array<A>> {
-  return isOutOfBound(i, as) ? option.none : option.some(unsafeDeleteAt(i, as))
-}
+/**
+ * Delete the element at the specified index, creating a new array, or
+ * returning `None` if the index is out of bounds
+ */
+export const deleteAt = (i: number) => <A>(as: Array<A>): Option<Array<A>> =>
+  isOutOfBound(i)(as) ? option.none : option.some(unsafeDeleteAt(i)(as))
 
-export function modifyAt<A>(i: number, f: Endomorphism<A>, as: Array<A>): Option<Array<A>> {
-  return isOutOfBound(i, as) ? option.none : updateAt(i, f(as[i]), as)
-}
+/**
+ * Apply a function to the element at the specified index, creating a new
+ * array, or returning `Nothing` if the index is out of bounds
+ */
+export const modifyAt = (i: number) => <A>(f: Endomorphism<A>) => (as: Array<A>): Option<Array<A>> =>
+  isOutOfBound(i)(as) ? option.none : updateAt(i)(f(as[i]))(as)
 
-export function reverse<A>(as: Array<A>): Array<A> {
-  return copy(as).reverse()
-}
+/** Reverse an array, creating a new array */
+export const reverse = <A>(as: Array<A>): Array<A> => copy(as).reverse()
 
-export function mapOption<A, B>(f: (a: A) => Option<B>, as: Array<A>): Array<B> {
-  return chain(a => option.fold(empty, of, f(a)), as)
-}
+/**
+ * Apply a function to each element in an array, keeping only the results
+ * which contain a value, creating a new array
+ */
+export const mapOption = <A, B>(f: (a: A) => Option<B>) => (as: Array<A>): Array<B> =>
+  chain(a => option.fold(empty, of, f(a)), as)
 
-export function catOptions<A>(as: Array<Option<A>>): Array<A> {
-  return mapOption<Option<A>, A>(identity, as)
-}
+/**
+ * Filter an array of optional values, keeping only the elements which contain
+ * a value, creating a new array
+ */
+export const catOptions = <A>(as: Array<Option<A>>): Array<A> => mapOption<Option<A>, A>(identity)(as)
 
-export function sort<A>(ord: Ord<A>, as: Array<A>): Array<A> {
-  return copy(as).sort(toNativeComparator(ord.compare))
-}
-
-export function partitionMap<A, L, R>(f: (a: A) => Either<L, R>, fa: Array<A>): { left: Array<L>; right: Array<R> } {
-  const left: Array<L> = []
-  const right: Array<R> = []
-  for (let i = 0; i < fa.length; i++) {
-    f(fa[i]).fold(l => left.push(l), r => right.push(r))
-  }
-  return { left, right }
-}
-
-export function wilt<M>(
-  M: Applicative<M>
-): <A, L, R>(f: (a: A) => HKT<M, Either<L, R>>, ta: Array<A>) => HKT<M, { left: Array<L>; right: Array<R> }> {
-  return (f, ta) => M.map(es => partitionMap(e => e, es), traverse(M)(f, ta))
-}
+/** Sort the elements of an array in increasing order, creating a new array */
+export const sort = <A>(ord: Ord<A>) => (as: Array<A>): Array<A> => copy(as).sort(toNativeComparator(ord.compare))
 
 /**
  * Apply a function to pairs of elements at the same index in two arrays,
  * collecting the results in a new array,
  * If one input array is short, excess elements of the longer array are discarded
  */
-export function zipWith<A, B, C>(f: (a: A, b: B) => C, fa: Array<A>, fb: Array<B>): Array<C> {
+export const zipWith = <A, B, C>(f: (a: A, b: B) => C) => (fa: Array<A>) => (fb: Array<B>): Array<C> => {
   const fc = []
   const len = Math.min(fa.length, fb.length)
   for (let i = 0; i < len; i++) {
@@ -273,13 +273,12 @@ export function zipWith<A, B, C>(f: (a: A, b: B) => C, fa: Array<A>, fb: Array<B
  * Takes two arrays and returns an array of corresponding pairs.
  * If one input array is short, excess elements of the longer array are discarded
  */
-export function zip<A, B>(fa: Array<A>, fb: Array<B>): Array<[A, B]> {
-  return zipWith<A, B, [A, B]>(tuple, fa, fb)
-}
+export const zip = <A>(fa: Array<A>) => <B>(fb: Array<B>): Array<[A, B]> => zipWith<A, B, [A, B]>(tuple)(fa)(fb)
 
 export const array: Monoid<Array<any>> &
   Monad<URI> &
   Foldable<URI> &
+  Unfoldable<URI> &
   Traversable<URI> &
   Alternative<URI> &
   Plus<URI> &
@@ -294,6 +293,7 @@ export const array: Monoid<Array<any>> &
   ap,
   chain,
   reduce,
+  unfoldr,
   traverse,
   zero,
   alt,

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -80,7 +80,7 @@ export const traverse: Ops['traverse'] = ops.traverse
 
 export const zero = empty
 
-export const alt = concat
+export const alt = <A>(x: Array<A>) => (y: Array<A>): Array<A> => x.concat(y)
 
 export function unfoldr<A, B>(f: (b: B) => Option<[A, B]>, b: B): Array<A> {
   const ret: Array<A> = []

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -59,8 +59,8 @@ export class Ops {
   traverse<F extends HKTS>(F: Applicative<F>): <A, B>(f: (a: A) => HKTAs<F, B>, ta: Array<A>) => HKTAs<F, Array<B>>
   traverse<F>(F: Applicative<F>): <A, B>(f: (a: A) => HKT<F, B>, ta: Array<A>) => HKT<F, Array<B>>
   traverse<F>(F: Applicative<F>): <A, B>(f: (a: A) => HKT<F, B>, ta: Array<A>) => HKT<F, Array<B>> {
-    const liftedSnoc: <A>(fa: HKT<F, Array<A>>, fb: HKT<F, A>) => HKT<F, Array<A>> = liftA2(F, snoc)
-    return (f, ta) => reduce((fab, a) => liftedSnoc(fab, f(a)), F.of(empty()), ta)
+    const liftedSnoc: <A>(fa: HKT<F, Array<A>>) => (fb: HKT<F, A>) => HKT<F, Array<A>> = liftA2(F)(snoc)
+    return (f, ta) => reduce((fab, a) => liftedSnoc(fab)(f(a)), F.of(empty()), ta)
   }
 }
 

--- a/src/Bifunctor.ts
+++ b/src/Bifunctor.ts
@@ -6,5 +6,5 @@ export interface Bifunctor<F> {
 }
 
 export interface FantasyBifunctor<F, L, A> {
-  bimap<M, B>(f: (l: L) => M, g: (a: A) => B): HKT2<F, M, B>
+  bimap: <M, B>(f: (l: L) => M, g: (a: A) => B) => HKT2<F, M, B>
 }

--- a/src/Bifunctor.ts
+++ b/src/Bifunctor.ts
@@ -2,7 +2,7 @@ import { HKT2 } from './HKT'
 
 export interface Bifunctor<F> {
   readonly URI: F
-  bimap<L, A, M, B>(f: (u: L) => M, g: (a: A) => B, fla: HKT2<F, L, A>): HKT2<F, M, B>
+  bimap: <L, A, M, B>(f: (u: L) => M, g: (a: A) => B) => (fla: HKT2<F, L, A>) => HKT2<F, M, B>
 }
 
 export interface FantasyBifunctor<F, L, A> {

--- a/src/Chain.ts
+++ b/src/Chain.ts
@@ -3,11 +3,11 @@ import { Apply, FantasyApply } from './Apply'
 import { Kleisli } from './function'
 
 export interface Chain<F> extends Apply<F> {
-  chain<A, B>(f: Kleisli<F, A, B>, fa: HKT<F, A>): HKT<F, B>
+  chain: <A, B>(f: Kleisli<F, A, B>, fa: HKT<F, A>) => HKT<F, B>
 }
 
 export interface FantasyChain<F, A> extends FantasyApply<F, A> {
-  chain<B>(f: Kleisli<F, A, B>): HKT<F, B>
+  chain: <B>(f: Kleisli<F, A, B>) => HKT<F, B>
 }
 
 export class Ops {

--- a/src/ChainRec.ts
+++ b/src/ChainRec.ts
@@ -4,11 +4,11 @@ import { Either } from './Either'
 import { isLeft } from './Either'
 
 export interface ChainRec<F> extends Chain<F> {
-  chainRec<A, B>(f: (a: A) => HKT<F, Either<A, B>>, a: A): HKT<F, B>
+  chainRec: <A, B>(f: (a: A) => HKT<F, Either<A, B>>, a: A) => HKT<F, B>
 }
 
 export interface FantasyChainRec<F, A> extends FantasyChain<F, A> {
-  chainRec<A, B>(f: (a: A) => HKT<F, Either<A, B>>): HKT<F, B>
+  chainRec: <A, B>(f: (a: A) => HKT<F, Either<A, B>>) => HKT<F, B>
 }
 
 export const tailRec = <A, B>(f: (a: A) => Either<A, B>, a: A): B => {

--- a/src/ChainRec.ts
+++ b/src/ChainRec.ts
@@ -11,7 +11,7 @@ export interface FantasyChainRec<F, A> extends FantasyChain<F, A> {
   chainRec<A, B>(f: (a: A) => HKT<F, Either<A, B>>): HKT<F, B>
 }
 
-export function tailRec<A, B>(f: (a: A) => Either<A, B>, a: A): B {
+export const tailRec = <A, B>(f: (a: A) => Either<A, B>, a: A): B => {
   let v = f(a)
   while (isLeft(v)) {
     v = f(v.value)

--- a/src/Comonad.ts
+++ b/src/Comonad.ts
@@ -2,9 +2,9 @@ import { HKT } from './HKT'
 import { Extend, FantasyExtend } from './Extend'
 
 export interface Comonad<F> extends Extend<F> {
-  extract<A>(ca: HKT<F, A>): A
+  extract: <A>(ca: HKT<F, A>) => A
 }
 
 export interface FantasyComonad<F, A> extends FantasyExtend<F, A> {
-  extract(): A
+  extract: () => A
 }

--- a/src/Console.ts
+++ b/src/Console.ts
@@ -2,18 +2,10 @@ import { IO } from './IO'
 
 // Adapted from https://github.com/purescript/purescript-console
 
-export function log(s: any): IO<void> {
-  return new IO(() => console.log(s))
-}
+export const log = (s: any): IO<void> => new IO(() => console.log(s))
 
-export function warn(s: any): IO<void> {
-  return new IO(() => console.warn(s))
-}
+export const warn = (s: any): IO<void> => new IO(() => console.warn(s))
 
-export function error(s: any): IO<void> {
-  return new IO(() => console.error(s))
-}
+export const error = (s: any): IO<void> => new IO(() => console.error(s))
 
-export function info(s: any): IO<void> {
-  return new IO(() => console.info(s))
-}
+export const info = (s: any): IO<void> => new IO(() => console.info(s))

--- a/src/Const.ts
+++ b/src/Const.ts
@@ -21,7 +21,7 @@ export class Const<L, A> implements FantasyFunctor<URI, A>, FantasyContravariant
   readonly _A: A
   readonly _L: L
   readonly _URI: URI
-  constructor(public readonly value: L) {}
+  constructor(readonly value: L) {}
   map<B, C>(f: (b: B) => C): Const<L, C> {
     return this as any
   }
@@ -46,40 +46,30 @@ export const equals = <L>(S: Setoid<L>) => <A>(fx: Const<L, A>) => (fy: Const<L,
   return fx.equals(S, fy)
 }
 
-export function getSetoid<L, A>(S: Setoid<L>): Setoid<Const<L, A>> {
-  return {
-    equals: x => y => equals(S)(x)(y)
-  }
-}
+export const getSetoid = <L, A>(S: Setoid<L>): Setoid<Const<L, A>> => ({
+  equals: x => y => equals(S)(x)(y)
+})
 
-export function map<L, A, B>(f: (a: A) => B, fa: Const<L, A>): Const<L, B> {
-  return fa.map(f)
-}
+export const map = <L, A, B>(f: (a: A) => B, fa: Const<L, A>): Const<L, B> => fa.map(f)
 
-export function contramap<L, A>(fa: Const<L, A>): <B>(f: (b: B) => A) => Const<L, B> {
-  return <B>(f: (b: B) => A) => fa.contramap(f)
-}
+export const contramap = <L, A>(fa: Const<L, A>): (<B>(f: (b: B) => A) => Const<L, B>) => <B>(f: (b: B) => A) =>
+  fa.contramap(f)
 
-export function getApply<L>(S: Semigroup<L>): Apply<URI> {
-  function ap<A, B>(fab: Const<L, (a: A) => B>, fa: Const<L, A>): Const<L, B> {
+export const getApply = <L>(S: Semigroup<L>): Apply<URI> => ({
+  URI,
+  map,
+  ap<A, B>(fab: Const<L, (a: A) => B>, fa: Const<L, A>): Const<L, B> {
     return new Const(S.concat(fab.fold(identity))(fa.fold(identity)))
   }
-  return {
-    URI,
-    map,
-    ap
-  }
-}
+})
 
-export function getApplicative<L>(M: Monoid<L>): Applicative<URI> {
-  const apply = getApply(M)
+export const getApplicative = <L>(M: Monoid<L>): Applicative<URI> => {
   const empty = new Const<L, any>(M.empty())
-  function of<A>(b: A): Const<L, A> {
-    return empty
-  }
   return {
-    ...apply,
-    of
+    ...getApply(M),
+    of<A>(b: A): Const<L, A> {
+      return empty
+    }
   }
 }
 

--- a/src/Const.ts
+++ b/src/Const.ts
@@ -42,13 +42,13 @@ export class Const<L, A> implements FantasyFunctor<URI, A>, FantasyContravariant
   }
 }
 
-export function equals<L, A>(S: Setoid<L>, fx: Const<L, A>, fy: Const<L, A>): boolean {
+export const equals = <L>(S: Setoid<L>) => <A>(fx: Const<L, A>) => (fy: Const<L, A>): boolean => {
   return fx.equals(S, fy)
 }
 
 export function getSetoid<L, A>(S: Setoid<L>): Setoid<Const<L, A>> {
   return {
-    equals: x => y => equals(S, x, y)
+    equals: x => y => equals(S)(x)(y)
   }
 }
 
@@ -83,4 +83,8 @@ export function getApplicative<L>(M: Monoid<L>): Applicative<URI> {
   }
 }
 
-export const const_: Functor<URI> & Contravariant<URI> = { URI, map, contramap }
+export const const_: Functor<URI> & Contravariant<URI> = {
+  URI,
+  map,
+  contramap
+}

--- a/src/Const.ts
+++ b/src/Const.ts
@@ -62,7 +62,7 @@ export function contramap<L, A>(fa: Const<L, A>): <B>(f: (b: B) => A) => Const<L
 
 export function getApply<L>(S: Semigroup<L>): Apply<URI> {
   function ap<A, B>(fab: Const<L, (a: A) => B>, fa: Const<L, A>): Const<L, B> {
-    return new Const(S.concat(fab.fold(identity), fa.fold(identity)))
+    return new Const(S.concat(fab.fold(identity))(fa.fold(identity)))
   }
   return {
     URI,

--- a/src/Const.ts
+++ b/src/Const.ts
@@ -32,7 +32,7 @@ export class Const<L, A> implements FantasyFunctor<URI, A>, FantasyContravariant
     return f(this.value)
   }
   equals(S: Setoid<L>, fy: Const<L, A>): boolean {
-    return this.fold(x => fy.fold(y => S.equals(x, y)))
+    return this.fold(x => fy.fold(y => S.equals(x)(y)))
   }
   inspect() {
     return this.toString()
@@ -48,7 +48,7 @@ export function equals<L, A>(S: Setoid<L>, fx: Const<L, A>, fy: Const<L, A>): bo
 
 export function getSetoid<L, A>(S: Setoid<L>): Setoid<Const<L, A>> {
   return {
-    equals: (x, y) => equals(S, x, y)
+    equals: x => y => equals(S, x, y)
   }
 }
 

--- a/src/Contravariant.ts
+++ b/src/Contravariant.ts
@@ -10,14 +10,13 @@ export interface FantasyContravariant<F, A> {
 }
 
 export class Ops {
-  lift<F extends HKT2S, A, B>(
-    contravariant: Contravariant<F>,
-    f: (b: B) => A
-  ): <L>(fa: HKT2As<F, L, A>) => HKT2As<F, L, B>
-  lift<F extends HKTS, A, B>(contravariant: Contravariant<F>, f: (b: B) => A): (fa: HKTAs<F, A>) => HKTAs<F, B>
-  lift<F, A, B>(contravariant: Contravariant<F>, f: (b: B) => A): (fa: HKT<F, A>) => HKT<F, B>
-  lift<F, A, B>(contravariant: Contravariant<F>, f: (b: B) => A): (fa: HKT<F, A>) => HKT<F, B> {
-    return fa => contravariant.contramap(fa)(f)
+  lift<F extends HKT2S>(
+    contravariant: Contravariant<F>
+  ): <A, B>(f: (b: B) => A) => <L>(fa: HKT2As<F, L, A>) => HKT2As<F, L, B>
+  lift<F extends HKTS>(contravariant: Contravariant<F>): <A, B>(f: (b: B) => A) => (fa: HKTAs<F, A>) => HKTAs<F, B>
+  lift<F>(contravariant: Contravariant<F>): <A, B>(f: (b: B) => A) => (fa: HKT<F, A>) => HKT<F, B>
+  lift<F>(contravariant: Contravariant<F>): <A, B>(f: (b: B) => A) => (fa: HKT<F, A>) => HKT<F, B> {
+    return f => fa => contravariant.contramap(fa)(f)
   }
 }
 

--- a/src/Contravariant.ts
+++ b/src/Contravariant.ts
@@ -2,11 +2,11 @@ import { HKT, HKTS, HKT2S, HKTAs, HKT2As } from './HKT'
 
 export interface Contravariant<F> {
   readonly URI: F
-  contramap<A>(fa: HKT<F, A>): <B>(f: (b: B) => A) => HKT<F, B>
+  contramap: <A>(fa: HKT<F, A>) => <B>(f: (b: B) => A) => HKT<F, B>
 }
 
 export interface FantasyContravariant<F, A> {
-  contramap<B>(f: (b: B) => A): HKT<F, B>
+  contramap: <B>(f: (b: B) => A) => HKT<F, B>
 }
 
 export class Ops {

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -150,7 +150,7 @@ export class Right<L, A>
     return this.value
   }
   equals(setoid: Setoid<A>, fy: Either<L, A>): boolean {
-    return fy.fold(constFalse, y => setoid.equals(this.value, y))
+    return fy.fold(constFalse, y => setoid.equals(this.value)(y))
   }
   mapLeft<M>(f: (l: L) => M): Either<M, A> {
     return this as any
@@ -172,7 +172,7 @@ export function equals<L, A>(setoid: Setoid<A>, fx: Either<L, A>, fy: Either<L, 
 
 export function getSetoid<L, A>(setoid: Setoid<A>): Setoid<Either<L, A>> {
   return {
-    equals: (x, y) => equals(setoid, x, y)
+    equals: x => y => equals(setoid, x, y)
   }
 }
 

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -204,7 +204,7 @@ export function bimap<L, V, A, B>(f: (u: L) => V, g: (a: A) => B, fau: Either<L,
   return fau.bimap(f, g)
 }
 
-export function alt<L, A>(fx: Either<L, A>, fy: Either<L, A>): Either<L, A> {
+export const alt = <L, A>(fx: Either<L, A>) => (fy: Either<L, A>): Either<L, A> => {
   return fx.alt(fy)
 }
 

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -184,7 +184,8 @@ export const ap = <L, A, B>(fab: Either<L, (a: A) => B>, fa: Either<L, A>): Eith
 
 export const chain = <L, A, B>(f: (a: A) => Either<L, B>, fa: Either<L, A>): Either<L, B> => fa.chain(f)
 
-export const bimap = <L, V, A, B>(f: (u: L) => V, g: (a: A) => B, fau: Either<L, A>): Either<V, B> => fau.bimap(f, g)
+export const bimap = <L, V, A, B>(f: (u: L) => V, g: (a: A) => B) => (fau: Either<L, A>): Either<V, B> =>
+  fau.bimap(f, g)
 
 export const alt = <L, A>(fx: Either<L, A>) => (fy: Either<L, A>): Either<L, A> => fx.alt(fy)
 

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -26,8 +26,6 @@ export type URI = typeof URI
 
 export type Either<L, A> = Left<L, A> | Right<L, A>
 
-export const of = <L, A>(a: A): Either<L, A> => new Right(a)
-
 export class Left<L, A>
   implements FantasyMonad<URI, A>,
     FantasyFoldable<A>,
@@ -35,17 +33,13 @@ export class Left<L, A>
     FantasyAlt<URI, A>,
     FantasyExtend<URI, A>,
     FantasyBifunctor<URI, L, A> {
-  static of = of
   readonly _tag: 'Left' = 'Left'
   readonly _A: A
   readonly _L: L
   readonly _URI: URI
-  constructor(public readonly value: L) {}
+  constructor(readonly value: L) {}
   map<B>(f: (a: A) => B): Either<L, B> {
     return this as any
-  }
-  of<M, B>(b: B): Either<M, B> {
-    return of(b)
   }
   ap<B>(fab: Either<L, (a: A) => B>): Either<L, B> {
     return (isLeft(fab) ? fab : this) as any
@@ -103,17 +97,13 @@ export class Right<L, A>
     FantasyTraversable<URI, A>,
     FantasyAlt<URI, A>,
     FantasyExtend<URI, A> {
-  static of = of
   readonly _tag: 'Right' = 'Right'
   readonly _A: A
   readonly _L: L
   readonly _URI: URI
-  constructor(public readonly value: A) {}
+  constructor(readonly value: A) {}
   map<B>(f: (a: A) => B): Either<L, B> {
     return new Right(f(this.value))
-  }
-  of<L2, B>(b: B): Either<L2, B> {
-    return of<L2, B>(b)
   }
   ap<B>(fab: Either<L, (a: A) => B>): Either<L, B> {
     if (isRight(fab)) {
@@ -179,6 +169,8 @@ export const fold = <L, A, B>(left: (l: L) => B, right: (a: A) => B, fa: Either<
 export const getOrElse = <A>(f: () => A) => <L>(fa: Either<L, A>): A => fa.getOrElse(f)
 
 export const map = <L, A, B>(f: (a: A) => B, fa: Either<L, A>): Either<L, B> => fa.map(f)
+
+export const of = <L, A>(a: A): Either<L, A> => new Right(a)
 
 export const ap = <L, A, B>(fab: Either<L, (a: A) => B>, fa: Either<L, A>): Either<L, B> => fa.ap(fab)
 

--- a/src/EitherT.ts
+++ b/src/EitherT.ts
@@ -67,13 +67,13 @@ export class Ops {
 
   mapLeft<F extends HKT2S>(
     F: Functor<F>
-  ): <N, L, M, A>(f: (l: L) => N, fa: HKT2As<F, M, Either<L, A>>) => HKT2As<F, M, Either<N, A>>
+  ): <N, L, M>(f: (l: L) => N) => <A>(fa: HKT2As<F, M, Either<L, A>>) => HKT2As<F, M, Either<N, A>>
   mapLeft<F extends HKTS>(
     F: Functor<F>
-  ): <N, L, A>(f: (l: L) => N, fa: HKTAs<F, Either<L, A>>) => HKTAs<F, Either<N, A>>
-  mapLeft<F>(F: Functor<F>): <N, L, A>(f: (l: L) => N, fa: HKT<F, Either<L, A>>) => HKT<F, Either<N, A>>
-  mapLeft<F>(F: Functor<F>): <N, L, A>(f: (l: L) => N, fa: HKT<F, Either<L, A>>) => HKT<F, Either<N, A>> {
-    return (f, fa) => F.map(e => e.mapLeft(f), fa)
+  ): <N, L>(f: (l: L) => N) => <A>(fa: HKTAs<F, Either<L, A>>) => HKTAs<F, Either<N, A>>
+  mapLeft<F>(F: Functor<F>): <N, L>(f: (l: L) => N) => <A>(fa: HKT<F, Either<L, A>>) => HKT<F, Either<N, A>>
+  mapLeft<F>(F: Functor<F>): <N, L>(f: (l: L) => N) => <A>(fa: HKT<F, Either<L, A>>) => HKT<F, Either<N, A>> {
+    return f => fa => F.map(e => e.mapLeft(f), fa)
   }
 
   toOption<F extends HKT2S>(F: Functor<F>): <L, M, A>(fa: HKT2As<F, M, Either<L, A>>) => HKT2As<F, M, Option<A>>

--- a/src/EitherT.ts
+++ b/src/EitherT.ts
@@ -87,7 +87,7 @@ export class Ops {
   getEitherT<M extends HKTS>(M: Monad<M>): EitherT1<M>
   getEitherT<M>(M: Monad<M>): EitherT<M>
   getEitherT<M>(M: Monad<M>): EitherT<M> {
-    const applicativeComposition = getApplicativeComposition(M)(either)
+    const applicativeComposition = getApplicativeComposition(M, either)
 
     return {
       ...applicativeComposition,

--- a/src/EitherT.ts
+++ b/src/EitherT.ts
@@ -87,7 +87,7 @@ export class Ops {
   getEitherT<M extends HKTS>(M: Monad<M>): EitherT1<M>
   getEitherT<M>(M: Monad<M>): EitherT<M>
   getEitherT<M>(M: Monad<M>): EitherT<M> {
-    const applicativeComposition = getApplicativeComposition(M, either)
+    const applicativeComposition = getApplicativeComposition(M)(either)
 
     return {
       ...applicativeComposition,

--- a/src/Exception.ts
+++ b/src/Exception.ts
@@ -1,4 +1,4 @@
-import { IO } from './IO'
+import { IO, of } from './IO'
 import { Option, some, none } from './Option'
 import { Either, left, right } from './Either'
 
@@ -37,4 +37,4 @@ export const catchException = <A>(handler: (e: Error) => IO<A>) => (action: IO<A
  * computation succeeds the result gets wrapped in a `Right`.
  */
 export const tryCatch = <A>(action: IO<A>): IO<Either<Error, A>> =>
-  catchException(e => IO.of(left<Error, A>(e)))(action.map(a => right(a)))
+  catchException(e => of(left<Error, A>(e)))(action.map(a => right(a)))

--- a/src/Exception.ts
+++ b/src/Exception.ts
@@ -5,30 +5,23 @@ import { Either, left, right } from './Either'
 // Adapted from https://github.com/purescript/purescript-exceptions
 
 /** Create a JavaScript error, specifying a message */
-export function error(message: string): Error {
-  return new Error(message)
-}
+export const error = (message: string): Error => new Error(message)
 
 /** Get the error message from a JavaScript error */
-export function message(e: Error): string {
-  return e.message
-}
+export const message = (e: Error): string => e.message
 
 /** Get the stack trace from a JavaScript error */
-export function stack(e: Error): Option<string> {
-  return e.stack ? some(e.stack) : none
-}
+export const stack = (e: Error): Option<string> => (e.stack ? some(e.stack) : none)
 
 /** Throw an exception */
-export function throwException<A>(e: Error): IO<A> {
-  return new IO(() => {
+export const throwException = <A>(e: Error): IO<A> =>
+  new IO(() => {
     throw e
   })
-}
 
 /** Catch an exception by providing an exception handler */
-export function catchException<A>(handler: (e: Error) => IO<A>, action: IO<A>): IO<A> {
-  return new IO(() => {
+export const catchException = <A>(handler: (e: Error) => IO<A>) => (action: IO<A>): IO<A> =>
+  new IO(() => {
     try {
       return action.run()
     } catch (e) {
@@ -39,11 +32,9 @@ export function catchException<A>(handler: (e: Error) => IO<A>, action: IO<A>): 
       }
     }
   })
-}
 
 /** Runs an IO and returns eventual Exceptions as a `Left` value. If the
  * computation succeeds the result gets wrapped in a `Right`.
  */
-export function tryCatch<A>(action: IO<A>): IO<Either<Error, A>> {
-  return catchException(e => IO.of(left(e)), action.map(a => right(a)))
-}
+export const tryCatch = <A>(action: IO<A>): IO<Either<Error, A>> =>
+  catchException(e => IO.of(left<Error, A>(e)))(action.map(a => right(a)))

--- a/src/Extend.ts
+++ b/src/Extend.ts
@@ -3,11 +3,11 @@ import { Cokleisli } from './function'
 import { Functor, FantasyFunctor } from './Functor'
 
 export interface Extend<F> extends Functor<F> {
-  extend<A, B>(f: Cokleisli<F, A, B>, ea: HKT<F, A>): HKT<F, B>
+  extend: <A, B>(f: Cokleisli<F, A, B>, ea: HKT<F, A>) => HKT<F, B>
 }
 
 export interface FantasyExtend<F, A> extends FantasyFunctor<F, A> {
-  extend<B>(f: Cokleisli<F, A, B>): HKT<F, B>
+  extend: <B>(f: Cokleisli<F, A, B>) => HKT<F, B>
 }
 
 export class Ops {

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -4,9 +4,9 @@ import { Setoid } from './Setoid'
 // adapted from https://github.com/purescript/purescript-prelude/blob/master/src/Data/Field.purs
 
 export interface Field<A> extends Ring<A> {
-  degree(a: A): number
-  div(x: A, y: A): A
-  mod(x: A, y: A): A
+  degree: (a: A) => number
+  div: (x: A) => (y: A) => A
+  mod: (x: A) => (y: A) => A
 }
 
 export const fieldNumber: Field<number> = {
@@ -16,8 +16,8 @@ export const fieldNumber: Field<number> = {
   one: () => 1,
   sub: x => y => x - y,
   degree: () => 1,
-  div: (x, y) => x / y,
-  mod: (x, y) => x % y
+  div: x => y => x / y,
+  mod: x => y => x % y
 }
 
 /** The *greatest common divisor* of two values */
@@ -27,7 +27,7 @@ export function gcd<A>(setoid: Setoid<A>, field: Field<A>): (x: A, y: A) => A {
     if (setoid.equals(y)(zero)) {
       return x
     }
-    return f(y, field.mod(x, y))
+    return f(y, field.mod(x)(y))
   }
   return f
 }
@@ -39,6 +39,6 @@ export function lcm<A>(setoid: Setoid<A>, field: Field<A>): (x: A, y: A) => A {
     if (setoid.equals(x)(zero) || setoid.equals(y)(zero)) {
       return zero
     }
-    return field.div(field.mul(x)(y), gcd(setoid, field)(x, y))
+    return field.div(field.mul(x)(y))(gcd(setoid, field)(x, y))
   }
 }

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -14,7 +14,7 @@ export const fieldNumber: Field<number> = {
   zero: () => 0,
   mul: x => y => x * y,
   one: () => 1,
-  sub: (x, y) => x - y,
+  sub: x => y => x - y,
   degree: () => 1,
   div: (x, y) => x / y,
   mod: (x, y) => x % y

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -24,7 +24,7 @@ export const fieldNumber: Field<number> = {
 export function gcd<A>(setoid: Setoid<A>, field: Field<A>): (x: A, y: A) => A {
   const zero = field.zero()
   function f(x: A, y: A): A {
-    if (setoid.equals(y, zero)) {
+    if (setoid.equals(y)(zero)) {
       return x
     }
     return f(y, field.mod(x, y))
@@ -36,7 +36,7 @@ export function gcd<A>(setoid: Setoid<A>, field: Field<A>): (x: A, y: A) => A {
 export function lcm<A>(setoid: Setoid<A>, field: Field<A>): (x: A, y: A) => A {
   const zero = field.zero()
   return (x, y) => {
-    if (setoid.equals(x, zero) || setoid.equals(y, zero)) {
+    if (setoid.equals(x)(zero) || setoid.equals(y)(zero)) {
       return zero
     }
     return field.div(field.mul(x)(y), gcd(setoid, field)(x, y))

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -10,9 +10,9 @@ export interface Field<A> extends Ring<A> {
 }
 
 export const fieldNumber: Field<number> = {
-  add: (x, y) => x + y,
+  add: x => y => x + y,
   zero: () => 0,
-  mul: (x, y) => x * y,
+  mul: x => y => x * y,
   one: () => 1,
   sub: (x, y) => x - y,
   degree: () => 1,
@@ -39,6 +39,6 @@ export function lcm<A>(setoid: Setoid<A>, field: Field<A>): (x: A, y: A) => A {
     if (setoid.equals(x, zero) || setoid.equals(y, zero)) {
       return zero
     }
-    return field.div(field.mul(x, y), gcd(setoid, field)(x, y))
+    return field.div(field.mul(x)(y), gcd(setoid, field)(x, y))
   }
 }

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -21,24 +21,15 @@ export const fieldNumber: Field<number> = {
 }
 
 /** The *greatest common divisor* of two values */
-export function gcd<A>(setoid: Setoid<A>, field: Field<A>): (x: A, y: A) => A {
+export const gcd = <A>(S: Setoid<A>, field: Field<A>): ((x: A) => (y: A) => A) => {
   const zero = field.zero()
-  function f(x: A, y: A): A {
-    if (setoid.equals(y)(zero)) {
-      return x
-    }
-    return f(y, field.mod(x)(y))
-  }
+  const f = (x: A) => (y: A): A => (S.equals(y)(zero) ? x : f(y)(field.mod(x)(y)))
   return f
 }
 
 /** The *least common multiple* of two values */
-export function lcm<A>(setoid: Setoid<A>, field: Field<A>): (x: A, y: A) => A {
+export const lcm = <A>(setoid: Setoid<A>, field: Field<A>): ((x: A) => (y: A) => A) => {
   const zero = field.zero()
-  return (x, y) => {
-    if (setoid.equals(x)(zero) || setoid.equals(y)(zero)) {
-      return zero
-    }
-    return field.div(field.mul(x)(y))(gcd(setoid, field)(x, y))
-  }
+  return x => y =>
+    setoid.equals(x)(zero) || setoid.equals(y)(zero) ? zero : field.div(field.mul(x)(y))(gcd(setoid, field)(x)(y))
 }

--- a/src/Filterable.ts
+++ b/src/Filterable.ts
@@ -18,13 +18,13 @@ export class Ops {
   /** partition a data structure based on boolean predicate */
   partition<F extends HKT2S>(
     F: Filterable<F>
-  ): <L, A>(predicate: Predicate<A>, fa: HKT2As<F, L, A>) => { no: HKT2As<F, L, A>; yes: HKT2As<F, L, A> }
+  ): <A>(predicate: Predicate<A>) => <L>(fa: HKT2As<F, L, A>) => { no: HKT2As<F, L, A>; yes: HKT2As<F, L, A> }
   partition<F extends HKTS>(
     F: Filterable<F>
-  ): <A>(predicate: Predicate<A>, fa: HKTAs<F, A>) => { no: HKTAs<F, A>; yes: HKTAs<F, A> }
-  partition<F>(F: Filterable<F>): <A>(predicate: Predicate<A>, fa: HKT<F, A>) => { no: HKT<F, A>; yes: HKT<F, A> }
-  partition<F>(F: Filterable<F>): <A>(predicate: Predicate<A>, fa: HKT<F, A>) => { no: HKT<F, A>; yes: HKT<F, A> } {
-    return (predicate, fa) => {
+  ): <A>(predicate: Predicate<A>) => (fa: HKTAs<F, A>) => { no: HKTAs<F, A>; yes: HKTAs<F, A> }
+  partition<F>(F: Filterable<F>): <A>(predicate: Predicate<A>) => (fa: HKT<F, A>) => { no: HKT<F, A>; yes: HKT<F, A> }
+  partition<F>(F: Filterable<F>): <A>(predicate: Predicate<A>) => (fa: HKT<F, A>) => { no: HKT<F, A>; yes: HKT<F, A> } {
+    return predicate => fa => {
       const { left, right } = F.partitionMap(fromPredicate(predicate, identity), fa)
       return { no: left, yes: right }
     }
@@ -33,21 +33,20 @@ export class Ops {
   /** map over a data structure and filter based on a maybe */
   filterMap<F extends HKT2S>(
     F: Filterable<F>
-  ): <L, A, B>(f: (a: A) => Option<B>, fa: HKT2As<F, L, A>) => HKT2As<F, L, B>
-  filterMap<F extends HKTS>(F: Filterable<F>): <A, B>(f: (a: A) => Option<B>, fa: HKTAs<F, A>) => HKTAs<F, B>
-  filterMap<F>(F: Filterable<F>): <A, B>(f: (a: A) => Option<B>, fa: HKT<F, A>) => HKT<F, B>
-  filterMap<F>(F: Filterable<F>): <A, B>(f: (a: A) => Option<B>, fa: HKT<F, A>) => HKT<F, B> {
-    return <A, B>(f: (a: A) => Option<B>, fa: HKT<F, A>) => {
-      return F.partitionMap((a: A) => f(a).fold(() => left<null, B>(null), b => right<null, B>(b)), fa).right
-    }
+  ): <A, B>(f: (a: A) => Option<B>) => <L>(fa: HKT2As<F, L, A>) => HKT2As<F, L, B>
+  filterMap<F extends HKTS>(F: Filterable<F>): <A, B>(f: (a: A) => Option<B>) => (fa: HKTAs<F, A>) => HKTAs<F, B>
+  filterMap<F>(F: Filterable<F>): <A, B>(f: (a: A) => Option<B>) => (fa: HKT<F, A>) => HKT<F, B>
+  filterMap<F>(F: Filterable<F>): <A, B>(f: (a: A) => Option<B>) => (fa: HKT<F, A>) => HKT<F, B> {
+    return <A, B>(f: (a: A) => Option<B>) => (fa: HKT<F, A>) =>
+      F.partitionMap((a: A) => f(a).fold(() => left<null, B>(null), b => right<null, B>(b)), fa).right
   }
 
   /** filter a data structure based on a boolean */
-  filter<F extends HKT2S>(F: Filterable<F>): <L, A>(predicate: Predicate<A>, fa: HKT2As<F, L, A>) => HKT2As<F, L, A>
-  filter<F extends HKTS>(F: Filterable<F>): <A>(predicate: Predicate<A>, fa: HKTAs<F, A>) => HKTAs<F, A>
-  filter<F>(F: Filterable<F>): <A>(predicate: Predicate<A>, fa: HKT<F, A>) => HKT<F, A>
-  filter<F>(F: Filterable<F>): <A>(predicate: Predicate<A>, fa: HKT<F, A>) => HKT<F, A> {
-    return <A>(predicate: Predicate<A>, fa: HKT<F, A>) => this.filterMap(F)(optionFromPredicate(predicate), fa)
+  filter<F extends HKT2S>(F: Filterable<F>): <A>(predicate: Predicate<A>) => <L>(fa: HKT2As<F, L, A>) => HKT2As<F, L, A>
+  filter<F extends HKTS>(F: Filterable<F>): <A>(predicate: Predicate<A>) => (fa: HKTAs<F, A>) => HKTAs<F, A>
+  filter<F>(F: Filterable<F>): <A>(predicate: Predicate<A>) => (fa: HKT<F, A>) => HKT<F, A>
+  filter<F>(F: Filterable<F>): <A>(predicate: Predicate<A>) => (fa: HKT<F, A>) => HKT<F, A> {
+    return <A>(predicate: Predicate<A>) => (fa: HKT<F, A>) => this.filterMap(F)(optionFromPredicate(predicate))(fa)
   }
 
   partitioned<F extends HKT2S>(
@@ -66,7 +65,7 @@ export class Ops {
   filtered<F extends HKTS>(F: Filterable<F>): <A>(fa: HKTAs<F, Option<A>>) => HKTAs<F, A>
   filtered<F>(F: Filterable<F>): <A>(fa: HKT<F, Option<A>>) => HKT<F, A>
   filtered<F>(F: Filterable<F>): <A>(fa: HKT<F, Option<A>>) => HKT<F, A> {
-    return <A>(fa: HKT<F, Option<A>>) => this.filterMap(F)(a => a, fa)
+    return <A>(fa: HKT<F, Option<A>>) => this.filterMap(F)((oa: Option<A>) => oa)(fa)
   }
 }
 

--- a/src/Filterable.ts
+++ b/src/Filterable.ts
@@ -6,12 +6,12 @@ import { Predicate, identity } from './function'
 
 export interface Filterable<F> extends Functor<F> {
   /** partition a data structure based on an either predicate */
-  partitionMap<A, L, R>(f: (a: A) => Either<L, R>, fa: HKT<F, A>): { left: HKT<F, L>; right: HKT<F, R> }
+  partitionMap: <A, L, R>(f: (a: A) => Either<L, R>, fa: HKT<F, A>) => { left: HKT<F, L>; right: HKT<F, R> }
 }
 
 export interface FantasyFilterable<F, A> extends FantasyFunctor<F, A> {
   /** partition a data structure based on an either predicate */
-  partitionMap<L, R>(f: (a: A) => Either<L, R>): { left: HKT<F, L>; right: HKT<F, R> }
+  partitionMap: <L, R>(f: (a: A) => Either<L, R>) => { left: HKT<F, L>; right: HKT<F, R> }
 }
 
 export class Ops {

--- a/src/Foldable.ts
+++ b/src/Foldable.ts
@@ -64,7 +64,7 @@ export class Ops {
   ): <A, B>(f: (a: A) => HKTAs<M, B>, fa: HKT<F, A>) => HKTAs<M, void>
   traverse_<M, F>(M: Applicative<M>, F: Foldable<F>): <A, B>(f: (a: A) => HKT<M, B>, fa: HKT<F, A>) => HKT<M, void>
   traverse_<M, F>(M: Applicative<M>, F: Foldable<F>): <A, B>(f: (a: A) => HKT<M, B>, fa: HKT<F, A>) => HKT<M, void> {
-    return (f, fa) => toArray(F)(fa).reduce((mu, a) => applyFirst(M)(mu, f(a)), M.of(undefined))
+    return (f, fa) => toArray(F)(fa).reduce((mu, a) => applyFirst(M)(mu)(f(a)), M.of(undefined))
   }
 
   sequence_<M extends HKT2S, F>(

--- a/src/Foldable.ts
+++ b/src/Foldable.ts
@@ -5,22 +5,20 @@ import { applyFirst } from './Apply'
 
 export interface Foldable<F> {
   readonly URI: F
-  reduce<A, B>(f: (b: B, a: A) => B, b: B, fa: HKT<F, A>): B
+  reduce: <A, B>(f: (b: B, a: A) => B, b: B, fa: HKT<F, A>) => B
 }
 
 export interface FantasyFoldable<A> {
-  reduce<B>(f: (b: B, a: A) => B, b: B): B
+  reduce: <B>(f: (b: B, a: A) => B, b: B) => B
 }
 
 export interface FoldableComposition<F, G> {
-  reduce<A, B>(f: (b: B, a: A) => B, b: B, fga: HKT<F, HKT<G, A>>): B
+  reduce: <A, B>(f: (b: B, a: A) => B, b: B, fga: HKT<F, HKT<G, A>>) => B
 }
 
 export const getFoldableComposition = <F, G>(F: Foldable<F>, G: Foldable<G>): FoldableComposition<F, G> => {
   return {
-    reduce<A, B>(f: (b: B, a: A) => B, b: B, fga: HKT<F, HKT<G, A>>): B {
-      return F.reduce((b, ga) => G.reduce(f, b, ga), b, fga)
-    }
+    reduce: (f, b, fga) => F.reduce((b, ga) => G.reduce(f, b, ga), b, fga)
   }
 }
 

--- a/src/Foldable.ts
+++ b/src/Foldable.ts
@@ -26,7 +26,7 @@ export function getFoldableComposition<F, G>(F: Foldable<F>, G: Foldable<G>): Fo
 
 /** A default implementation of `foldMap` using `foldl`. */
 export function foldMap<F, M>(foldable: Foldable<F>, monoid: Monoid<M>): <A>(f: (a: A) => M, fa: HKT<F, A>) => M {
-  return (f, fa) => foldable.reduce((acc, x) => monoid.concat(acc, f(x)), monoid.empty(), fa)
+  return (f, fa) => foldable.reduce((acc, x) => monoid.concat(acc)(f(x)), monoid.empty(), fa)
 }
 
 export function toArray<F>(foldable: Foldable<F>): <A>(fa: HKT<F, A>) => Array<A> {
@@ -47,7 +47,7 @@ type Acc<M> = { init: boolean; acc: M }
 export function intercalate<F, M>(foldable: Foldable<F>, monoid: Monoid<M>): (sep: M, fm: HKT<F, M>) => M {
   return (sep, fm) => {
     function go({ init, acc }: Acc<M>, x: M): Acc<M> {
-      return init ? { init: false, acc: x } : { init: false, acc: monoid.concat(monoid.concat(acc, sep), x) }
+      return init ? { init: false, acc: x } : { init: false, acc: monoid.concat(monoid.concat(acc)(sep))(x) }
     }
     return foldable.reduce(go, { init: true, acc: monoid.empty() }, fm).acc
   }

--- a/src/Free.ts
+++ b/src/Free.ts
@@ -13,17 +13,13 @@ export type URI = typeof URI
 export type Free<F, A> = Pure<F, A> | Impure<F, A, any>
 
 export class Pure<F, A> implements FantasyMonad<URI, A> {
-  static of = of
   readonly _tag: 'Pure' = 'Pure'
   readonly _A: A
   readonly _L: F
   readonly _URI: URI
-  constructor(public readonly value: A) {}
+  constructor(readonly value: A) {}
   map<B>(f: (a: A) => B): Free<F, B> {
     return new Pure(f(this.value))
-  }
-  of<B>(b: B): Free<F, B> {
-    return of(b)
   }
   ap<B>(fab: Free<F, (a: A) => B>): Free<F, B> {
     return fab.chain(f => this.map(f)) // <- derived
@@ -48,17 +44,13 @@ export class Pure<F, A> implements FantasyMonad<URI, A> {
 }
 
 export class Impure<F, A, X> implements FantasyMonad<URI, A> {
-  static of = of
   readonly _tag: 'Impure' = 'Impure'
   readonly _A: A
   readonly _L: F
   readonly _URI: URI
-  constructor(public readonly fx: HKT<F, X>, public readonly f: (x: X) => Free<F, A>) {}
+  constructor(readonly fx: HKT<F, X>, readonly f: (x: X) => Free<F, A>) {}
   map<B>(f: (a: A) => B): Free<F, B> {
     return new Impure(this.fx, x => this.f(x).map(f))
-  }
-  of<B>(b: B): Free<F, B> {
-    return of(b)
   }
   ap<B>(fab: Free<F, (a: A) => B>): Free<F, B> {
     return fab.chain(f => this.map(f)) // <- derived
@@ -82,9 +74,7 @@ export class Impure<F, A, X> implements FantasyMonad<URI, A> {
   }
 }
 
-export function of<F, A>(a: A): Free<F, A> {
-  return new Pure(a)
-}
+export const of = <F, A>(a: A): Free<F, A> => new Pure(a)
 
 export const liftF = <F, A>(fa: HKT<F, A>): Free<F, A> => new Impure(fa, a => of(a))
 

--- a/src/Functor.ts
+++ b/src/Functor.ts
@@ -35,27 +35,27 @@ export class Ops {
    * Lift a function of one argument to a function which accepts and returns
    * values wrapped with the type constructor `F`
    */
-  lift<F extends HKT2S, A, B>(F: Functor<F>, f: (a: A) => B): <L>(fa: HKT2As<F, L, A>) => HKT2As<F, L, B>
-  lift<F extends HKTS, A, B>(F: Functor<F>, f: (a: A) => B): (fa: HKTAs<F, A>) => HKTAs<F, B>
-  lift<F, A, B>(F: Functor<F>, f: (a: A) => B): (fa: HKT<F, A>) => HKT<F, B>
-  lift<F, A, B>(F: Functor<F>, f: (a: A) => B): (fa: HKT<F, A>) => HKT<F, B> {
-    return fa => F.map(f, fa)
+  lift<F extends HKT2S>(F: Functor<F>): <A, B>(f: (a: A) => B) => <L>(fa: HKT2As<F, L, A>) => HKT2As<F, L, B>
+  lift<F extends HKTS>(F: Functor<F>): <A, B>(f: (a: A) => B) => (fa: HKTAs<F, A>) => HKTAs<F, B>
+  lift<F>(F: Functor<F>): <A, B>(f: (a: A) => B) => (fa: HKT<F, A>) => HKT<F, B>
+  lift<F>(F: Functor<F>): <A, B>(f: (a: A) => B) => (fa: HKT<F, A>) => HKT<F, B> {
+    return f => fa => F.map(f, fa)
   }
 
   /** Ignore the return value of a computation, using the specified return value instead (`<$`) */
-  voidRight<F extends HKT2S, L, A, B>(F: Functor<F>, a: A, fb: HKT2<F, L, B>): HKT2As<F, L, A>
-  voidRight<F extends HKTS, A, B>(F: Functor<F>, a: A, fb: HKT<F, B>): HKTAs<F, A>
-  voidRight<F, A, B>(F: Functor<F>, a: A, fb: HKT<F, B>): HKT<F, A>
-  voidRight<F, A, B>(F: Functor<F>, a: A, fb: HKT<F, B>): HKT<F, A> {
-    return F.map(constant(a), fb)
+  voidRight<F extends HKT2S>(F: Functor<F>): <A>(a: A) => <L, B>(fb: HKT2<F, L, B>) => HKT2As<F, L, A>
+  voidRight<F extends HKTS>(F: Functor<F>): <A>(a: A) => <B>(fb: HKT<F, B>) => HKTAs<F, A>
+  voidRight<F>(F: Functor<F>): <A>(a: A) => <B>(fb: HKT<F, B>) => HKT<F, A>
+  voidRight<F>(F: Functor<F>): <A>(a: A) => <B>(fb: HKT<F, B>) => HKT<F, A> {
+    return a => fb => F.map(constant(a), fb)
   }
 
   /** A version of `voidRight` with its arguments flipped (`$>`) */
-  voidLeft<F extends HKT2S, L, A, B>(F: Functor<F>, fa: HKT2<F, L, A>, b: B): HKT2As<F, L, B>
-  voidLeft<F extends HKTS, A, B>(F: Functor<F>, fa: HKT<F, A>, b: B): HKTAs<F, B>
-  voidLeft<F, A, B>(F: Functor<F>, fa: HKT<F, A>, b: B): HKT<F, B>
-  voidLeft<F, A, B>(F: Functor<F>, fa: HKT<F, A>, b: B): HKT<F, B> {
-    return F.map(constant(b), fa)
+  voidLeft<F extends HKT2S>(F: Functor<F>): <L, A>(fa: HKT2<F, L, A>) => <B>(b: B) => HKT2As<F, L, B>
+  voidLeft<F extends HKTS>(F: Functor<F>): <A>(fa: HKT<F, A>) => <B>(b: B) => HKTAs<F, B>
+  voidLeft<F>(F: Functor<F>): <A>(fa: HKT<F, A>) => <B>(b: B) => HKT<F, B>
+  voidLeft<F>(F: Functor<F>): <A>(fa: HKT<F, A>) => <B>(b: B) => HKT<F, B> {
+    return fa => b => F.map(constant(b), fa)
   }
 
   /** Apply a value in a computational context to a value in no context.

--- a/src/Functor.ts
+++ b/src/Functor.ts
@@ -3,31 +3,31 @@ import { constant } from './function'
 
 export interface Functor<F> {
   readonly URI: F
-  map<A, B>(f: (a: A) => B, fa: HKT<F, A>): HKT<F, B>
+  map: <A, B>(f: (a: A) => B, fa: HKT<F, A>) => HKT<F, B>
 }
 
 export interface FantasyFunctor<F, A> {
-  map<B>(f: (a: A) => B): HKT<F, B>
+  map: <B>(f: (a: A) => B) => HKT<F, B>
 }
 
 export interface FunctorComposition<F, G> {
-  map<A, B>(f: (a: A) => B, fa: HKT<F, HKT<G, A>>): HKT<F, HKT<G, B>>
+  map: <A, B>(f: (a: A) => B, fa: HKT<F, HKT<G, A>>) => HKT<F, HKT<G, B>>
 }
 
 export interface FunctorComposition11<F extends HKTS, G extends HKTS> {
-  map<A, B>(f: (a: A) => B, fa: HKTAs<F, HKTAs<G, A>>): HKTAs<F, HKTAs<G, B>>
+  map: <A, B>(f: (a: A) => B, fa: HKTAs<F, HKTAs<G, A>>) => HKTAs<F, HKTAs<G, B>>
 }
 
 export interface FunctorComposition12<F extends HKTS, G extends HKT2S> {
-  map<L, A, B>(f: (a: A) => B, fa: HKTAs<F, HKT2As<G, L, A>>): HKTAs<F, HKT2As<G, L, B>>
+  map: <L, A, B>(f: (a: A) => B, fa: HKTAs<F, HKT2As<G, L, A>>) => HKTAs<F, HKT2As<G, L, B>>
 }
 
 export interface FunctorComposition21<F extends HKT2S, G extends HKTS> {
-  map<L, A, B>(f: (a: A) => B, fa: HKT2As<F, L, HKTAs<G, A>>): HKT2As<F, L, HKTAs<G, B>>
+  map: <L, A, B>(f: (a: A) => B, fa: HKT2As<F, L, HKTAs<G, A>>) => HKT2As<F, L, HKTAs<G, B>>
 }
 
 export interface FunctorComposition22<F extends HKT2S, G extends HKT2S> {
-  map<L, M, A, B>(f: (a: A) => B, fa: HKT2As<F, L, HKT2As<G, M, A>>): HKT2As<F, L, HKT2As<G, M, B>>
+  map: <L, M, A, B>(f: (a: A) => B, fa: HKT2As<F, L, HKT2As<G, M, A>>) => HKT2As<F, L, HKT2As<G, M, B>>
 }
 
 export class Ops {
@@ -58,14 +58,15 @@ export class Ops {
     return fa => b => F.map(constant(b), fa)
   }
 
-  /** Apply a value in a computational context to a value in no context.
+  /**
+   * Apply a value in a computational context to a value in no context.
    * Generalizes `flip`
    */
-  flap<F extends HKT2S>(functor: Functor<F>): <L, A, B>(ff: HKT2As<F, L, (a: A) => B>, a: A) => HKT2As<F, L, B>
-  flap<F extends HKTS>(functor: Functor<F>): <A, B>(ff: HKTAs<F, (a: A) => B>, a: A) => HKTAs<F, B>
-  flap<F>(functor: Functor<F>): <A, B>(ff: HKT<F, (a: A) => B>, a: A) => HKT<F, B>
-  flap<F>(functor: Functor<F>): <A, B>(ff: HKT<F, (a: A) => B>, a: A) => HKT<F, B> {
-    return (ff, a) => functor.map(f => f(a), ff)
+  flap<F extends HKT2S>(functor: Functor<F>): <L, A, B>(ff: HKT2As<F, L, (a: A) => B>) => (a: A) => HKT2As<F, L, B>
+  flap<F extends HKTS>(functor: Functor<F>): <A, B>(ff: HKTAs<F, (a: A) => B>) => (a: A) => HKTAs<F, B>
+  flap<F>(functor: Functor<F>): <A, B>(ff: HKT<F, (a: A) => B>) => (a: A) => HKT<F, B>
+  flap<F>(functor: Functor<F>): <A, B>(ff: HKT<F, (a: A) => B>) => (a: A) => HKT<F, B> {
+    return ff => a => functor.map(f => f(a), ff)
   }
 
   getFunctorComposition<F extends HKT2S, G extends HKT2S>(F: Functor<F>, G: Functor<G>): FunctorComposition22<F, G>
@@ -75,9 +76,7 @@ export class Ops {
   getFunctorComposition<F, G>(F: Functor<F>, G: Functor<G>): FunctorComposition<F, G>
   getFunctorComposition<F, G>(F: Functor<F>, G: Functor<G>): FunctorComposition<F, G> {
     return {
-      map<A, B>(f: (a: A) => B, fa: HKT<F, HKT<G, A>>): HKT<F, HKT<G, B>> {
-        return F.map(ga => G.map(f, ga), fa)
-      }
+      map: (f, fa) => F.map(ga => G.map(f, ga), fa)
     }
   }
 }

--- a/src/IO.ts
+++ b/src/IO.ts
@@ -37,7 +37,7 @@ export class IO<A> implements FantasyMonad<URI, A> {
     return new IO(() => f(this.run()).run())
   }
   concat(semigroup: Semigroup<A>, fy: IO<A>): IO<A> {
-    return new IO(() => semigroup.concat(this.run(), fy.run()))
+    return new IO(() => semigroup.concat(this.run())(fy.run()))
   }
   inspect() {
     return this.toString()
@@ -68,7 +68,7 @@ export function concat<A>(semigroup: Semigroup<A>, fx: IO<A>, fy: IO<A>): IO<A> 
 }
 
 export function getSemigroup<A>(semigroup: Semigroup<A>): Semigroup<IO<A>> {
-  return { concat: (fx, fy) => concat(semigroup, fx, fy) }
+  return { concat: fx => fy => concat(semigroup, fx, fy) }
 }
 
 export function getMonoid<A>(monoid: Monoid<A>): Monoid<IO<A>> {

--- a/src/IO.ts
+++ b/src/IO.ts
@@ -13,21 +13,12 @@ export const URI = 'IO'
 
 export type URI = typeof URI
 
-export const of = <A>(a: A): IO<A> => new IO(() => a)
-
 export class IO<A> implements FantasyMonad<URI, A> {
-  static of = of
   readonly _A: A
   readonly _URI: URI
-  constructor(public readonly value: Lazy<A>) {}
-  run(): A {
-    return this.value()
-  }
+  constructor(readonly run: Lazy<A>) {}
   map<B>(f: (a: A) => B): IO<B> {
     return new IO(() => f(this.run()))
-  }
-  of<B>(b: B): IO<B> {
-    return of(b)
   }
   ap<B>(fab: IO<(a: A) => B>): IO<B> {
     return new IO(() => fab.run()(this.run()))
@@ -42,11 +33,13 @@ export class IO<A> implements FantasyMonad<URI, A> {
     return this.toString()
   }
   toString() {
-    return `new IO(${toString(this.value)})`
+    return `new IO(${toString(this.run)})`
   }
 }
 
 export const map = <A, B>(f: (a: A) => B, fa: IO<A>): IO<B> => fa.map(f)
+
+export const of = <A>(a: A): IO<A> => new IO(() => a)
 
 export const ap = <A, B>(fab: IO<(a: A) => B>, fa: IO<A>): IO<B> => fa.ap(fab)
 

--- a/src/Identity.ts
+++ b/src/Identity.ts
@@ -110,7 +110,7 @@ export function reduce<A, B>(f: (b: B, a: A) => B, b: B, fa: Identity<A>): B {
   return fa.reduce(f, b)
 }
 
-export function alt<A>(fx: Identity<A>, fy: Identity<A>): Identity<A> {
+export const alt = <A>(fx: Identity<A>) => (fy: Identity<A>): Identity<A> => {
   return fx.alt(fy)
 }
 

--- a/src/Identity.ts
+++ b/src/Identity.ts
@@ -20,8 +20,6 @@ export const URI = 'Identity'
 
 export type URI = typeof URI
 
-export const of = <A>(a: A): Identity<A> => new Identity(a)
-
 export const extract = <A>(fa: Identity<A>): A => fa.extract()
 
 export class Identity<A>
@@ -30,16 +28,11 @@ export class Identity<A>
     FantasyTraversable<URI, A>,
     FantasyAlt<URI, A>,
     FantasyComonad<URI, A> {
-  static of = of
-  static extract = extract
   readonly _A: A
   readonly _URI: URI
-  constructor(public readonly value: A) {}
+  constructor(readonly value: A) {}
   map<B>(f: (a: A) => B): Identity<B> {
     return new Identity(f(this.value))
-  }
-  of<B>(b: B): Identity<B> {
-    return of(b)
   }
   ap<B>(fab: Identity<(a: A) => B>): Identity<B> {
     return this.map(fab.extract())
@@ -89,6 +82,8 @@ export const getSetoid = <A>(setoid: Setoid<A>): Setoid<Identity<A>> => ({
 })
 
 export const map = <A, B>(f: (a: A) => B, fa: Identity<A>): Identity<B> => fa.map(f)
+
+export const of = <A>(a: A): Identity<A> => new Identity(a)
 
 export const ap = <A, B>(fab: Identity<(a: A) => B>, fa: Identity<A>): Identity<B> => fa.ap(fab)
 

--- a/src/Identity.ts
+++ b/src/Identity.ts
@@ -70,7 +70,7 @@ export class Identity<A>
     return f(this.value)
   }
   equals(setoid: Setoid<A>, fy: Identity<A>): boolean {
-    return setoid.equals(this.value, fy.value)
+    return setoid.equals(this.value)(fy.value)
   }
   inspect() {
     return this.toString()
@@ -86,7 +86,7 @@ export function equals<A>(setoid: Setoid<A>, fx: Identity<A>, fy: Identity<A>): 
 
 export function getSetoid<A>(setoid: Setoid<A>): Setoid<Identity<A>> {
   return {
-    equals: (x, y) => equals(setoid, x, y)
+    equals: x => y => equals(setoid, x, y)
   }
 }
 

--- a/src/Identity.ts
+++ b/src/Identity.ts
@@ -20,6 +20,10 @@ export const URI = 'Identity'
 
 export type URI = typeof URI
 
+export const of = <A>(a: A): Identity<A> => new Identity(a)
+
+export const extract = <A>(fa: Identity<A>): A => fa.extract()
+
 export class Identity<A>
   implements FantasyMonad<URI, A>,
     FantasyFoldable<A>,
@@ -69,9 +73,6 @@ export class Identity<A>
   fold<B>(f: (a: A) => B): B {
     return f(this.value)
   }
-  equals(setoid: Setoid<A>, fy: Identity<A>): boolean {
-    return setoid.equals(this.value)(fy.value)
-  }
   inspect() {
     return this.toString()
   }
@@ -80,39 +81,29 @@ export class Identity<A>
   }
 }
 
-export function equals<A>(setoid: Setoid<A>, fx: Identity<A>, fy: Identity<A>): boolean {
-  return fx.equals(setoid, fy as Identity<A>)
-}
+export const equals = <A>(setoid: Setoid<A>) => (fx: Identity<A>) => (fy: Identity<A>): boolean =>
+  setoid.equals(fx.value)(fy.value)
 
-export function getSetoid<A>(setoid: Setoid<A>): Setoid<Identity<A>> {
-  return {
-    equals: x => y => equals(setoid, x, y)
-  }
-}
+export const getSetoid = <A>(setoid: Setoid<A>): Setoid<Identity<A>> => ({
+  equals: equals(setoid)
+})
 
-export function map<A, B>(f: (a: A) => B, fa: Identity<A>): Identity<B> {
-  return fa.map(f)
-}
+export const map = <A, B>(f: (a: A) => B, fa: Identity<A>): Identity<B> => fa.map(f)
 
-export function of<A>(a: A): Identity<A> {
-  return new Identity(a)
-}
+export const ap = <A, B>(fab: Identity<(a: A) => B>, fa: Identity<A>): Identity<B> => fa.ap(fab)
 
-export function ap<A, B>(fab: Identity<(a: A) => B>, fa: Identity<A>): Identity<B> {
-  return fa.ap(fab)
-}
+export const chain = <A, B>(f: (a: A) => Identity<B>, fa: Identity<A>): Identity<B> => fa.chain(f)
 
-export function chain<A, B>(f: (a: A) => Identity<B>, fa: Identity<A>): Identity<B> {
-  return fa.chain(f)
-}
-
-export function reduce<A, B>(f: (b: B, a: A) => B, b: B, fa: Identity<A>): B {
-  return fa.reduce(f, b)
-}
+export const reduce = <A, B>(f: (b: B, a: A) => B, b: B, fa: Identity<A>): B => fa.reduce(f, b)
 
 export const alt = <A>(fx: Identity<A>) => (fy: Identity<A>): Identity<A> => {
   return fx.alt(fy)
 }
+
+export const extend = <A, B>(f: (ea: Identity<A>) => B, ea: Identity<A>): Identity<B> => ea.extend(f)
+
+export const chainRec = <A, B>(f: (a: A) => Identity<Either<A, B>>, a: A): Identity<B> =>
+  new Identity(tailRec(a => f(a).extract(), a))
 
 export class Ops {
   traverse<F extends HKT2S>(
@@ -129,18 +120,6 @@ export class Ops {
 
 const ops = new Ops()
 export const traverse: Ops['traverse'] = ops.traverse
-
-export function extend<A, B>(f: (ea: Identity<A>) => B, ea: Identity<A>): Identity<B> {
-  return ea.extend(f)
-}
-
-export function extract<A>(fa: Identity<A>): A {
-  return fa.extract()
-}
-
-export function chainRec<A, B>(f: (a: A) => Identity<Either<A, B>>, a: A): Identity<B> {
-  return new Identity(tailRec(a => f(a).extract(), a))
-}
 
 export const identity: Monad<URI> & Foldable<URI> & Traversable<URI> & Alt<URI> & Comonad<URI> & ChainRec<URI> = {
   URI,

--- a/src/IxIO.ts
+++ b/src/IxIO.ts
@@ -13,8 +13,13 @@ export const URI = 'IxIO'
 
 export type URI = typeof URI
 
+export const iof = <I, A>(a: A): IxIO<I, I, A> => new IxIO<I, I, A>(io.of(a))
+
+export const of = iof
+
 export class IxIO<I, O, A> implements FantasyIxMonad<URI, A, O, I> {
   static iof = iof
+  static of = of
   readonly _A: A
   readonly _L: O
   readonly _U: I
@@ -43,27 +48,13 @@ export class IxIO<I, O, A> implements FantasyIxMonad<URI, A, O, I> {
   }
 }
 
-export function iof<I, A>(a: A): IxIO<I, I, A> {
-  return new IxIO<I, I, A>(io.of(a))
-}
+export const ichain = <I, O, Z, A, B>(f: (a: A) => IxIO<O, Z, B>, fa: IxIO<I, O, A>): IxIO<I, Z, B> => fa.ichain(f)
 
-export function ichain<I, O, Z, A, B>(f: (a: A) => IxIO<O, Z, B>, fa: IxIO<I, O, A>): IxIO<I, Z, B> {
-  return fa.ichain(f)
-}
+export const map = <I, A, B>(f: (a: A) => B, fa: IxIO<I, I, A>): IxIO<I, I, B> => fa.map(f)
 
-export function map<I, A, B>(f: (a: A) => B, fa: IxIO<I, I, A>): IxIO<I, I, B> {
-  return fa.map(f)
-}
+export const ap = <I, A, B>(fab: IxIO<I, I, (a: A) => B>, fa: IxIO<I, I, A>): IxIO<I, I, B> => fa.ap(fab)
 
-export const of = iof
-
-export function ap<I, A, B>(fab: IxIO<I, I, (a: A) => B>, fa: IxIO<I, I, A>): IxIO<I, I, B> {
-  return fa.ap(fab)
-}
-
-export function chain<I, A, B>(f: (a: A) => IxIO<I, I, B>, fa: IxIO<I, I, A>): IxIO<I, I, B> {
-  return fa.chain(f)
-}
+export const chain = <I, A, B>(f: (a: A) => IxIO<I, I, B>, fa: IxIO<I, I, A>): IxIO<I, I, B> => fa.chain(f)
 
 export const ixIO: Monad<URI> & IxMonad<URI> = {
   URI,

--- a/src/IxIO.ts
+++ b/src/IxIO.ts
@@ -13,29 +13,17 @@ export const URI = 'IxIO'
 
 export type URI = typeof URI
 
-export const iof = <I, A>(a: A): IxIO<I, I, A> => new IxIO<I, I, A>(io.of(a))
-
-export const of = iof
-
 export class IxIO<I, O, A> implements FantasyIxMonad<URI, A, O, I> {
-  static iof = iof
-  static of = of
   readonly _A: A
   readonly _L: O
   readonly _U: I
   readonly _URI: URI
-  constructor(public readonly value: IO<A>) {}
+  constructor(readonly value: IO<A>) {}
   run(): A {
     return this.value.run()
   }
-  iof<I, B>(b: B): IxIO<I, I, B> {
-    return iof<I, B>(b)
-  }
   ichain<Z, B>(f: (a: A) => IxIO<O, Z, B>): IxIO<I, Z, B> {
     return new IxIO<I, Z, B>(this.value.chain(a => f(a).value))
-  }
-  of<I, B>(b: B): IxIO<I, I, B> {
-    return iof<I, B>(b)
   }
   map<B>(f: (a: A) => B): IxIO<I, O, B> {
     return new IxIO<I, O, B>(this.value.map(f))
@@ -48,9 +36,13 @@ export class IxIO<I, O, A> implements FantasyIxMonad<URI, A, O, I> {
   }
 }
 
+export const iof = <I, A>(a: A): IxIO<I, I, A> => new IxIO<I, I, A>(io.of(a))
+
 export const ichain = <I, O, Z, A, B>(f: (a: A) => IxIO<O, Z, B>, fa: IxIO<I, O, A>): IxIO<I, Z, B> => fa.ichain(f)
 
 export const map = <I, A, B>(f: (a: A) => B, fa: IxIO<I, I, A>): IxIO<I, I, B> => fa.map(f)
+
+export const of = iof
 
 export const ap = <I, A, B>(fab: IxIO<I, I, (a: A) => B>, fa: IxIO<I, I, A>): IxIO<I, I, B> => fa.ap(fab)
 

--- a/src/IxMonad.ts
+++ b/src/IxMonad.ts
@@ -10,8 +10,7 @@ export interface IxMonad<F> {
 }
 
 export interface FantasyIxMonad<F, A, O, I> {
-  iof<I, B>(b: B): HKT3<F, I, I, B>
-  ichain<Z, B>(f: (a: A) => HKT3<F, O, Z, B>): HKT3<F, I, Z, B>
+  ichain: <Z, B>(f: (a: A) => HKT3<F, O, Z, B>) => HKT3<F, I, Z, B>
 }
 
 export class Ops {

--- a/src/IxMonad.ts
+++ b/src/IxMonad.ts
@@ -5,8 +5,8 @@ import { constant } from './function'
 
 export interface IxMonad<F> {
   readonly URI: F
-  iof<I, A>(a: A): HKT3<F, I, I, A>
-  ichain<I, O, Z, A, B>(f: (a: A) => HKT3<F, O, Z, B>, fa: HKT3<F, I, O, A>): HKT3<F, I, Z, B>
+  iof: <I, A>(a: A) => HKT3<F, I, I, A>
+  ichain: <I, O, Z, A, B>(f: (a: A) => HKT3<F, O, Z, B>, fa: HKT3<F, I, O, A>) => HKT3<F, I, Z, B>
 }
 
 export interface FantasyIxMonad<F, A, O, I> {
@@ -17,20 +17,26 @@ export interface FantasyIxMonad<F, A, O, I> {
 export class Ops {
   iapplyFirst<F extends HKT3S>(
     ixmonad: IxMonad<F>
-  ): <I, O, Z, A, B>(fa: HKT3As<F, I, O, A>, fb: HKT3As<F, O, Z, B>) => HKT3As<F, I, Z, A>
-  iapplyFirst<F>(ixmonad: IxMonad<F>): <I, O, Z, A, B>(fa: HKT3<F, I, O, A>, fb: HKT3<F, O, Z, B>) => HKT3<F, I, Z, A>
-  iapplyFirst<F>(ixmonad: IxMonad<F>): <I, O, Z, A, B>(fa: HKT3<F, I, O, A>, fb: HKT3<F, O, Z, B>) => HKT3<F, I, Z, A> {
-    return (fa, fb) => ixmonad.ichain(a => ixmonad.ichain(() => ixmonad.iof(a), fb), fa)
+  ): <I, O, A>(fa: HKT3As<F, I, O, A>) => <Z, B>(fb: HKT3As<F, O, Z, B>) => HKT3As<F, I, Z, A>
+  iapplyFirst<F>(
+    ixmonad: IxMonad<F>
+  ): <I, O, A>(fa: HKT3<F, I, O, A>) => <Z, B>(fb: HKT3<F, O, Z, B>) => HKT3<F, I, Z, A>
+  iapplyFirst<F>(
+    ixmonad: IxMonad<F>
+  ): <I, O, A>(fa: HKT3<F, I, O, A>) => <Z, B>(fb: HKT3<F, O, Z, B>) => HKT3<F, I, Z, A> {
+    return fa => fb => ixmonad.ichain(a => ixmonad.ichain(() => ixmonad.iof(a), fb), fa)
   }
 
   iapplySecond<F extends HKT3S>(
     ixmonad: IxMonad<F>
-  ): <I, O, Z, A, B>(fa: HKT3As<F, I, O, A>, fb: HKT3As<F, O, Z, B>) => HKT3As<F, I, Z, B>
-  iapplySecond<F>(ixmonad: IxMonad<F>): <I, O, Z, A, B>(fa: HKT3<F, I, O, A>, fb: HKT3<F, O, Z, B>) => HKT3<F, I, Z, B>
+  ): <I, O, A>(fa: HKT3As<F, I, O, A>) => <Z, B>(fb: HKT3As<F, O, Z, B>) => HKT3As<F, I, Z, B>
   iapplySecond<F>(
     ixmonad: IxMonad<F>
-  ): <I, O, Z, A, B>(fa: HKT3<F, I, O, A>, fb: HKT3<F, O, Z, B>) => HKT3<F, I, Z, B> {
-    return (fa, fb) => ixmonad.ichain(constant(fb), fa)
+  ): <I, O, A>(fa: HKT3<F, I, O, A>) => <Z, B>(fb: HKT3<F, O, Z, B>) => HKT3<F, I, Z, B>
+  iapplySecond<F>(
+    ixmonad: IxMonad<F>
+  ): <I, O, A>(fa: HKT3<F, I, O, A>) => <Z, B>(fb: HKT3<F, O, Z, B>) => HKT3<F, I, Z, B> {
+    return fa => fb => ixmonad.ichain(constant(fb), fa)
   }
 }
 

--- a/src/Monoid.ts
+++ b/src/Monoid.ts
@@ -5,11 +5,11 @@ export interface Monoid<A> extends Semigroup<A> {
   empty(): A
 }
 
-export function fold<A>(monoid: Monoid<A>, as: Array<A>): A {
+export const fold = <A>(monoid: Monoid<A>) => (as: Array<A>): A => {
   return foldSemigroup(monoid)(monoid.empty())(as)
 }
 
-export function getProductMonoid<A, B>(amonoid: Monoid<A>, bmonoid: Monoid<B>): Monoid<[A, B]> {
+export const getProductMonoid = <A>(amonoid: Monoid<A>) => <B>(bmonoid: Monoid<B>): Monoid<[A, B]> => {
   const empty: [A, B] = [amonoid.empty(), bmonoid.empty()]
   return {
     empty: () => empty,

--- a/src/Monoid.ts
+++ b/src/Monoid.ts
@@ -24,50 +24,50 @@ export function getDualMonoid<A>(monoid: Monoid<A>): Monoid<A> {
 /** Boolean monoid under conjunction */
 export const monoidAll: Monoid<boolean> = {
   empty: () => true,
-  concat: (x, y) => x && y
+  concat: x => y => x && y
 }
 
 /** Boolean monoid under disjunction */
 export const monoidAny: Monoid<boolean> = {
   empty: () => false,
-  concat: (x, y) => x || y
+  concat: x => y => x || y
 }
 
 /** Monoid under array concatenation (`Array<any>`) */
 export const monoidArray: Monoid<Array<any>> = {
   empty: () => [],
-  concat: (x, y) => x.concat(y)
+  concat: x => y => x.concat(y)
 }
 
 /** Monoid under addition */
 export const monoidSum: Monoid<number> = {
   empty: () => 0,
-  concat: (x, y) => x + y
+  concat: x => y => x + y
 }
 
 /** Monoid under multiplication */
 export const monoidProduct: Monoid<number> = {
   empty: () => 1,
-  concat: (x, y) => x * y
+  concat: x => y => x * y
 }
 
 export const monoidString: Monoid<string> = {
   empty: () => '',
-  concat: (x, y) => x + y
+  concat: x => y => x + y
 }
 
 export function getFunctionMonoid<M>(monoid: Monoid<M>): <A>() => Monoid<(a: A) => M> {
   const empty = constant(constant(monoid.empty()))
   return <A>(): Monoid<(a: A) => M> => ({
     empty,
-    concat: (f, g) => a => monoid.concat(f(a), g(a))
+    concat: f => g => a => monoid.concat(f(a))(g(a))
   })
 }
 
 export function getEndomorphismMonoid<A>(): Monoid<Endomorphism<A>> {
   return {
     empty: () => identity,
-    concat: (x, y) => compose(x, y)
+    concat: x => y => compose(x, y)
   }
 }
 

--- a/src/Monoid.ts
+++ b/src/Monoid.ts
@@ -13,7 +13,7 @@ export function getProductMonoid<A, B>(amonoid: Monoid<A>, bmonoid: Monoid<B>): 
   const empty: [A, B] = [amonoid.empty(), bmonoid.empty()]
   return {
     empty: () => empty,
-    concat: getProductSemigroup(amonoid, bmonoid).concat
+    concat: getProductSemigroup(amonoid)(bmonoid).concat
   }
 }
 

--- a/src/Monoid.ts
+++ b/src/Monoid.ts
@@ -2,75 +2,72 @@ import { Semigroup, getProductSemigroup, getDualSemigroup, fold as foldSemigroup
 import { constant, Endomorphism, identity, compose } from './function'
 
 export interface Monoid<A> extends Semigroup<A> {
-  empty(): A
+  empty: () => A
 }
 
-export const fold = <A>(monoid: Monoid<A>) => (as: Array<A>): A => {
-  return foldSemigroup(monoid)(monoid.empty())(as)
+export const fold = <A>(M: Monoid<A>) => (as: Array<A>): A => {
+  return foldSemigroup(M)(M.empty())(as)
 }
 
-export const getProductMonoid = <A>(amonoid: Monoid<A>) => <B>(bmonoid: Monoid<B>): Monoid<[A, B]> => {
-  const empty: [A, B] = [amonoid.empty(), bmonoid.empty()]
+export const getProductMonoid = <A, B>(MA: Monoid<A>, MB: Monoid<B>): Monoid<[A, B]> => {
+  const empty: [A, B] = [MA.empty(), MB.empty()]
   return {
-    empty: () => empty,
-    concat: getProductSemigroup(amonoid)(bmonoid).concat
+    ...getProductSemigroup(MA, MB),
+    empty: () => empty
   }
 }
 
-export function getDualMonoid<A>(monoid: Monoid<A>): Monoid<A> {
-  return { empty: monoid.empty, concat: getDualSemigroup(monoid).concat }
-}
+export const getDualMonoid = <A>(M: Monoid<A>): Monoid<A> => ({
+  ...getDualSemigroup(M),
+  empty: M.empty
+})
 
 /** Boolean monoid under conjunction */
 export const monoidAll: Monoid<boolean> = {
-  empty: () => true,
-  concat: x => y => x && y
+  concat: x => y => x && y,
+  empty: () => true
 }
 
 /** Boolean monoid under disjunction */
 export const monoidAny: Monoid<boolean> = {
-  empty: () => false,
-  concat: x => y => x || y
+  concat: x => y => x || y,
+  empty: () => false
 }
 
 /** Monoid under array concatenation (`Array<any>`) */
 export const monoidArray: Monoid<Array<any>> = {
-  empty: () => [],
-  concat: x => y => x.concat(y)
+  concat: x => y => x.concat(y),
+  empty: () => []
 }
 
 /** Monoid under addition */
 export const monoidSum: Monoid<number> = {
-  empty: () => 0,
-  concat: x => y => x + y
+  concat: x => y => x + y,
+  empty: () => 0
 }
 
 /** Monoid under multiplication */
 export const monoidProduct: Monoid<number> = {
-  empty: () => 1,
-  concat: x => y => x * y
+  concat: x => y => x * y,
+  empty: () => 1
 }
 
 export const monoidString: Monoid<string> = {
-  empty: () => '',
-  concat: x => y => x + y
+  concat: x => y => x + y,
+  empty: () => ''
 }
 
-export function getFunctionMonoid<M>(monoid: Monoid<M>): <A>() => Monoid<(a: A) => M> {
+export const getFunctionMonoid = <M>(monoid: Monoid<M>): (<A>() => Monoid<(a: A) => M>) => {
   const empty = constant(constant(monoid.empty()))
-  return <A>(): Monoid<(a: A) => M> => ({
-    empty,
-    concat: f => g => a => monoid.concat(f(a))(g(a))
+  return () => ({
+    concat: f => g => a => monoid.concat(f(a))(g(a)),
+    empty
   })
 }
 
-export function getEndomorphismMonoid<A>(): Monoid<Endomorphism<A>> {
-  return {
-    empty: () => identity,
-    concat: x => y => compose(x, y)
-  }
-}
+export const getEndomorphismMonoid = <A>(): Monoid<Endomorphism<A>> => ({
+  concat: x => y => compose(x, y),
+  empty: () => identity
+})
 
-export function getArrayMonoid<A>(): Monoid<Array<A>> {
-  return monoidArray
-}
+export const getArrayMonoid = <A>(): Monoid<Array<A>> => monoidArray

--- a/src/Monoid.ts
+++ b/src/Monoid.ts
@@ -6,7 +6,7 @@ export interface Monoid<A> extends Semigroup<A> {
 }
 
 export function fold<A>(monoid: Monoid<A>, as: Array<A>): A {
-  return foldSemigroup(monoid, monoid.empty(), as)
+  return foldSemigroup(monoid)(monoid.empty())(as)
 }
 
 export function getProductMonoid<A, B>(amonoid: Monoid<A>, bmonoid: Monoid<B>): Monoid<[A, B]> {

--- a/src/Monoidal.ts
+++ b/src/Monoidal.ts
@@ -1,11 +1,7 @@
 import { HKT } from './HKT'
 import { Functor } from './Functor'
 import { Applicative } from './Applicative'
-import { constant } from './function'
-
-function tuple<A>(a: A): <B>(b: B) => [A, B] {
-  return b => [a, b]
-}
+import { constant, curriedTuple } from './function'
 
 /**
  * Applicative functors are equivalent to strong lax monoidal functors
@@ -14,24 +10,20 @@ function tuple<A>(a: A): <B>(b: B) => [A, B] {
  */
 export interface Monoidal<F> extends Functor<F> {
   readonly URI: F
-  unit(): HKT<F, void>
-  mult<A, B>(fa: HKT<F, A>, fb: HKT<F, B>): HKT<F, [A, B]>
+  unit: () => HKT<F, void>
+  mult: <A>(fa: HKT<F, A>) => <B>(fb: HKT<F, B>) => HKT<F, [A, B]>
 }
 
-export function fromApplicative<F>(applicative: Applicative<F>): Monoidal<F> {
-  return {
-    URI: applicative.URI,
-    map: applicative.map,
-    unit: () => applicative.of(undefined),
-    mult: (fa, fb) => applicative.ap(applicative.ap(applicative.of(tuple), fa), fb)
-  }
-}
+export const fromApplicative = <F>(applicative: Applicative<F>): Monoidal<F> => ({
+  URI: applicative.URI,
+  map: applicative.map,
+  unit: () => applicative.of(undefined),
+  mult: fa => fb => applicative.ap(applicative.ap(applicative.of(curriedTuple), fa), fb)
+})
 
-export function toApplicative<F>(monoidal: Monoidal<F>): Applicative<F> {
-  return {
-    URI: monoidal.URI,
-    map: monoidal.map,
-    of: a => monoidal.map(constant(a), monoidal.unit()),
-    ap: (fab, fa) => monoidal.map(([f, a]) => f(a), monoidal.mult(fab, fa))
-  }
-}
+export const toApplicative = <F>(monoidal: Monoidal<F>): Applicative<F> => ({
+  URI: monoidal.URI,
+  map: monoidal.map,
+  of: a => monoidal.map(constant(a), monoidal.unit()),
+  ap: (fab, fa) => monoidal.map(([f, a]) => f(a), monoidal.mult(fab)(fa))
+})

--- a/src/NonEmptyArray.ts
+++ b/src/NonEmptyArray.ts
@@ -19,14 +19,11 @@ export const URI = 'NonEmptyArray'
 
 export type URI = typeof URI
 
-export const of = <A>(a: A): NonEmptyArray<A> => new NonEmptyArray(a, [])
-
 export class NonEmptyArray<A>
   implements FantasyMonad<URI, A>, FantasyComonad<URI, A>, FantasyFoldable<A>, FantasyTraversable<URI, A> {
-  static of = of
   readonly _A: A
   readonly _URI: URI
-  constructor(public readonly head: A, public readonly tail: Array<A>) {}
+  constructor(readonly head: A, readonly tail: Array<A>) {}
   toArray(): Array<A> {
     return [this.head].concat(this.tail)
   }
@@ -35,9 +32,6 @@ export class NonEmptyArray<A>
   }
   map<B>(f: (a: A) => B): NonEmptyArray<B> {
     return new NonEmptyArray(f(this.head), this.tail.map(f))
-  }
-  of<B>(b: B): NonEmptyArray<B> {
-    return of(b)
   }
   ap<B>(fab: NonEmptyArray<(a: A) => B>): NonEmptyArray<B> {
     return fab.chain(f => this.map(f)) // <= derived
@@ -81,6 +75,8 @@ const unsafeFromArray = <A>(as: Array<A>): NonEmptyArray<A> => new NonEmptyArray
 export const fromArray = <A>(as: Array<A>): Option<NonEmptyArray<A>> => (as.length ? some(unsafeFromArray(as)) : none)
 
 export const map = <A, B>(f: (a: A) => B, fa: NonEmptyArray<A>): NonEmptyArray<B> => fa.map(f)
+
+export const of = <A>(a: A): NonEmptyArray<A> => new NonEmptyArray(a, [])
 
 export const ap = <A, B>(fab: NonEmptyArray<(a: A) => B>, fa: NonEmptyArray<A>): NonEmptyArray<B> => fa.ap(fab)
 

--- a/src/NonEmptyArray.ts
+++ b/src/NonEmptyArray.ts
@@ -19,6 +19,8 @@ export const URI = 'NonEmptyArray'
 
 export type URI = typeof URI
 
+export const of = <A>(a: A): NonEmptyArray<A> => new NonEmptyArray(a, [])
+
 export class NonEmptyArray<A>
   implements FantasyMonad<URI, A>, FantasyComonad<URI, A>, FantasyFoldable<A>, FantasyTraversable<URI, A> {
   static of = of
@@ -74,37 +76,23 @@ export class NonEmptyArray<A>
   }
 }
 
-function unsafeFromArray<A>(as: Array<A>): NonEmptyArray<A> {
-  return new NonEmptyArray(as[0], as.slice(1))
-}
+const unsafeFromArray = <A>(as: Array<A>): NonEmptyArray<A> => new NonEmptyArray(as[0], as.slice(1))
 
-export function fromArray<A>(as: Array<A>): Option<NonEmptyArray<A>> {
-  return as.length ? some(unsafeFromArray(as)) : none
-}
+export const fromArray = <A>(as: Array<A>): Option<NonEmptyArray<A>> => (as.length ? some(unsafeFromArray(as)) : none)
 
-export function map<A, B>(f: (a: A) => B, fa: NonEmptyArray<A>): NonEmptyArray<B> {
-  return fa.map(f)
-}
+export const map = <A, B>(f: (a: A) => B, fa: NonEmptyArray<A>): NonEmptyArray<B> => fa.map(f)
 
-export function ap<A, B>(fab: NonEmptyArray<(a: A) => B>, fa: NonEmptyArray<A>): NonEmptyArray<B> {
-  return fa.ap(fab)
-}
+export const ap = <A, B>(fab: NonEmptyArray<(a: A) => B>, fa: NonEmptyArray<A>): NonEmptyArray<B> => fa.ap(fab)
 
-export function of<A>(a: A): NonEmptyArray<A> {
-  return new NonEmptyArray(a, [])
-}
+export const chain = <A, B>(f: (a: A) => NonEmptyArray<B>, fa: NonEmptyArray<A>): NonEmptyArray<B> => fa.chain(f)
 
-export function chain<A, B>(f: (a: A) => NonEmptyArray<B>, fa: NonEmptyArray<A>): NonEmptyArray<B> {
-  return fa.chain(f)
-}
+export const concat = <A>(fx: NonEmptyArray<A>) => (fy: NonEmptyArray<A>): NonEmptyArray<A> => fx.concat(fy)
 
-export const concat = <A>(fx: NonEmptyArray<A>) => (fy: NonEmptyArray<A>): NonEmptyArray<A> => {
-  return fx.concat(fy)
-}
+export const reduce = <A, B>(f: (b: B, a: A) => B, b: B, fa: NonEmptyArray<A>): B => fa.reduce(f, b)
 
-export function reduce<A, B>(f: (b: B, a: A) => B, b: B, fa: NonEmptyArray<A>): B {
-  return fa.reduce(f, b)
-}
+export const extend = <A, B>(f: (fa: NonEmptyArray<A>) => B, fa: NonEmptyArray<A>): NonEmptyArray<B> => fa.extend(f)
+
+export const extract = <A>(fa: NonEmptyArray<A>): A => fa.extract()
 
 export class Ops {
   traverse<F extends HKT2S>(
@@ -121,14 +109,6 @@ export class Ops {
 
 const ops = new Ops()
 export const traverse: Ops['traverse'] = ops.traverse
-
-export function extend<A, B>(f: (fa: NonEmptyArray<A>) => B, fa: NonEmptyArray<A>): NonEmptyArray<B> {
-  return fa.extend(f)
-}
-
-export function extract<A>(fa: NonEmptyArray<A>): A {
-  return fa.extract()
-}
 
 export const nonEmptyArray: Monad<URI> & Comonad<URI> & Semigroup<any> & Foldable<URI> & Traversable<URI> = {
   URI,

--- a/src/NonEmptyArray.ts
+++ b/src/NonEmptyArray.ts
@@ -98,7 +98,7 @@ export function chain<A, B>(f: (a: A) => NonEmptyArray<B>, fa: NonEmptyArray<A>)
   return fa.chain(f)
 }
 
-export function concat<A>(fx: NonEmptyArray<A>, fy: NonEmptyArray<A>): NonEmptyArray<A> {
+export const concat = <A>(fx: NonEmptyArray<A>) => (fy: NonEmptyArray<A>): NonEmptyArray<A> => {
   return fx.concat(fy)
 }
 

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -205,7 +205,7 @@ export class Some<A>
     return fy.fold(() => this, y => new Some(semigroup.concat(this.value)(y)))
   }
   equals(setoid: Setoid<A>, fy: Option<A>): boolean {
-    return fy.fold(constFalse, y => setoid.equals(this.value, y))
+    return fy.fold(constFalse, y => setoid.equals(this.value)(y))
   }
   toNullable(): A | null {
     return this.value
@@ -217,7 +217,7 @@ export class Some<A>
     return `some(${toString(this.value)})`
   }
   contains(setoid: Setoid<A>, a: A): boolean {
-    return setoid.equals(this.value, a)
+    return setoid.equals(this.value)(a)
   }
   isNone(): boolean {
     return false
@@ -236,7 +236,7 @@ export function equals<A>(setoid: Setoid<A>, fx: Option<A>, fy: Option<A>): bool
 
 export function getSetoid<A>(setoid: Setoid<A>): Setoid<Option<A>> {
   return {
-    equals: (x, y) => equals(setoid, x, y)
+    equals: x => y => equals(setoid, x, y)
   }
 }
 

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -202,7 +202,7 @@ export class Some<A>
     return this.value
   }
   concat(semigroup: Semigroup<A>, fy: Option<A>): Option<A> {
-    return fy.fold(() => this, y => new Some(semigroup.concat(this.value, y)))
+    return fy.fold(() => this, y => new Some(semigroup.concat(this.value)(y)))
   }
   equals(setoid: Setoid<A>, fy: Option<A>): boolean {
     return fy.fold(constFalse, y => setoid.equals(this.value, y))
@@ -304,7 +304,7 @@ export function extend<A, B>(f: (ea: Option<A>) => B, ea: Option<A>): Option<B> 
   return ea.extend(f)
 }
 
-const first = { empty, concat: <A>(fx: Option<A>, fy: Option<A>) => alt(fx)(fy) }
+const first = { empty, concat: alt }
 const last = getDualMonoid(first)
 
 /** Maybe monoid returning the left-most non-None value */
@@ -322,7 +322,7 @@ export function concat<A>(semigroup: Semigroup<A>, fx: Option<A>, fy: Option<A>)
 }
 
 export function getSemigroup<A>(semigroup: Semigroup<A>): Semigroup<Option<A>> {
-  return { concat: (fx, fy) => concat(semigroup, fx, fy) }
+  return { concat: fx => fy => concat(semigroup, fx, fy) }
 }
 
 export function getMonoid<A>(semigroup: Semigroup<A>): Monoid<Option<A>> {

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -294,15 +294,17 @@ export class Ops {
 const ops = new Ops()
 export const traverse: Ops['traverse'] = ops.traverse
 
-export function alt<A>(fx: Option<A>, fy: Option<A>): Option<A> {
-  return fx.alt(fy)
+export function alt(fx: Option<never>): <A>(fy: Option<A>) => Option<A>
+export function alt<A>(fx: Option<A>): (fy: Option<A>) => Option<A>
+export function alt<A>(fx: Option<A>): (fy: Option<A>) => Option<A> {
+  return fy => fx.alt(fy)
 }
 
 export function extend<A, B>(f: (ea: Option<A>) => B, ea: Option<A>): Option<B> {
   return ea.extend(f)
 }
 
-const first = { empty, concat: alt }
+const first = { empty, concat: <A>(fx: Option<A>, fy: Option<A>) => alt(fx)(fy) }
 const last = getDualMonoid(first)
 
 /** Maybe monoid returning the left-most non-None value */

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -242,7 +242,12 @@ export const chain = <A, B>(f: (a: A) => Option<B>, fa: Option<A>): Option<B> =>
 
 export const reduce = <A, B>(f: (b: B, a: A) => B, b: B, fa: Option<A>): B => fa.reduce(f, b)
 
-export const alt = <A>(fx: Option<A>): ((fy: Option<A>) => Option<A>) => fy => fx.alt(fy)
+// overload here to support 'none' as first argument
+export function alt(fx: Option<never>): <A>(fy: Option<A>) => Option<A>
+export function alt<A>(fx: Option<A>): (fy: Option<A>) => Option<A>
+export function alt<A>(fx: Option<A>): (fy: Option<A>) => Option<A> {
+  return fy => fx.alt(fy)
+}
 
 export const extend = <A, B>(f: (ea: Option<A>) => B, ea: Option<A>): Option<B> => ea.extend(f)
 

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -26,12 +26,6 @@ export type URI = typeof URI
 
 export type Option<A> = None<A> | Some<A>
 
-export const of = <A>(a: A): Option<A> => new Some(a)
-
-export const zero = <A>(): Option<A> => none
-
-export const empty = zero
-
 export class None<A>
   implements FantasyMonad<URI, A>,
     FantasyFoldable<A>,
@@ -40,9 +34,6 @@ export class None<A>
     FantasyWitherable<URI, A>,
     FantasyAlternative<URI, A>,
     FantasyExtend<URI, A> {
-  static of = of
-  static empty = empty
-  static zero = zero
   static value: Option<never> = new None()
   readonly _tag: 'None' = 'None'
   readonly _A: A
@@ -50,9 +41,6 @@ export class None<A>
   private constructor() {}
   map<B>(f: (a: A) => B): Option<B> {
     return none
-  }
-  of<B>(b: B): Option<B> {
-    return of(b)
   }
   ap<B>(fab: Option<(a: A) => B>): Option<B> {
     return none
@@ -79,9 +67,6 @@ export class None<A>
     M: Applicative<M>
   ): <L, R>(f: (a: A) => HKT<M, Either<L, R>>) => HKT<M, { left: Option<L>; right: Option<R> }> {
     return <L, R>(f: (a: A) => HKT<M, Either<L, R>>) => M.of({ left: none, right: none })
-  }
-  zero<B>(): Option<B> {
-    return zero()
   }
   alt(fa: Option<A>): Option<A> {
     return fa
@@ -134,18 +119,12 @@ export class Some<A>
     FantasyWitherable<URI, A>,
     FantasyAlternative<URI, A>,
     FantasyExtend<URI, A> {
-  static of = of
-  static empty = empty
-  static zero = zero
   readonly _tag: 'Some' = 'Some'
   readonly _A: A
   readonly _URI: URI
-  constructor(public readonly value: A) {}
+  constructor(readonly value: A) {}
   map<B>(f: (a: A) => B): Option<B> {
     return new Some(f(this.value))
-  }
-  of<B>(b: B): Option<B> {
-    return of(b)
   }
   ap<B>(fab: Option<(a: A) => B>): Option<B> {
     return fab.map(f => f(this.value))
@@ -183,9 +162,6 @@ export class Some<A>
           ),
         f(this.value)
       )
-  }
-  zero<B>(): Option<B> {
-    return zero<B>()
   }
   alt(fa: Option<A>): Option<A> {
     return this
@@ -236,6 +212,8 @@ export const getSetoid = <A>(S: Setoid<A>): Setoid<Option<A>> => ({
 
 export const map = <A, B>(f: (a: A) => B, fa: Option<A>): Option<B> => fa.map(f)
 
+export const of = <A>(a: A): Option<A> => new Some(a)
+
 export const ap = <A, B>(fab: Option<(a: A) => B>, fa: Option<A>): Option<B> => fa.ap(fab)
 
 export const chain = <A, B>(f: (a: A) => Option<B>, fa: Option<A>): Option<B> => fa.chain(f)
@@ -250,6 +228,10 @@ export function alt<A>(fx: Option<A>): (fy: Option<A>) => Option<A> {
 }
 
 export const extend = <A, B>(f: (ea: Option<A>) => B, ea: Option<A>): Option<B> => ea.extend(f)
+
+export const zero = <A>(): Option<A> => none
+
+export const empty = zero
 
 const first = { empty, concat: alt }
 const last = getDualMonoid(first)

--- a/src/OptionT.ts
+++ b/src/OptionT.ts
@@ -70,7 +70,7 @@ export class Ops {
     return (none, some, fa) => F.map(o => o.fold(none, some), fa)
   }
 
-  getOrElse<F extends HKT2S>(F: Functor<F>): <L, A>(f: Lazy<A>) => (fa: HKT2As<F, L, Option<A>>) => HKT2As<F, L, A>
+  getOrElse<F extends HKT2S>(F: Functor<F>): <A>(f: Lazy<A>) => <L>(fa: HKT2As<F, L, Option<A>>) => HKT2As<F, L, A>
   getOrElse<F extends HKTS>(F: Functor<F>): <A>(f: Lazy<A>) => (fa: HKTAs<F, Option<A>>) => HKTAs<F, A>
   getOrElse<F>(F: Functor<F>): <A>(f: Lazy<A>) => (fa: HKT<F, Option<A>>) => HKT<F, A>
   getOrElse<F>(F: Functor<F>): <A>(f: Lazy<A>) => (fa: HKT<F, Option<A>>) => HKT<F, A> {

--- a/src/OptionT.ts
+++ b/src/OptionT.ts
@@ -70,11 +70,11 @@ export class Ops {
     return (none, some, fa) => F.map(o => o.fold(none, some), fa)
   }
 
-  getOrElse<F extends HKT2S>(F: Functor<F>): <L, A>(f: Lazy<A>, fa: HKT2As<F, L, Option<A>>) => HKT2As<F, L, A>
-  getOrElse<F extends HKTS>(F: Functor<F>): <A>(f: Lazy<A>, fa: HKTAs<F, Option<A>>) => HKTAs<F, A>
-  getOrElse<F>(F: Functor<F>): <A>(f: Lazy<A>, fa: HKT<F, Option<A>>) => HKT<F, A>
-  getOrElse<F>(F: Functor<F>): <A>(f: Lazy<A>, fa: HKT<F, Option<A>>) => HKT<F, A> {
-    return (f, fa) => F.map(o => o.getOrElse(f), fa)
+  getOrElse<F extends HKT2S>(F: Functor<F>): <L, A>(f: Lazy<A>) => (fa: HKT2As<F, L, Option<A>>) => HKT2As<F, L, A>
+  getOrElse<F extends HKTS>(F: Functor<F>): <A>(f: Lazy<A>) => (fa: HKTAs<F, Option<A>>) => HKTAs<F, A>
+  getOrElse<F>(F: Functor<F>): <A>(f: Lazy<A>) => (fa: HKT<F, Option<A>>) => HKT<F, A>
+  getOrElse<F>(F: Functor<F>): <A>(f: Lazy<A>) => (fa: HKT<F, Option<A>>) => HKT<F, A> {
+    return f => fa => F.map(o => o.getOrElse(f), fa)
   }
 
   getOptionT<M extends HKT2S>(M: Monad<M>): OptionT2<M>

--- a/src/OptionT.ts
+++ b/src/OptionT.ts
@@ -81,7 +81,7 @@ export class Ops {
   getOptionT<M extends HKTS>(M: Monad<M>): OptionT1<M>
   getOptionT<M>(M: Monad<M>): OptionT<M>
   getOptionT<M>(M: Monad<M>): OptionT<M> {
-    const applicativeComposition = getApplicativeComposition(M, option)
+    const applicativeComposition = getApplicativeComposition(M)(option)
 
     return {
       ...applicativeComposition,

--- a/src/OptionT.ts
+++ b/src/OptionT.ts
@@ -81,7 +81,7 @@ export class Ops {
   getOptionT<M extends HKTS>(M: Monad<M>): OptionT1<M>
   getOptionT<M>(M: Monad<M>): OptionT<M>
   getOptionT<M>(M: Monad<M>): OptionT<M> {
-    const applicativeComposition = getApplicativeComposition(M)(option)
+    const applicativeComposition = getApplicativeComposition(M, option)
 
     return {
       ...applicativeComposition,

--- a/src/Ord.ts
+++ b/src/Ord.ts
@@ -22,34 +22,34 @@ export const numberOrd: Ord<number> = { compare: unsafeCompare, equals: setoidNu
 
 export const booleanOrd: Ord<boolean> = { compare: unsafeCompare, equals: setoidBoolean.equals }
 
-export function lessThan<A>(ord: Ord<A>, x: A, y: A): boolean {
+export const lessThan = <A>(ord: Ord<A>) => (x: A) => (y: A): boolean => {
   return ord.compare(x)(y) === 'LT'
 }
 
-export function greaterThan<A>(ord: Ord<A>, x: A, y: A): boolean {
+export const greaterThan = <A>(ord: Ord<A>) => (x: A) => (y: A): boolean => {
   return ord.compare(x)(y) === 'GT'
 }
 
-export function lessThanOrEq<A>(ord: Ord<A>, x: A, y: A): boolean {
+export const lessThanOrEq = <A>(ord: Ord<A>) => (x: A) => (y: A): boolean => {
   return ord.compare(x)(y) !== 'GT'
 }
 
-export function greaterThanOrEq<A>(ord: Ord<A>, x: A, y: A): boolean {
+export const greaterThanOrEq = <A>(ord: Ord<A>) => (x: A) => (y: A): boolean => {
   return ord.compare(x)(y) !== 'LT'
 }
 
-export function min<A>(ord: Ord<A>, x: A, y: A): A {
+export const min = <A>(ord: Ord<A>) => (x: A) => (y: A): A => {
   return ord.compare(x)(y) === 'GT' ? y : x
 }
 
-export function max<A>(ord: Ord<A>, x: A, y: A): A {
+export const max = <A>(ord: Ord<A>) => (x: A) => (y: A): A => {
   return ord.compare(x)(y) === 'LT' ? y : x
 }
 
-export function clamp<A>(ord: Ord<A>, low: A, hi: A, x: A): A {
-  return min(ord, hi, max(ord, low, x))
+export const clamp = <A>(ord: Ord<A>) => (low: A) => (hi: A) => (x: A): A => {
+  return min(ord)(hi)(max(ord)(low)(x))
 }
 
-export function between<A>(ord: Ord<A>, low: A, hi: A, x: A): boolean {
-  return lessThan(ord, x, low) || greaterThan(ord, x, hi) ? false : true
+export const between = <A>(ord: Ord<A>) => (low: A) => (hi: A) => (x: A): boolean => {
+  return lessThan(ord)(x)(low) || greaterThan(ord)(x)(hi) ? false : true
 }

--- a/src/Ord.ts
+++ b/src/Ord.ts
@@ -2,17 +2,17 @@ import { Ordering } from './Ordering'
 import { Setoid, setoidBoolean, setoidNumber, setoidString } from './Setoid'
 
 export interface Ord<A> extends Setoid<A> {
-  compare(x: A, y: A): Ordering
+  compare: (x: A) => (y: A) => Ordering
 }
 
-export function toNativeComparator<A>(compare: (x: A, y: A) => Ordering): (x: A, y: A) => number {
+export function toNativeComparator<A>(compare: (x: A) => (y: A) => Ordering): (x: A, y: A) => number {
   return (x, y) => {
-    const c = compare(x, y)
+    const c = compare(x)(y)
     return c === 'GT' ? 1 : c === 'EQ' ? 0 : -1
   }
 }
 
-export function unsafeCompare(x: any, y: any): Ordering {
+export const unsafeCompare = (x: any) => (y: any): Ordering => {
   return x < y ? 'LT' : x > y ? 'GT' : 'EQ'
 }
 
@@ -23,27 +23,27 @@ export const numberOrd: Ord<number> = { compare: unsafeCompare, equals: setoidNu
 export const booleanOrd: Ord<boolean> = { compare: unsafeCompare, equals: setoidBoolean.equals }
 
 export function lessThan<A>(ord: Ord<A>, x: A, y: A): boolean {
-  return ord.compare(x, y) === 'LT'
+  return ord.compare(x)(y) === 'LT'
 }
 
 export function greaterThan<A>(ord: Ord<A>, x: A, y: A): boolean {
-  return ord.compare(x, y) === 'GT'
+  return ord.compare(x)(y) === 'GT'
 }
 
 export function lessThanOrEq<A>(ord: Ord<A>, x: A, y: A): boolean {
-  return ord.compare(x, y) !== 'GT'
+  return ord.compare(x)(y) !== 'GT'
 }
 
 export function greaterThanOrEq<A>(ord: Ord<A>, x: A, y: A): boolean {
-  return ord.compare(x, y) !== 'LT'
+  return ord.compare(x)(y) !== 'LT'
 }
 
 export function min<A>(ord: Ord<A>, x: A, y: A): A {
-  return ord.compare(x, y) === 'GT' ? y : x
+  return ord.compare(x)(y) === 'GT' ? y : x
 }
 
 export function max<A>(ord: Ord<A>, x: A, y: A): A {
-  return ord.compare(x, y) === 'LT' ? y : x
+  return ord.compare(x)(y) === 'LT' ? y : x
 }
 
 export function clamp<A>(ord: Ord<A>, low: A, hi: A, x: A): A {

--- a/src/Ord.ts
+++ b/src/Ord.ts
@@ -5,51 +5,41 @@ export interface Ord<A> extends Setoid<A> {
   compare: (x: A) => (y: A) => Ordering
 }
 
-export function toNativeComparator<A>(compare: (x: A) => (y: A) => Ordering): (x: A, y: A) => number {
-  return (x, y) => {
-    const c = compare(x)(y)
-    return c === 'GT' ? 1 : c === 'EQ' ? 0 : -1
-  }
+export const toNativeComparator = <A>(compare: (x: A) => (y: A) => Ordering): ((x: A, y: A) => number) => (x, y) => {
+  const c = compare(x)(y)
+  return c === 'GT' ? 1 : c === 'EQ' ? 0 : -1
 }
 
-export const unsafeCompare = (x: any) => (y: any): Ordering => {
-  return x < y ? 'LT' : x > y ? 'GT' : 'EQ'
+export const unsafeCompare = (x: any) => (y: any): Ordering => (x < y ? 'LT' : x > y ? 'GT' : 'EQ')
+
+export const ordString: Ord<string> = {
+  ...setoidString,
+  compare: unsafeCompare
 }
 
-export const stringOrd: Ord<string> = { compare: unsafeCompare, equals: setoidString.equals }
-
-export const numberOrd: Ord<number> = { compare: unsafeCompare, equals: setoidNumber.equals }
-
-export const booleanOrd: Ord<boolean> = { compare: unsafeCompare, equals: setoidBoolean.equals }
-
-export const lessThan = <A>(ord: Ord<A>) => (x: A) => (y: A): boolean => {
-  return ord.compare(x)(y) === 'LT'
+export const ordNumber: Ord<number> = {
+  ...setoidNumber,
+  compare: unsafeCompare
 }
 
-export const greaterThan = <A>(ord: Ord<A>) => (x: A) => (y: A): boolean => {
-  return ord.compare(x)(y) === 'GT'
+export const ordBooleanOrd: Ord<boolean> = {
+  ...setoidBoolean,
+  compare: unsafeCompare
 }
 
-export const lessThanOrEq = <A>(ord: Ord<A>) => (x: A) => (y: A): boolean => {
-  return ord.compare(x)(y) !== 'GT'
-}
+export const lessThan = <A>(ord: Ord<A>) => (x: A) => (y: A): boolean => ord.compare(x)(y) === 'LT'
 
-export const greaterThanOrEq = <A>(ord: Ord<A>) => (x: A) => (y: A): boolean => {
-  return ord.compare(x)(y) !== 'LT'
-}
+export const greaterThan = <A>(ord: Ord<A>) => (x: A) => (y: A): boolean => ord.compare(x)(y) === 'GT'
 
-export const min = <A>(ord: Ord<A>) => (x: A) => (y: A): A => {
-  return ord.compare(x)(y) === 'GT' ? y : x
-}
+export const lessThanOrEq = <A>(ord: Ord<A>) => (x: A) => (y: A): boolean => ord.compare(x)(y) !== 'GT'
 
-export const max = <A>(ord: Ord<A>) => (x: A) => (y: A): A => {
-  return ord.compare(x)(y) === 'LT' ? y : x
-}
+export const greaterThanOrEq = <A>(ord: Ord<A>) => (x: A) => (y: A): boolean => ord.compare(x)(y) !== 'LT'
 
-export const clamp = <A>(ord: Ord<A>) => (low: A) => (hi: A) => (x: A): A => {
-  return min(ord)(hi)(max(ord)(low)(x))
-}
+export const min = <A>(ord: Ord<A>) => (x: A) => (y: A): A => (ord.compare(x)(y) === 'GT' ? y : x)
 
-export const between = <A>(ord: Ord<A>) => (low: A) => (hi: A) => (x: A): boolean => {
-  return lessThan(ord)(x)(low) || greaterThan(ord)(x)(hi) ? false : true
-}
+export const max = <A>(ord: Ord<A>) => (x: A) => (y: A): A => (ord.compare(x)(y) === 'LT' ? y : x)
+
+export const clamp = <A>(ord: Ord<A>) => (low: A) => (hi: A) => (x: A): A => min(ord)(hi)(max(ord)(low)(x))
+
+export const between = <A>(ord: Ord<A>) => (low: A) => (hi: A) => (x: A): boolean =>
+  lessThan(ord)(x)(low) || greaterThan(ord)(x)(hi) ? false : true

--- a/src/Ordering.ts
+++ b/src/Ordering.ts
@@ -4,7 +4,7 @@ import { Semigroup } from './Semigroup'
 export type Ordering = 'LT' | 'EQ' | 'GT'
 
 export const orderingSetoid: Setoid<Ordering> = {
-  equals(a, b) {
+  equals: a => b => {
     return a === b
   }
 }

--- a/src/Ordering.ts
+++ b/src/Ordering.ts
@@ -10,7 +10,7 @@ export const orderingSetoid: Setoid<Ordering> = {
 }
 
 export const orderingSemigroup: Semigroup<Ordering> = {
-  concat(a, b) {
+  concat: a => b => {
     if (a === 'LT') {
       return 'LT'
     }

--- a/src/Ordering.ts
+++ b/src/Ordering.ts
@@ -21,7 +21,7 @@ export const orderingSemigroup: Semigroup<Ordering> = {
   }
 }
 
-export function invert(a: Ordering): Ordering {
+export const invert = (a: Ordering): Ordering => {
   if (a === 'LT') {
     return 'GT'
   }

--- a/src/Pair.ts
+++ b/src/Pair.ts
@@ -126,15 +126,15 @@ export function getOrd<A>(O: Ord<A>): Ord<Pair<A>> {
   return {
     ...S,
     compare(x, y) {
-      return orderingSemigroup.concat(O.compare(x.fst(), y.fst()), O.compare(x.snd(), y.snd()))
+      return orderingSemigroup.concat(O.compare(x.fst(), y.fst()))(O.compare(x.snd(), y.snd()))
     }
   }
 }
 
 export function getSemigroup<A>(S: Semigroup<A>): Semigroup<Pair<A>> {
   return {
-    concat(x, y) {
-      return new Pair([S.concat(x.fst(), y.fst()), S.concat(x.snd(), y.snd())])
+    concat: x => y => {
+      return new Pair([S.concat(x.fst())(y.fst()), S.concat(x.snd())(y.snd())])
     }
   }
 }

--- a/src/Pair.ts
+++ b/src/Pair.ts
@@ -115,8 +115,8 @@ export function extend<A, B>(f: (fb: Pair<A>) => B, fa: Pair<A>): Pair<B> {
 
 export function getSetoid<A>(S: Setoid<A>): Setoid<Pair<A>> {
   return {
-    equals(x, y) {
-      return S.equals(x.fst(), y.fst()) && S.equals(x.snd(), y.snd())
+    equals: x => y => {
+      return S.equals(x.fst())(y.fst()) && S.equals(x.snd())(y.snd())
     }
   }
 }

--- a/src/Pair.ts
+++ b/src/Pair.ts
@@ -23,13 +23,10 @@ export const URI = 'Pair'
 
 export type URI = typeof URI
 
-export const of = <A>(a: A): Pair<A> => new Pair([a, a])
-
 export class Pair<A> {
-  static of = of
   readonly _A: A
   readonly _URI: URI
-  constructor(public readonly value: [A, A]) {}
+  constructor(readonly value: [A, A]) {}
   fst(): A {
     return this.value[0]
   }
@@ -50,9 +47,6 @@ export class Pair<A> {
   }
   map<B>(f: (a: A) => B): Pair<B> {
     return new Pair([f(this.fst()), f(this.snd())])
-  }
-  of<B>(b: B): Pair<B> {
-    return of(b)
   }
   ap<B>(fab: Pair<(a: A) => B>): Pair<B> {
     return new Pair([fab.fst()(this.fst()), fab.snd()(this.snd())])
@@ -79,6 +73,8 @@ export class Pair<A> {
 }
 
 export const map = <A, B>(f: (a: A) => B, fa: Pair<A>): Pair<B> => fa.map(f)
+
+export const of = <A>(a: A): Pair<A> => new Pair([a, a])
 
 export const ap = <A, B>(fab: Pair<(a: A) => B>, fa: Pair<A>): Pair<B> => fa.ap(fab)
 

--- a/src/Pair.ts
+++ b/src/Pair.ts
@@ -66,7 +66,7 @@ export class Pair<A> {
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, Pair<B>>
   traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, Pair<B>> {
     return <B>(f: (a: A) => HKT<F, B>) =>
-      liftA2(F, (b1: B) => (b2: B) => new Pair([b1, b2]))(f(this.fst()), f(this.snd()))
+      liftA2(F)((b1: B) => (b2: B) => new Pair([b1, b2]))(f(this.fst()))(f(this.snd()))
   }
   extract(): A {
     return this.fst()

--- a/src/Pair.ts
+++ b/src/Pair.ts
@@ -23,6 +23,8 @@ export const URI = 'Pair'
 
 export type URI = typeof URI
 
+export const of = <A>(a: A): Pair<A> => new Pair([a, a])
+
 export class Pair<A> {
   static of = of
   readonly _A: A
@@ -76,21 +78,49 @@ export class Pair<A> {
   }
 }
 
-export function map<A, B>(f: (a: A) => B, fa: Pair<A>): Pair<B> {
-  return fa.map(f)
+export const map = <A, B>(f: (a: A) => B, fa: Pair<A>): Pair<B> => fa.map(f)
+
+export const ap = <A, B>(fab: Pair<(a: A) => B>, fa: Pair<A>): Pair<B> => fa.ap(fab)
+
+export const reduce = <A, B>(f: (b: B, a: A) => B, b: B, fa: Pair<A>): B => fa.reduce(f, b)
+
+export const extract = <A>(fa: Pair<A>): A => fa.extract()
+
+export const extend = <A, B>(f: (fb: Pair<A>) => B, fa: Pair<A>): Pair<B> => fa.extend(f)
+
+export const getSetoid = <A>(S: Setoid<A>): Setoid<Pair<A>> => ({
+  equals: x => y => S.equals(x.fst())(y.fst()) && S.equals(x.snd())(y.snd())
+})
+
+export const getOrd = <A>(O: Ord<A>): Ord<Pair<A>> => {
+  const S = getSetoid(O)
+  return {
+    ...S,
+    compare: x => y => orderingSemigroup.concat(O.compare(x.fst())(y.fst()))(O.compare(x.snd())(y.snd()))
+  }
 }
 
-export function of<A>(a: A): Pair<A> {
-  return new Pair([a, a])
+export const getSemigroup = <A>(S: Semigroup<A>): Semigroup<Pair<A>> => ({
+  concat: x => y => new Pair([S.concat(x.fst())(y.fst()), S.concat(x.snd())(y.snd())])
+})
+
+export const getMonoid = <A>(M: Monoid<A>): Monoid<Pair<A>> => {
+  const S = getSemigroup(M)
+  const empty = new Pair([M.empty(), M.empty()])
+  return {
+    ...S,
+    empty: () => empty
+  }
 }
 
-export function ap<A, B>(fab: Pair<(a: A) => B>, fa: Pair<A>): Pair<B> {
-  return fa.ap(fab)
-}
+/** Map a function over the first field of a pair */
+export const first = <A>(f: Endomorphism<A>) => (fa: Pair<A>): Pair<A> => fa.first(f)
 
-export function reduce<A, B>(f: (b: B, a: A) => B, b: B, fa: Pair<A>): B {
-  return fa.reduce(f, b)
-}
+/** Map a function over the second field of a pair */
+export const second = <A>(f: Endomorphism<A>) => (fa: Pair<A>): Pair<A> => fa.second(f)
+
+/** Swaps the elements in a pair */
+export const swap = <A>(fa: Pair<A>): Pair<A> => fa.swap()
 
 export class Ops {
   traverse<F extends HKT2S>(
@@ -105,64 +135,6 @@ export class Ops {
 
 const ops = new Ops()
 export const traverse: Ops['traverse'] = ops.traverse
-
-export function extract<A>(fa: Pair<A>): A {
-  return fa.extract()
-}
-export function extend<A, B>(f: (fb: Pair<A>) => B, fa: Pair<A>): Pair<B> {
-  return fa.extend(f)
-}
-
-export function getSetoid<A>(S: Setoid<A>): Setoid<Pair<A>> {
-  return {
-    equals: x => y => {
-      return S.equals(x.fst())(y.fst()) && S.equals(x.snd())(y.snd())
-    }
-  }
-}
-
-export function getOrd<A>(O: Ord<A>): Ord<Pair<A>> {
-  const S = getSetoid(O)
-  return {
-    ...S,
-    compare: x => y => {
-      return orderingSemigroup.concat(O.compare(x.fst())(y.fst()))(O.compare(x.snd())(y.snd()))
-    }
-  }
-}
-
-export function getSemigroup<A>(S: Semigroup<A>): Semigroup<Pair<A>> {
-  return {
-    concat: x => y => {
-      return new Pair([S.concat(x.fst())(y.fst()), S.concat(x.snd())(y.snd())])
-    }
-  }
-}
-
-export function getMonoid<A>(M: Monoid<A>): Monoid<Pair<A>> {
-  const S = getSemigroup(M)
-  return {
-    ...S,
-    empty() {
-      return new Pair([M.empty(), M.empty()])
-    }
-  }
-}
-
-/** Map a function over the first field of a pair */
-export function first<A>(f: Endomorphism<A>, fa: Pair<A>): Pair<A> {
-  return fa.first(f)
-}
-
-/** Map a function over the second field of a pair */
-export function second<A>(f: Endomorphism<A>, fa: Pair<A>): Pair<A> {
-  return fa.second(f)
-}
-
-/** Swaps the elements in a pair */
-export function swap<A>(fa: Pair<A>): Pair<A> {
-  return fa.swap()
-}
 
 export const pair: Applicative<URI> & Foldable<URI> & Traversable<URI> & Comonad<URI> = {
   URI,

--- a/src/Pair.ts
+++ b/src/Pair.ts
@@ -125,8 +125,8 @@ export function getOrd<A>(O: Ord<A>): Ord<Pair<A>> {
   const S = getSetoid(O)
   return {
     ...S,
-    compare(x, y) {
-      return orderingSemigroup.concat(O.compare(x.fst(), y.fst()))(O.compare(x.snd(), y.snd()))
+    compare: x => y => {
+      return orderingSemigroup.concat(O.compare(x.fst())(y.fst()))(O.compare(x.snd())(y.snd()))
     }
   }
 }

--- a/src/Plus.ts
+++ b/src/Plus.ts
@@ -2,9 +2,7 @@ import { HKT } from './HKT'
 import { Alt, FantasyAlt } from './Alt'
 
 export interface Plus<F> extends Alt<F> {
-  zero<A>(): HKT<F, A>
+  zero: <A>() => HKT<F, A>
 }
 
-export interface FantasyPlus<F, A> extends FantasyAlt<F, A> {
-  zero<A>(): FantasyPlus<F, A>
-}
+export interface FantasyPlus<F, A> extends FantasyAlt<F, A> {}

--- a/src/Profunctor.ts
+++ b/src/Profunctor.ts
@@ -2,11 +2,11 @@ import { HKT2 } from './HKT'
 import { Functor, FantasyFunctor } from './Functor'
 
 export interface Profunctor<F> extends Functor<F> {
-  promap<A, B, C, D>(f: (a: A) => B, g: (c: C) => D, fbc: HKT2<F, B, C>): HKT2<F, A, D>
+  promap: <A, B, C, D>(f: (a: A) => B, g: (c: C) => D, fbc: HKT2<F, B, C>) => HKT2<F, A, D>
 }
 
 export interface FantasyProfunctor<F, B, C> extends FantasyFunctor<F, C> {
-  promap<A, D>(f: (a: A) => B, g: (c: C) => D): HKT2<F, A, D>
+  promap: <A, D>(f: (a: A) => B, g: (c: C) => D) => HKT2<F, A, D>
 }
 
 export const lmap = <F>(profunctor: Profunctor<F>) => <A, B>(f: (a: A) => B) => <C>(

--- a/src/Profunctor.ts
+++ b/src/Profunctor.ts
@@ -9,10 +9,10 @@ export interface FantasyProfunctor<F, B, C> extends FantasyFunctor<F, C> {
   promap<A, D>(f: (a: A) => B, g: (c: C) => D): HKT2<F, A, D>
 }
 
-export function lmap<F>(profunctor: Profunctor<F>): <A, B, C>(f: (a: A) => B, fbc: HKT2<F, B, C>) => HKT2<F, A, C> {
-  return (f, fbc) => profunctor.promap(f, c => c, fbc)
-}
+export const lmap = <F>(profunctor: Profunctor<F>) => <A, B>(f: (a: A) => B) => <C>(
+  fbc: HKT2<F, B, C>
+): HKT2<F, A, C> => profunctor.promap(f, c => c, fbc)
 
-export function rmap<F>(profunctor: Profunctor<F>): <B, C, D>(g: (c: C) => D, fbc: HKT2<F, B, C>) => HKT2<F, B, D> {
-  return <B, C, D>(g: (c: C) => D, fbc: HKT2<F, B, C>) => profunctor.promap((b: B) => b, g, fbc)
-}
+export const rmap = <F>(profunctor: Profunctor<F>) => <C, D>(g: (c: C) => D) => <B>(
+  fbc: HKT2<F, B, C>
+): HKT2<F, B, D> => profunctor.promap(b => b, g, fbc)

--- a/src/Random.ts
+++ b/src/Random.ts
@@ -5,27 +5,20 @@ import { IO } from './IO'
 /** Returns a random number between 0 (inclusive) and 1 (exclusive). This is
  * a direct wrapper around JavaScript's `Math.random()`.
  */
-export function random(): IO<number> {
-  return new IO(() => Math.random())
-}
+export const random = (): IO<number> => new IO(() => Math.random())
 
 /** Takes a range specified by `low` (the first argument) and `high` (the
  * second), and returns a random integer uniformly distributed in the closed
  * interval `[low, high]`. It is unspecified what happens if `low > high`,
  * or if either of `low` or `high` is not an integer.
  */
-export const randomInt = (low: number) => (high: number): IO<number> => {
-  return random().map(n => Math.floor((high - low + 1) * n + low))
-}
+export const randomInt = (low: number, high: number): IO<number> =>
+  random().map(n => Math.floor((high - low + 1) * n + low))
 
 /** Returns a random number between a minimum value (inclusive) and a maximum
  * value (exclusive). It is unspecified what happens if `maximum < minimum`.
  */
-export const randomRange = (min: number) => (max: number): IO<number> => {
-  return random().map(n => (max - min + 1) * n + min)
-}
+export const randomRange = (min: number, max: number): IO<number> => random().map(n => (max - min + 1) * n + min)
 
 /** Returns a random boolean value with an equal chance of being `true` or `false` */
-export function randomBool(): IO<boolean> {
-  return random().map(n => n < 0.5)
-}
+export const randomBool = (): IO<boolean> => random().map(n => n < 0.5)

--- a/src/Random.ts
+++ b/src/Random.ts
@@ -14,14 +14,14 @@ export function random(): IO<number> {
  * interval `[low, high]`. It is unspecified what happens if `low > high`,
  * or if either of `low` or `high` is not an integer.
  */
-export function randomInt(low: number, high: number): IO<number> {
+export const randomInt = (low: number) => (high: number): IO<number> => {
   return random().map(n => Math.floor((high - low + 1) * n + low))
 }
 
 /** Returns a random number between a minimum value (inclusive) and a maximum
  * value (exclusive). It is unspecified what happens if `maximum < minimum`.
  */
-export function randomRange(min: number, max: number): IO<number> {
+export const randomRange = (min: number) => (max: number): IO<number> => {
   return random().map(n => (max - min + 1) * n + min)
 }
 

--- a/src/Reader.ts
+++ b/src/Reader.ts
@@ -6,19 +6,12 @@ export const URI = 'Reader'
 export type URI = typeof URI
 
 export class Reader<E, A> implements FantasyMonad<URI, A> {
-  static of = of
   readonly _L: E
   readonly _A: A
   readonly _URI: URI
-  constructor(public readonly value: (e: E) => A) {}
-  run(e: E): A {
-    return this.value(e)
-  }
+  constructor(readonly run: (e: E) => A) {}
   map<B>(f: (a: A) => B): Reader<E, B> {
     return new Reader((e: E) => f(this.run(e)))
-  }
-  of<E2, B>(b: B): Reader<E2, B> {
-    return of(b)
   }
   ap<B>(fab: Reader<E, (a: A) => B>): Reader<E, B> {
     return new Reader((e: E) => fab.run(e)(this.run(e)))
@@ -28,36 +21,23 @@ export class Reader<E, A> implements FantasyMonad<URI, A> {
   }
 }
 
-export function map<E, A, B>(f: (a: A) => B, fa: Reader<E, A>): Reader<E, B> {
-  return fa.map(f)
-}
+export const map = <E, A, B>(f: (a: A) => B, fa: Reader<E, A>): Reader<E, B> => fa.map(f)
 
-export function of<E, A>(a: A): Reader<E, A> {
-  return new Reader((e: E) => a)
-}
+export const of = <E, A>(a: A): Reader<E, A> => new Reader((e: E) => a)
 
-export function ap<E, A, B>(fab: Reader<E, (a: A) => B>, fa: Reader<E, A>): Reader<E, B> {
-  return fa.ap(fab)
-}
+export const ap = <E, A, B>(fab: Reader<E, (a: A) => B>, fa: Reader<E, A>): Reader<E, B> => fa.ap(fab)
 
-export function chain<E, A, B>(f: (a: A) => Reader<E, B>, fa: Reader<E, A>): Reader<E, B> {
-  return fa.chain(f)
-}
+export const chain = <E, A, B>(f: (a: A) => Reader<E, B>, fa: Reader<E, A>): Reader<E, B> => fa.chain(f)
 
 /** reads the current context */
-export function ask<E>(): Reader<E, E> {
-  return new Reader(identity)
-}
+export const ask = <E>(): Reader<E, E> => new Reader(identity)
 
 /** Projects a value from the global context in a Reader */
-export function asks<E, A>(f: (e: E) => A): Reader<E, A> {
-  return new Reader(f)
-}
+export const asks = <E, A>(f: (e: E) => A): Reader<E, A> => new Reader(f)
 
 /** changes the value of the local context during the execution of the action `fa` */
-export function local<E, A>(f: Endomorphism<E>, fa: Reader<E, A>): Reader<E, A> {
-  return new Reader((e: E) => fa.run(f(e)))
-}
+export const local = <E>(f: Endomorphism<E>) => <A>(fa: Reader<E, A>): Reader<E, A> =>
+  new Reader((e: E) => fa.run(f(e)))
 
 export const reader: Monad<URI> = {
   URI,

--- a/src/Ring.ts
+++ b/src/Ring.ts
@@ -1,4 +1,3 @@
-import { Function1 } from './function'
 import { Semiring, getFunctionSemiring } from './Semiring'
 
 // adapted from https://github.com/purescript/purescript-prelude/blob/master/src/Data/Ring.purs
@@ -16,15 +15,10 @@ export interface Ring<A> extends Semiring<A> {
   sub: (x: A) => (y: A) => A
 }
 
-export function getFunctionRing<A, B>(ring: Ring<B>): Ring<Function1<A, B>> {
-  const semiring = getFunctionSemiring<A, B>(ring)
-  return {
-    ...semiring,
-    sub: f => g => x => ring.sub(f(x))(g(x))
-  }
-}
+export const getFunctionRing = <A, B>(ring: Ring<B>): Ring<(a: A) => B> => ({
+  ...getFunctionSemiring(ring),
+  sub: f => g => x => ring.sub(f(x))(g(x))
+})
 
 /** `negate x` can be used as a shorthand for `zero - x` */
-export const negate = <A>(ring: Ring<A>) => (a: A): A => {
-  return ring.sub(ring.zero())(a)
-}
+export const negate = <A>(ring: Ring<A>) => (a: A): A => ring.sub(ring.zero())(a)

--- a/src/Ring.ts
+++ b/src/Ring.ts
@@ -13,18 +13,18 @@ import { Semiring, getFunctionSemiring } from './Semiring'
  * - Additive inverse: `a - a = (zero - a) + a = zero`
  */
 export interface Ring<A> extends Semiring<A> {
-  sub(x: A, y: A): A
+  sub: (x: A) => (y: A) => A
 }
 
 export function getFunctionRing<A, B>(ring: Ring<B>): Ring<Function1<A, B>> {
   const semiring = getFunctionSemiring<A, B>(ring)
   return {
     ...semiring,
-    sub: (f, g) => x => ring.sub(f(x), g(x))
+    sub: f => g => x => ring.sub(f(x))(g(x))
   }
 }
 
 /** `negate x` can be used as a shorthand for `zero - x` */
-export function negate<A>(ring: Ring<A>, a: A): A {
-  return ring.sub(ring.zero(), a)
+export const negate = <A>(ring: Ring<A>) => (a: A): A => {
+  return ring.sub(ring.zero())(a)
 }

--- a/src/Semigroup.ts
+++ b/src/Semigroup.ts
@@ -14,7 +14,9 @@ export function getLastSemigroup<A>(): Semigroup<A> {
   return { concat: x => y => y }
 }
 
-export const getProductSemigroup = <A>(asemigroup: Semigroup<A>) => <B>(bsemigroup: Semigroup<B>): Semigroup<[A, B]> => {
+export const getProductSemigroup = <A>(asemigroup: Semigroup<A>) => <B>(
+  bsemigroup: Semigroup<B>
+): Semigroup<[A, B]> => {
   return {
     concat: ([xa, xb]) => ([ya, yb]) => [asemigroup.concat(xa)(ya), bsemigroup.concat(xb)(yb)]
   }

--- a/src/Semigroup.ts
+++ b/src/Semigroup.ts
@@ -2,26 +2,18 @@ export interface Semigroup<A> {
   concat: (x: A) => (y: A) => A
 }
 
-export const fold = <A>(semigroup: Semigroup<A>) => (a: A) => (as: Array<A>): A => {
-  return as.reduce((acc, a) => semigroup.concat(acc)(a), a)
+export const fold = <A>(S: Semigroup<A>) => (a: A) => (as: Array<A>): A => {
+  return as.reduce((acc, a) => S.concat(acc)(a), a)
 }
 
-export function getFirstSemigroup<A>(): Semigroup<A> {
-  return { concat: x => y => x }
-}
+export const getFirstSemigroup = <A>(): Semigroup<A> => ({ concat: x => y => x })
 
-export function getLastSemigroup<A>(): Semigroup<A> {
-  return { concat: x => y => y }
-}
+export const getLastSemigroup = <A>(): Semigroup<A> => ({ concat: x => y => y })
 
-export const getProductSemigroup = <A>(asemigroup: Semigroup<A>) => <B>(
-  bsemigroup: Semigroup<B>
-): Semigroup<[A, B]> => {
-  return {
-    concat: ([xa, xb]) => ([ya, yb]) => [asemigroup.concat(xa)(ya), bsemigroup.concat(xb)(yb)]
-  }
-}
+export const getProductSemigroup = <A, B>(SA: Semigroup<A>, SB: Semigroup<B>): Semigroup<[A, B]> => ({
+  concat: ([xa, xb]) => ([ya, yb]) => [SA.concat(xa)(ya), SB.concat(xb)(yb)]
+})
 
-export function getDualSemigroup<A>(semigroup: Semigroup<A>): Semigroup<A> {
-  return { concat: x => y => semigroup.concat(y)(x) }
-}
+export const getDualSemigroup = <A>(S: Semigroup<A>): Semigroup<A> => ({
+  concat: x => y => S.concat(y)(x)
+})

--- a/src/Semigroup.ts
+++ b/src/Semigroup.ts
@@ -2,7 +2,7 @@ export interface Semigroup<A> {
   concat: (x: A) => (y: A) => A
 }
 
-export function fold<A>(semigroup: Semigroup<A>, a: A, as: Array<A>): A {
+export const fold = <A>(semigroup: Semigroup<A>) => (a: A) => (as: Array<A>): A => {
   return as.reduce((acc, a) => semigroup.concat(acc)(a), a)
 }
 

--- a/src/Semigroup.ts
+++ b/src/Semigroup.ts
@@ -1,23 +1,25 @@
 export interface Semigroup<A> {
-  concat(x: A, y: A): A
+  concat: (x: A) => (y: A) => A
 }
 
 export function fold<A>(semigroup: Semigroup<A>, a: A, as: Array<A>): A {
-  return as.reduce((acc, a) => semigroup.concat(acc, a), a)
+  return as.reduce((acc, a) => semigroup.concat(acc)(a), a)
 }
 
 export function getFirstSemigroup<A>(): Semigroup<A> {
-  return { concat: (x, y) => x }
+  return { concat: x => y => x }
 }
 
 export function getLastSemigroup<A>(): Semigroup<A> {
-  return { concat: (x, y) => y }
+  return { concat: x => y => y }
 }
 
 export function getProductSemigroup<A, B>(asemigroup: Semigroup<A>, bsemigroup: Semigroup<B>): Semigroup<[A, B]> {
-  return { concat: ([xa, xb], [ya, yb]) => [asemigroup.concat(xa, ya), bsemigroup.concat(xb, yb)] }
+  return {
+    concat: ([xa, xb]) => ([ya, yb]) => [asemigroup.concat(xa)(ya), bsemigroup.concat(xb)(yb)]
+  }
 }
 
 export function getDualSemigroup<A>(semigroup: Semigroup<A>): Semigroup<A> {
-  return { concat: (x, y) => semigroup.concat(y, x) }
+  return { concat: x => y => semigroup.concat(y)(x) }
 }

--- a/src/Semigroup.ts
+++ b/src/Semigroup.ts
@@ -14,7 +14,7 @@ export function getLastSemigroup<A>(): Semigroup<A> {
   return { concat: x => y => y }
 }
 
-export function getProductSemigroup<A, B>(asemigroup: Semigroup<A>, bsemigroup: Semigroup<B>): Semigroup<[A, B]> {
+export const getProductSemigroup = <A>(asemigroup: Semigroup<A>) => <B>(bsemigroup: Semigroup<B>): Semigroup<[A, B]> => {
   return {
     concat: ([xa, xb]) => ([ya, yb]) => [asemigroup.concat(xa)(ya), bsemigroup.concat(xb)(yb)]
   }

--- a/src/Semigroupoid.ts
+++ b/src/Semigroupoid.ts
@@ -1,7 +1,7 @@
 import { HKT2 } from './HKT'
 
 export interface Semigroupoid<F> {
-  compose<L, A, B>(bc: HKT2<F, A, B>, ab: HKT2<F, L, A>): HKT2<F, L, B>
+  compose: <A, B>(bc: HKT2<F, A, B>) => <L>(ab: HKT2<F, L, A>) => HKT2<F, L, B>
 }
 
 export interface FantasySemigroupoid<F, L, A> {

--- a/src/Semigroupoid.ts
+++ b/src/Semigroupoid.ts
@@ -5,5 +5,5 @@ export interface Semigroupoid<F> {
 }
 
 export interface FantasySemigroupoid<F, L, A> {
-  compose<B>(bc: HKT2<F, A, B>): HKT2<F, L, B>
+  compose: <B>(bc: HKT2<F, A, B>) => HKT2<F, L, B>
 }

--- a/src/Semiring.ts
+++ b/src/Semiring.ts
@@ -32,11 +32,9 @@ export interface Semiring<A> {
   one: () => A
 }
 
-export function getFunctionSemiring<A, B>(semiring: Semiring<B>): Semiring<Function1<A, B>> {
-  return {
-    add: f => g => x => semiring.add(f(x))(g(x)),
-    zero: () => () => semiring.zero(),
-    mul: f => g => x => semiring.mul(f(x))(g(x)),
-    one: () => () => semiring.one()
-  }
-}
+export const getFunctionSemiring = <A, B>(semiring: Semiring<B>): Semiring<Function1<A, B>> => ({
+  add: f => g => x => semiring.add(f(x))(g(x)),
+  zero: () => () => semiring.zero(),
+  mul: f => g => x => semiring.mul(f(x))(g(x)),
+  one: () => () => semiring.one()
+})

--- a/src/Semiring.ts
+++ b/src/Semiring.ts
@@ -26,17 +26,17 @@ import { Function1 } from './function'
  * `Infinity` values. The behaviour is unspecified in these cases.
  */
 export interface Semiring<A> {
-  add(x: A, y: A): A
-  zero(): A
-  mul(x: A, y: A): A
-  one(): A
+  add: (x: A) => (y: A) => A
+  zero: () => A
+  mul: (x: A) => (y: A) => A
+  one: () => A
 }
 
 export function getFunctionSemiring<A, B>(semiring: Semiring<B>): Semiring<Function1<A, B>> {
   return {
-    add: (f, g) => x => semiring.add(f(x), g(x)),
+    add: f => g => x => semiring.add(f(x))(g(x)),
     zero: () => () => semiring.zero(),
-    mul: (f, g) => x => semiring.mul(f(x), g(x)),
+    mul: f => g => x => semiring.mul(f(x))(g(x)),
     one: () => () => semiring.one()
   }
 }

--- a/src/Setoid.ts
+++ b/src/Setoid.ts
@@ -1,8 +1,8 @@
 export interface Setoid<M> {
-  equals(x: M, y: M): boolean
+  equals: (x: M) => (y: M) => boolean
 }
 
-export function strictEqual(a: any, b: any): boolean {
+export const strictEqual = (a: any) => (b: any): boolean => {
   return a === b
 }
 
@@ -14,8 +14,8 @@ export const setoidBoolean: Setoid<boolean> = { equals: strictEqual }
 
 export function getArraySetoid<A>(S: Setoid<A>): Setoid<Array<A>> {
   return {
-    equals(xs, ys) {
-      return xs.length === ys.length && xs.every((x, i) => S.equals(x, ys[i]))
+    equals: xs => ys => {
+      return xs.length === ys.length && xs.every((x, i) => S.equals(x)(ys[i]))
     }
   }
 }

--- a/src/Setoid.ts
+++ b/src/Setoid.ts
@@ -1,10 +1,8 @@
-export interface Setoid<M> {
-  equals: (x: M) => (y: M) => boolean
+export interface Setoid<A> {
+  equals: (x: A) => (y: A) => boolean
 }
 
-export const strictEqual = (a: any) => (b: any): boolean => {
-  return a === b
-}
+export const strictEqual = (a: any) => (b: any): boolean => a === b
 
 export const setoidString: Setoid<string> = { equals: strictEqual }
 
@@ -12,10 +10,6 @@ export const setoidNumber: Setoid<number> = { equals: strictEqual }
 
 export const setoidBoolean: Setoid<boolean> = { equals: strictEqual }
 
-export function getArraySetoid<A>(S: Setoid<A>): Setoid<Array<A>> {
-  return {
-    equals: xs => ys => {
-      return xs.length === ys.length && xs.every((x, i) => S.equals(x)(ys[i]))
-    }
-  }
-}
+export const getArraySetoid = <A>(S: Setoid<A>): Setoid<Array<A>> => ({
+  equals: xs => ys => xs.length === ys.length && xs.every((x, i) => S.equals(x)(ys[i]))
+})

--- a/src/State.ts
+++ b/src/State.ts
@@ -15,10 +15,7 @@ export class State<S, A> implements FantasyMonad<URI, A> {
   readonly _A: A
   readonly _L: S
   readonly _URI: URI
-  constructor(public readonly value: (s: S) => [A, S]) {}
-  run(s: S): [A, S] {
-    return this.value(s)
-  }
+  constructor(readonly run: (s: S) => [A, S]) {}
   eval(s: S): A {
     return this.run(s)[0]
   }
@@ -31,9 +28,6 @@ export class State<S, A> implements FantasyMonad<URI, A> {
       return [f(a), s1]
     })
   }
-  of<S2, B>(b: B): State<S2, B> {
-    return of(b)
-  }
   ap<B>(fab: State<S, (a: A) => B>): State<S, B> {
     return fab.chain(f => this.map(f)) // <= derived
   }
@@ -45,37 +39,21 @@ export class State<S, A> implements FantasyMonad<URI, A> {
   }
 }
 
-export function map<S, A, B>(f: (a: A) => B, fa: State<S, A>): State<S, B> {
-  return fa.map(f)
-}
+export const map = <S, A, B>(f: (a: A) => B, fa: State<S, A>): State<S, B> => fa.map(f)
 
-export function ap<S, A, B>(fab: State<S, (a: A) => B>, fa: State<S, A>): State<S, B> {
-  return fa.ap(fab)
-}
+export const of = <S, A>(a: A): State<S, A> => new State(s => [a, s])
 
-export function of<S, A>(a: A): State<S, A> {
-  return new State(s => [a, s])
-}
+export const ap = <S, A, B>(fab: State<S, (a: A) => B>, fa: State<S, A>): State<S, B> => fa.ap(fab)
 
-export function chain<S, A, B>(f: (a: A) => State<S, B>, fa: State<S, A>): State<S, B> {
-  return fa.chain(f)
-}
+export const chain = <S, A, B>(f: (a: A) => State<S, B>, fa: State<S, A>): State<S, B> => fa.chain(f)
 
-export function get<S>(): State<S, S> {
-  return new State(s => [s, s])
-}
+export const get = <S>(): State<S, S> => new State(s => [s, s])
 
-export function put<S>(s: S): State<S, undefined> {
-  return new State(() => [undefined, s])
-}
+export const put = <S>(s: S): State<S, undefined> => new State(() => [undefined, s])
 
-export function modify<S>(f: Endomorphism<S>): State<S, undefined> {
-  return new State(s => [undefined, f(s)])
-}
+export const modify = <S>(f: Endomorphism<S>): State<S, undefined> => new State(s => [undefined, f(s)])
 
-export function gets<S, A>(f: (s: S) => A): State<S, A> {
-  return new State(s => [f(s), s])
-}
+export const gets = <S, A>(f: (s: S) => A): State<S, A> => new State(s => [f(s), s])
 
 export const state: Monad<URI> = {
   URI,

--- a/src/StateT.ts
+++ b/src/StateT.ts
@@ -87,28 +87,28 @@ export class Ops {
     return (f, fa) => s => F.chain(([a, s1]) => f(a)(s1), fa(s))
   }
 
-  get<F extends HKT2S>(F: Applicative<F>): <L, S>() => (s: S) => HKT2As<F, L, [S, S]>
+  get<F extends HKT2S>(F: Applicative<F>): <S>() => <L>(s: S) => HKT2As<F, L, [S, S]>
   get<F extends HKTS>(F: Applicative<F>): <S>() => (s: S) => HKTAs<F, [S, S]>
   get<F>(F: Applicative<F>): <S>() => (s: S) => HKT<F, [S, S]>
   get<F>(F: Applicative<F>): <S>() => (s: S) => HKT<F, [S, S]> {
     return () => s => F.of(tuple(s, s))
   }
 
-  put<F extends HKT2S>(F: Applicative<F>): <L, S>(s: S) => (s: S) => HKT2As<F, L, [void, S]>
-  put<F extends HKTS>(F: Applicative<F>): <S>(s: S) => (s: S) => HKTAs<F, [void, S]>
-  put<F>(F: Applicative<F>): <S>(s: S) => (s: S) => HKT<F, [void, S]>
-  put<F>(F: Applicative<F>): <S>(s: S) => (s: S) => HKT<F, [void, S]> {
+  put<F extends HKT2S>(F: Applicative<F>): <S>(s: S) => <L>() => HKT2As<F, L, [void, S]>
+  put<F extends HKTS>(F: Applicative<F>): <S>(s: S) => () => HKTAs<F, [void, S]>
+  put<F>(F: Applicative<F>): <S>(s: S) => () => HKT<F, [void, S]>
+  put<F>(F: Applicative<F>): <S>(s: S) => () => HKT<F, [void, S]> {
     return s => () => F.of(tuple(undefined, s))
   }
 
-  modify<F extends HKT2S>(F: Applicative<F>): <L, S>(f: Endomorphism<S>) => (s: S) => HKT2As<F, L, [void, S]>
+  modify<F extends HKT2S>(F: Applicative<F>): <S>(f: Endomorphism<S>) => <L>(s: S) => HKT2As<F, L, [void, S]>
   modify<F extends HKTS>(F: Applicative<F>): <S>(f: Endomorphism<S>) => (s: S) => HKTAs<F, [void, S]>
   modify<F>(F: Applicative<F>): <S>(f: Endomorphism<S>) => (s: S) => HKT<F, [void, S]>
   modify<F>(F: Applicative<F>): <S>(f: Endomorphism<S>) => (s: S) => HKT<F, [void, S]> {
     return f => s => F.of(tuple(undefined, f(s)))
   }
 
-  gets<F extends HKT2S>(F: Applicative<F>): <L, S, A>(f: (s: S) => A) => (s: S) => HKT2As<F, L, [A, S]>
+  gets<F extends HKT2S>(F: Applicative<F>): <S, A>(f: (s: S) => A) => <L>(s: S) => HKT2As<F, L, [A, S]>
   gets<F extends HKTS>(F: Applicative<F>): <S, A>(f: (s: S) => A) => (s: S) => HKTAs<F, [A, S]>
   gets<F>(F: Applicative<F>): <S, A>(f: (s: S) => A) => (s: S) => HKT<F, [A, S]>
   gets<F>(F: Applicative<F>): <S, A>(f: (s: S) => A) => (s: S) => HKT<F, [A, S]> {

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -17,7 +17,7 @@ export class Store<S, A> implements FantasyComonad<URI, A> {
   readonly _A: A
   readonly _L: S
   readonly _URI: URI
-  constructor(public readonly peek: (s: S) => A, public readonly pos: S) {}
+  constructor(readonly peek: (s: S) => A, readonly pos: S) {}
   /** Reposition the focus at the specified position */
   seek(s: S): Store<S, A> {
     return new Store(this.peek, s)
@@ -39,43 +39,29 @@ export class Store<S, A> implements FantasyComonad<URI, A> {
   }
 }
 
-export function map<S, A, B>(f: (a: A) => B, sa: Store<S, A>): Store<S, B> {
-  return sa.map(f)
-}
+export const map = <S, A, B>(f: (a: A) => B, sa: Store<S, A>): Store<S, B> => sa.map(f)
 
-export function extract<S, A>(sa: Store<S, A>): A {
-  return sa.extract()
-}
+export const extract = <S, A>(sa: Store<S, A>): A => sa.extract()
 
-export function extend<S, A, B>(f: (sa: Store<S, A>) => B, sa: Store<S, A>): Store<S, B> {
-  return sa.extend(f)
-}
+export const extend = <S, A, B>(f: (sa: Store<S, A>) => B, sa: Store<S, A>): Store<S, B> => sa.extend(f)
 
 /** Reads the value at the specified position in the specified context */
-export function peek<S, A>(sa: Store<S, A>, s: S): A {
-  return sa.peek(s)
-}
+export const peek = <S, A>(sa: Store<S, A>) => (s: S): A => sa.peek(s)
 
 /** Extract a value from a position which depends on the current position */
-export function peeks<S, A>(f: Endomorphism<S>, sa: Store<S, A>, s: S): A {
-  return sa.peek(f(sa.pos))
-}
+export const peeks = <S>(f: Endomorphism<S>) => <A>(sa: Store<S, A>) => (s: S): A => sa.peek(f(sa.pos))
 
 /** Reposition the focus at the specified position */
-export function seek<S, A>(s: S, sa: Store<S, A>): Store<S, A> {
-  return sa.seek(s)
-}
+export const seek = <S>(s: S) => <A>(sa: Store<S, A>): Store<S, A> => sa.seek(s)
 
 /** Reposition the focus at the specified position, which depends on the current position */
-export function seeks<S, A>(f: Endomorphism<S>, sa: Store<S, A>): Store<S, A> {
-  return new Store(sa.peek, f(sa.pos))
-}
+export const seeks = <S>(f: Endomorphism<S>) => <A>(sa: Store<S, A>): Store<S, A> => new Store(sa.peek, f(sa.pos))
 
 export class Ops {
   /** Extract a collection of values from positions which depend on the current position */
-  experiment<F, S, A>(functor: Functor<F>, f: (s: S) => HKT<F, S>, sa: Store<S, A>): HKT<F, A>
-  experiment<F, S, A>(functor: Functor<F>, f: (s: S) => HKT<F, S>, sa: Store<S, A>): HKT<F, A> {
-    return functor.map(s => sa.peek(s), f(sa.pos))
+  experiment<F>(F: Functor<F>): <S>(f: (s: S) => HKT<F, S>) => <A>(sa: Store<S, A>) => HKT<F, A>
+  experiment<F>(F: Functor<F>): <S>(f: (s: S) => HKT<F, S>) => <A>(sa: Store<S, A>) => HKT<F, A> {
+    return f => sa => F.map(s => sa.peek(s), f(sa.pos))
   }
 }
 

--- a/src/StrMap.ts
+++ b/src/StrMap.ts
@@ -109,7 +109,7 @@ export const traverse: Ops['traverse'] = ops.traverse
 /** Test whether one dictionary contains all of the keys and values contained in another dictionary */
 export function isSubdictionary<A>(setoid: Setoid<A>, d1: StrMap<A>, d2: StrMap<A>): boolean {
   for (let k in d1.value) {
-    if (!d2.value.hasOwnProperty(k) || !setoid.equals(d1.value[k], d2.value[k])) {
+    if (!d2.value.hasOwnProperty(k) || !setoid.equals(d1.value[k])(d2.value[k])) {
       return false
     }
   }
@@ -131,7 +131,7 @@ export function isEmpty<A>(d: StrMap<A>): boolean {
 
 export function getSetoid<A>(setoid: Setoid<A>): Setoid<StrMap<A>> {
   return {
-    equals(x, y) {
+    equals: x => y => {
       return isSubdictionary(setoid, x, y) && isSubdictionary(setoid, y, x)
     }
   }

--- a/src/StrMap.ts
+++ b/src/StrMap.ts
@@ -4,11 +4,12 @@ import { Functor, FantasyFunctor } from './Functor'
 import { Applicative } from './Applicative'
 import { Foldable, FantasyFoldable } from './Foldable'
 import { Traversable, FantasyTraversable } from './Traversable'
-import { constant, Lazy, tuple } from './function'
+import { tuple } from './function'
 import { liftA2 } from './Apply'
 import { Setoid } from './Setoid'
 import { Option, none, some } from './Option'
 import { Unfoldable } from './Unfoldable'
+import { URI as ArrayURI } from './Array'
 
 // https://github.com/purescript/purescript-maps
 
@@ -25,7 +26,7 @@ export type URI = typeof URI
 export class StrMap<A> implements FantasyFunctor<URI, A>, FantasyFoldable<A>, FantasyTraversable<URI, A> {
   readonly _A: A
   readonly _URI: URI
-  constructor(public readonly value: { [key: string]: A }) {}
+  constructor(readonly value: { [key: string]: A }) {}
   mapWithKey<B>(f: (k: string, a: A) => B): StrMap<B> {
     const fb: { [key: string]: B } = {}
     for (let k in this.value) {
@@ -49,9 +50,9 @@ export class StrMap<A> implements FantasyFunctor<URI, A>, FantasyFoldable<A>, Fa
   traverseWithKey<F extends HKTS>(F: Applicative<F>): <B>(f: (k: string, a: A) => HKTAs<F, B>) => HKTAs<F, StrMap<B>>
   traverseWithKey<F>(F: Applicative<F>): <B>(f: (k: string, a: A) => HKT<F, B>) => HKT<F, StrMap<B>>
   traverseWithKey<F>(F: Applicative<F>): <B>(f: (k: string, a: A) => HKT<F, B>) => HKT<F, StrMap<B>> {
-    const concatA2 = liftA2(F)(concat)
-    return f => {
-      let out = F.of(empty())
+    const concatA2: <A>(a: HKT<F, StrMap<A>>) => (b: HKT<F, StrMap<A>>) => HKT<F, StrMap<A>> = liftA2(F)(concat)
+    return <B>(f: (k: string, a: A) => HKT<F, B>) => {
+      let out: HKT<F, StrMap<B>> = F.of(empty())
       for (let k in this.value) {
         out = concatA2(out)(F.map(b => singleton(k)(b), f(k, this.value[k])))
       }
@@ -66,19 +67,15 @@ export class StrMap<A> implements FantasyFunctor<URI, A>, FantasyFoldable<A>, Fa
   }
 }
 
-export const empty: Lazy<StrMap<any>> = constant(new StrMap({}))
+export const empty = <A>(): StrMap<A> => new StrMap({})
 
 export const concat = <A>(x: StrMap<A>) => (y: StrMap<A>): StrMap<A> => {
   return new StrMap(Object.assign({}, x.value, y.value))
 }
 
-export function map<A, B>(f: (a: A) => B, fa: StrMap<A>): StrMap<B> {
-  return fa.map(f)
-}
+export const map = <A, B>(f: (a: A) => B, fa: StrMap<A>): StrMap<B> => fa.map(f)
 
-export function reduce<A, B>(f: (b: B, a: A) => B, b: B, fa: StrMap<A>): B {
-  return fa.reduce(f, b)
-}
+export const reduce = <A, B>(f: (b: B, a: A) => B, b: B, fa: StrMap<A>): B => fa.reduce(f, b)
 
 export class Ops {
   traverseWithKey<F extends HKT2S>(
@@ -117,53 +114,43 @@ export const isSubdictionary = <A>(setoid: Setoid<A>) => (d1: StrMap<A>) => (d2:
 }
 
 /** Calculate the number of key/value pairs in a dictionary */
-export function size<A>(d: StrMap<A>): number {
-  return Object.keys(d.value).length
-}
+export const size = <A>(d: StrMap<A>): number => Object.keys(d.value).length
 
 /** Test whether a dictionary is empty */
-export function isEmpty<A>(d: StrMap<A>): boolean {
+export const isEmpty = <A>(d: StrMap<A>): boolean => {
   for (const k in d.value) {
     return k === null
   }
   return true
 }
 
-export function getSetoid<A>(setoid: Setoid<A>): Setoid<StrMap<A>> {
-  return {
-    equals: x => y => {
-      return isSubdictionary(setoid)(x)(y) && isSubdictionary(setoid)(y)(x)
-    }
-  }
-}
+export const getSetoid = <A>(setoid: Setoid<A>): Setoid<StrMap<A>> => ({
+  equals: x => y => isSubdictionary(setoid)(x)(y) && isSubdictionary(setoid)(y)(x)
+})
 
 /** Create a dictionary with one key/value pair */
-export const singleton = (k: string) => <A>(a: A): StrMap<A> => {
-  return new StrMap({ [k]: a })
-}
+export const singleton = (k: string) => <A>(a: A): StrMap<A> => new StrMap({ [k]: a })
 
 /** Lookup the value for a key in a dictionary */
-export const lookup = (k: string) => <A>(d: StrMap<A>): Option<A> => {
-  return d.value.hasOwnProperty(k) ? some(d.value[k]) : none
-}
+export const lookup = (k: string) => <A>(d: StrMap<A>): Option<A> =>
+  d.value.hasOwnProperty(k) ? some(d.value[k]) : none
 
-/** Create a dictionary from a foldable collection of key/value pairs, using the
+/**
+ * Create a dictionary from a foldable collection of key/value pairs, using the
  * specified function to combine values for duplicate keys.
  */
-export function fromFoldable<F>(
-  F: Foldable<F>
-): (<A>(f: (existing: A, a: A) => A) => (ta: HKT<F, [string, A]>) => StrMap<A>) {
-  return <A>(f: (existing: A, a: A) => A) => (ta: HKT<F, [string, A]>) =>
-    F.reduce(
-      (b, a) => {
-        const k = a[0]
-        b.value[k] = b.value.hasOwnProperty(k) ? f(b.value[k], a[1]) : a[1]
-        return b
-      },
-      new StrMap<A>({}),
-      ta
-    )
-}
+export const fromFoldable = <F>(F: Foldable<F>) => <A>(f: (existing: A) => (a: A) => A) => (
+  ta: HKT<F, [string, A]>
+): StrMap<A> =>
+  F.reduce(
+    (b, a) => {
+      const k = a[0]
+      b.value[k] = b.value.hasOwnProperty(k) ? f(b.value[k])(a[1]) : a[1]
+      return b
+    },
+    new StrMap<A>({}),
+    ta
+  )
 
 export const collect = <A, B>(f: (k: string, a: A) => B) => (d: StrMap<A>): Array<B> => {
   const out: Array<B> = []
@@ -173,27 +160,21 @@ export const collect = <A, B>(f: (k: string, a: A) => B) => (d: StrMap<A>): Arra
   return out
 }
 
-export function toArray<A>(d: StrMap<A>): Array<[string, A]> {
-  return collect((k, a) => [k, a] as [string, A])(d)
-}
+export const toArray = <A>(d: StrMap<A>): Array<[string, A]> => collect((k, a: A) => tuple(k, a))(d)
 
 /** Unfolds a dictionary into a list of key/value pairs */
-export function toUnfoldable<F extends string>(unfoldable: Unfoldable<F>): <A>(d: StrMap<A>) => HKT<F, [string, A]> {
-  return <A>(d: StrMap<A>) => {
-    const arr = toArray(d)
-    if (unfoldable.URI === 'Array') {
-      return arr as any
-    }
-    const len = arr.length
-    return unfoldable.unfoldr(b => (b < len ? some(tuple(arr[b], b + 1)) : none), 0)
+export const toUnfoldable = <F extends string>(unfoldable: Unfoldable<F>) => <A>(d: StrMap<A>): HKT<F, [string, A]> => {
+  const arr = toArray(d)
+  if (unfoldable.URI === ArrayURI) {
+    return arr as any
   }
+  const len = arr.length
+  return unfoldable.unfoldr(b => (b < len ? some(tuple(arr[b], b + 1)) : none), 0)
 }
 
 // cannot curry
 /** Apply a function of two arguments to each key/value pair, producing a new dictionary */
-export function mapWithKey<A, B>(f: (k: string, a: A) => B, fa: StrMap<A>): StrMap<B> {
-  return fa.mapWithKey(f)
-}
+export const mapWithKey = <A, B>(f: (k: string, a: A) => B, fa: StrMap<A>): StrMap<B> => fa.mapWithKey(f)
 
 /** Insert or replace a key/value pair in a map */
 export const insert = (k: string) => <A>(a: A) => (d: StrMap<A>): StrMap<A> => {
@@ -210,9 +191,8 @@ export const remove = (k: string) => <A>(d: StrMap<A>): StrMap<A> => {
 }
 
 /** Delete a key and value from a map, returning the value as well as the subsequent map */
-export const pop = (k: string) => <A>(d: StrMap<A>): Option<[A, StrMap<A>]> => {
-  return lookup(k)(d).fold(() => none, a => some(tuple(a, remove(k)(d))))
-}
+export const pop = (k: string) => <A>(d: StrMap<A>): Option<[A, StrMap<A>]> =>
+  lookup(k)(d).fold(() => none, a => some(tuple(a, remove(k)(d))))
 
 export const strmap: Monoid<StrMap<any>> & Functor<URI> & Foldable<URI> & Traversable<URI> = {
   URI,

--- a/src/StrMap.ts
+++ b/src/StrMap.ts
@@ -49,11 +49,11 @@ export class StrMap<A> implements FantasyFunctor<URI, A>, FantasyFoldable<A>, Fa
   traverseWithKey<F extends HKTS>(F: Applicative<F>): <B>(f: (k: string, a: A) => HKTAs<F, B>) => HKTAs<F, StrMap<B>>
   traverseWithKey<F>(F: Applicative<F>): <B>(f: (k: string, a: A) => HKT<F, B>) => HKT<F, StrMap<B>>
   traverseWithKey<F>(F: Applicative<F>): <B>(f: (k: string, a: A) => HKT<F, B>) => HKT<F, StrMap<B>> {
-    const concatA2 = liftA2(F, concat)
+    const concatA2 = liftA2(F)(concat)
     return f => {
       let out = F.of(empty())
       for (let k in this.value) {
-        out = concatA2(out, F.map(b => singleton(k)(b), f(k, this.value[k])))
+        out = concatA2(out)(F.map(b => singleton(k)(b), f(k, this.value[k])))
       }
       return out
     }

--- a/src/StrMap.ts
+++ b/src/StrMap.ts
@@ -4,7 +4,7 @@ import { Functor, FantasyFunctor } from './Functor'
 import { Applicative } from './Applicative'
 import { Foldable, FantasyFoldable } from './Foldable'
 import { Traversable, FantasyTraversable } from './Traversable'
-import { constant, Lazy, curry, tuple } from './function'
+import { constant, Lazy, tuple } from './function'
 import { liftA2 } from './Apply'
 import { Setoid } from './Setoid'
 import { Option, none, some } from './Option'
@@ -49,7 +49,7 @@ export class StrMap<A> implements FantasyFunctor<URI, A>, FantasyFoldable<A>, Fa
   traverseWithKey<F extends HKTS>(F: Applicative<F>): <B>(f: (k: string, a: A) => HKTAs<F, B>) => HKTAs<F, StrMap<B>>
   traverseWithKey<F>(F: Applicative<F>): <B>(f: (k: string, a: A) => HKT<F, B>) => HKT<F, StrMap<B>>
   traverseWithKey<F>(F: Applicative<F>): <B>(f: (k: string, a: A) => HKT<F, B>) => HKT<F, StrMap<B>> {
-    const concatA2 = liftA2(F, curriedConcat)
+    const concatA2 = liftA2(F, concat)
     return f => {
       let out = F.of(empty())
       for (let k in this.value) {
@@ -68,7 +68,7 @@ export class StrMap<A> implements FantasyFunctor<URI, A>, FantasyFoldable<A>, Fa
 
 export const empty: Lazy<StrMap<any>> = constant(new StrMap({}))
 
-export function concat<A>(x: StrMap<A>, y: StrMap<A>): StrMap<A> {
+export const concat = <A>(x: StrMap<A>) => (y: StrMap<A>): StrMap<A> => {
   return new StrMap(Object.assign({}, x.value, y.value))
 }
 
@@ -79,8 +79,6 @@ export function map<A, B>(f: (a: A) => B, fa: StrMap<A>): StrMap<B> {
 export function reduce<A, B>(f: (b: B, a: A) => B, b: B, fa: StrMap<A>): B {
   return fa.reduce(f, b)
 }
-
-export const curriedConcat: <A>(x: StrMap<A>) => (y: StrMap<A>) => StrMap<A> = curry(concat)
 
 export class Ops {
   traverseWithKey<F extends HKT2S>(

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -76,7 +76,7 @@ export function chain<A, B>(f: (a: A) => Task<B>, fa: Task<A>): Task<B> {
   return fa.chain(f)
 }
 
-export function concat<A>(fx: Task<A>, fy: Task<A>): Task<A> {
+export const concat = <A>(fx: Task<A>) => (fy: Task<A>): Task<A> => {
   return fx.concat(fy)
 }
 
@@ -93,4 +93,12 @@ export function tryCatch<L, A>(f: Lazy<Promise<A>>, onrejected: (reason: any) =>
   return new Task(() => f().then(a => right<L, A>(a), reason => left<L, A>(onrejected(reason))))
 }
 
-export const task: Monad<URI> & Monoid<Task<any>> = { URI, map, of, ap, chain, concat, empty }
+export const task: Monad<URI> & Monoid<Task<any>> = {
+  URI,
+  map,
+  of,
+  ap,
+  chain,
+  concat,
+  empty
+}

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -89,7 +89,7 @@ export function empty<A>(): Task<A> {
   return never as Task<A>
 }
 
-export function tryCatch<L, A>(f: Lazy<Promise<A>>, onrejected: (reason: any) => L): Task<Either<L, A>> {
+export const tryCatch = <A>(f: Lazy<Promise<A>>) => <L>(onrejected: (reason: any) => L): Task<Either<L, A>> => {
   return new Task(() => f().then(a => right<L, A>(a), reason => left<L, A>(onrejected(reason))))
 }
 

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -14,19 +14,11 @@ export const URI = 'Task'
 export type URI = typeof URI
 
 export class Task<A> implements FantasyMonad<URI, A> {
-  static of = of
-  static empty = empty
   readonly _A: A
   readonly _URI: URI
-  constructor(public readonly value: Lazy<Promise<A>>) {}
-  run(): Promise<A> {
-    return this.value()
-  }
+  constructor(readonly run: Lazy<Promise<A>>) {}
   map<B>(f: (a: A) => B): Task<B> {
     return new Task(() => this.run().then(f))
-  }
-  of<B>(b: B): Task<B> {
-    return of(b)
   }
   ap<B>(fab: Task<(a: A) => B>): Task<B> {
     return new Task(() => Promise.all([fab.run(), this.run()]).then(([f, a]) => f(a)))
@@ -56,42 +48,29 @@ export class Task<A> implements FantasyMonad<URI, A> {
     return this.toString()
   }
   toString() {
-    return `new Task(${toString(this.value)})`
+    return `new Task(${toString(this.run)})`
   }
 }
 
-export function map<A, B>(f: (a: A) => B, fa: Task<A>): Task<B> {
-  return fa.map(f)
-}
+export const map = <A, B>(f: (a: A) => B, fa: Task<A>): Task<B> => fa.map(f)
 
-export function of<A>(a: A): Task<A> {
-  return new Task(() => Promise.resolve(a))
-}
+export const of = <A>(a: A): Task<A> => new Task(() => Promise.resolve(a))
 
-export function ap<A, B>(fab: Task<(a: A) => B>, fa: Task<A>): Task<B> {
-  return fa.ap(fab)
-}
+export const ap = <A, B>(fab: Task<(a: A) => B>, fa: Task<A>): Task<B> => fa.ap(fab)
 
-export function chain<A, B>(f: (a: A) => Task<B>, fa: Task<A>): Task<B> {
-  return fa.chain(f)
-}
+export const chain = <A, B>(f: (a: A) => Task<B>, fa: Task<A>): Task<B> => fa.chain(f)
 
-export const concat = <A>(fx: Task<A>) => (fy: Task<A>): Task<A> => {
-  return fx.concat(fy)
-}
+/** returns a task that never completes */
+export const empty = <A>(): Task<A> => never as Task<A>
+
+export const concat = <A>(fx: Task<A>) => (fy: Task<A>): Task<A> => fx.concat(fy)
 
 const neverPromise = new Promise(resolve => undefined)
 const neverLazyPromise = () => neverPromise
 const never = new Task(neverLazyPromise)
 
-/** returns a task that never completes */
-export function empty<A>(): Task<A> {
-  return never as Task<A>
-}
-
-export const tryCatch = <A>(f: Lazy<Promise<A>>) => <L>(onrejected: (reason: any) => L): Task<Either<L, A>> => {
-  return new Task(() => f().then(a => right<L, A>(a), reason => left<L, A>(onrejected(reason))))
-}
+export const tryCatch = <A>(f: Lazy<Promise<A>>) => <L>(onrejected: (reason: any) => L): Task<Either<L, A>> =>
+  new Task(() => f().then(a => right<L, A>(a), reason => left<L, A>(onrejected(reason))))
 
 export const task: Monad<URI> & Monoid<Task<any>> = {
   URI,

--- a/src/These.ts
+++ b/src/These.ts
@@ -57,7 +57,7 @@ export class This<L, A>
     return this_(this.value)
   }
   equals(setoidL: Setoid<L>, setoidA: Setoid<A>, fy: These<L, A>): boolean {
-    return fy.fold(l => setoidL.equals(l, this.value), constFalse, constFalse)
+    return fy.fold(l => setoidL.equals(l)(this.value), constFalse, constFalse)
   }
   concat(SL: Semigroup<L>, SA: Semigroup<A>, fy: These<L, A>): These<L, A> {
     return fy.fold(
@@ -107,7 +107,7 @@ export class That<L, A>
     return that(this.value)
   }
   equals(setoidL: Setoid<L>, setoidA: Setoid<A>, fy: These<L, A>): boolean {
-    return fy.fold(constFalse, a => setoidA.equals(a, this.value), constFalse)
+    return fy.fold(constFalse, a => setoidA.equals(a)(this.value), constFalse)
   }
   concat(SL: Semigroup<L>, SA: Semigroup<A>, fy: These<L, A>): These<L, A> {
     return fy.fold(
@@ -161,7 +161,7 @@ export class Both<L, A>
     return both(this.l, this.a)
   }
   equals(setoidL: Setoid<L>, setoidA: Setoid<A>, fy: These<L, A>): boolean {
-    return fy.fold(constFalse, constFalse, (l, a) => setoidL.equals(l, this.l) && setoidA.equals(a, this.a))
+    return fy.fold(constFalse, constFalse, (l, a) => setoidL.equals(l)(this.l) && setoidA.equals(a)(this.a))
   }
   concat(SL: Semigroup<L>, SA: Semigroup<A>, fy: These<L, A>): These<L, A> {
     return fy.fold(
@@ -178,8 +178,8 @@ export class Both<L, A>
   }
 }
 
-export function equals<L, A>(SL: Setoid<L>, SA: Setoid<A>): (fx: These<L, A>, fy: These<L, A>) => boolean {
-  return (fx, fy) => fx.equals(SL, SA, fy)
+export function equals<L, A>(SL: Setoid<L>, SA: Setoid<A>): ((fx: These<L, A>) => (fy: These<L, A>) => boolean) {
+  return fx => fy => fx.equals(SL, SA, fy)
 }
 
 export function getSetoid<L, A>(SL: Setoid<L>, SA: Setoid<A>): Setoid<These<L, A>> {

--- a/src/These.ts
+++ b/src/These.ts
@@ -26,12 +26,11 @@ export type These<L, A> = This<L, A> | That<L, A> | Both<L, A>
 
 export class This<L, A>
   implements FantasyFunctor<URI, A>, FantasyBifunctor<URI, L, A>, FantasyFoldable<A>, FantasyTraversable<URI, A> {
-  static of = of
   readonly _tag: 'This' = 'This'
   readonly _A: A
   readonly _L: L
   readonly _URI: URI
-  constructor(public readonly value: L) {}
+  constructor(readonly value: L) {}
   map<B>(f: (a: A) => B): These<L, B> {
     return this as any
   }
@@ -56,15 +55,16 @@ export class This<L, A>
   fold<B>(this_: (l: L) => B, that: (a: A) => B, both: (l: L, a: A) => B): B {
     return this_(this.value)
   }
-  equals(setoidL: Setoid<L>, setoidA: Setoid<A>, fy: These<L, A>): boolean {
-    return fy.fold(l => setoidL.equals(l)(this.value), constFalse, constFalse)
+  equals(setoidL: Setoid<L>, setoidA: Setoid<A>): (fy: These<L, A>) => boolean {
+    return fy => fy.fold(l => setoidL.equals(l)(this.value), constFalse, constFalse)
   }
-  concat(SL: Semigroup<L>, SA: Semigroup<A>, fy: These<L, A>): These<L, A> {
-    return fy.fold(
-      l => this_(SL.concat(this.value)(l)),
-      a => both(this.value, a),
-      (l, a) => both(SL.concat(this.value)(l), a)
-    )
+  concat(SL: Semigroup<L>, SA: Semigroup<A>): (fy: These<L, A>) => These<L, A> {
+    return fy =>
+      fy.fold(
+        l => this_(SL.concat(this.value)(l)),
+        a => both(this.value, a),
+        (l, a) => both(SL.concat(this.value)(l), a)
+      )
   }
   inspect() {
     return this.toString()
@@ -76,12 +76,11 @@ export class This<L, A>
 
 export class That<L, A>
   implements FantasyFunctor<URI, A>, FantasyBifunctor<URI, L, A>, FantasyFoldable<A>, FantasyTraversable<URI, A> {
-  static of = of
   readonly _tag: 'That' = 'That'
   readonly _A: A
   readonly _L: L
   readonly _URI: URI
-  constructor(public readonly value: A) {}
+  constructor(readonly value: A) {}
   map<B>(f: (a: A) => B): These<L, B> {
     return new That(f(this.value))
   }
@@ -106,15 +105,16 @@ export class That<L, A>
   fold<B>(this_: (l: L) => B, that: (a: A) => B, both: (l: L, a: A) => B): B {
     return that(this.value)
   }
-  equals(setoidL: Setoid<L>, setoidA: Setoid<A>, fy: These<L, A>): boolean {
-    return fy.fold(constFalse, a => setoidA.equals(a)(this.value), constFalse)
+  equals(setoidL: Setoid<L>, setoidA: Setoid<A>): (fy: These<L, A>) => boolean {
+    return fy => fy.fold(constFalse, a => setoidA.equals(a)(this.value), constFalse)
   }
-  concat(SL: Semigroup<L>, SA: Semigroup<A>, fy: These<L, A>): These<L, A> {
-    return fy.fold(
-      l => both(l, this.value),
-      a => that(SA.concat(this.value)(a)),
-      (l, a) => both(l, SA.concat(this.value)(a))
-    )
+  concat(SL: Semigroup<L>, SA: Semigroup<A>): (fy: These<L, A>) => These<L, A> {
+    return fy =>
+      fy.fold(
+        l => both(l, this.value),
+        a => that(SA.concat(this.value)(a)),
+        (l, a) => both(l, SA.concat(this.value)(a))
+      )
   }
   inspect() {
     return this.toString()
@@ -126,12 +126,11 @@ export class That<L, A>
 
 export class Both<L, A>
   implements FantasyFunctor<URI, A>, FantasyBifunctor<URI, L, A>, FantasyFoldable<A>, FantasyTraversable<URI, A> {
-  static of = of
   readonly _tag: 'Both' = 'Both'
   readonly _A: A
   readonly _L: L
   readonly _URI: URI
-  constructor(public readonly l: L, public readonly a: A) {}
+  constructor(readonly l: L, readonly a: A) {}
   map<B>(f: (a: A) => B): These<L, B> {
     return new Both(this.l, f(this.a))
   }
@@ -160,15 +159,16 @@ export class Both<L, A>
   fold<B>(this_: (l: L) => B, that: (a: A) => B, both: (l: L, a: A) => B): B {
     return both(this.l, this.a)
   }
-  equals(setoidL: Setoid<L>, setoidA: Setoid<A>, fy: These<L, A>): boolean {
-    return fy.fold(constFalse, constFalse, (l, a) => setoidL.equals(l)(this.l) && setoidA.equals(a)(this.a))
+  equals(setoidL: Setoid<L>, setoidA: Setoid<A>): (fy: These<L, A>) => boolean {
+    return fy => fy.fold(constFalse, constFalse, (l, a) => setoidL.equals(l)(this.l) && setoidA.equals(a)(this.a))
   }
-  concat(SL: Semigroup<L>, SA: Semigroup<A>, fy: These<L, A>): These<L, A> {
-    return fy.fold(
-      l => both(SL.concat(this.l)(l), this.a),
-      a => both(this.l, SA.concat(this.a)(a)),
-      (l, a) => both(SL.concat(this.l)(l), SA.concat(this.a)(a))
-    )
+  concat(SL: Semigroup<L>, SA: Semigroup<A>): (fy: These<L, A>) => These<L, A> {
+    return fy =>
+      fy.fold(
+        l => both(SL.concat(this.l)(l), this.a),
+        a => both(this.l, SA.concat(this.a)(a)),
+        (l, a) => both(SL.concat(this.l)(l), SA.concat(this.a)(a))
+      )
   }
   inspect() {
     return this.toString()
@@ -178,56 +178,38 @@ export class Both<L, A>
   }
 }
 
-export function equals<L, A>(SL: Setoid<L>, SA: Setoid<A>): ((fx: These<L, A>) => (fy: These<L, A>) => boolean) {
-  return fx => fy => fx.equals(SL, SA, fy)
-}
+export const equals = <L, A>(SL: Setoid<L>, SA: Setoid<A>) => (fx: These<L, A>) => (fy: These<L, A>): boolean =>
+  fx.equals(SL, SA)(fy)
 
-export function getSetoid<L, A>(SL: Setoid<L>, SA: Setoid<A>): Setoid<These<L, A>> {
-  return {
-    equals: equals(SL, SA)
-  }
-}
+export const getSetoid = <L, A>(SL: Setoid<L>, SA: Setoid<A>): Setoid<These<L, A>> => ({
+  equals: equals(SL, SA)
+})
 
-export function concat<L, A>(
-  SL: Semigroup<L>,
-  SA: Semigroup<A>
-): ((fx: These<L, A>) => (fy: These<L, A>) => These<L, A>) {
-  return fx => fy => fx.concat(SL, SA, fy)
-}
+export const concat = <L, A>(SL: Semigroup<L>, SA: Semigroup<A>) => (fx: These<L, A>) => (
+  fy: These<L, A>
+): These<L, A> => fx.concat(SL, SA)(fy)
 
-export function getSemigroup<L, A>(SL: Semigroup<L>, SA: Semigroup<A>): Semigroup<These<L, A>> {
-  return {
-    concat: concat(SL, SA)
-  }
-}
+export const getSemigroup = <L, A>(SL: Semigroup<L>, SA: Semigroup<A>): Semigroup<These<L, A>> => ({
+  concat: concat(SL, SA)
+})
 
-export function fold<L, A, B>(that: (l: L) => B, this_: (a: A) => B, both: (l: L, a: A) => B, fa: These<L, A>): B {
-  return fa.fold(that, this_, both)
-}
+export const fold = <L, A, B>(that: (l: L) => B, this_: (a: A) => B, both: (l: L, a: A) => B, fa: These<L, A>): B =>
+  fa.fold(that, this_, both)
 
-export function map<L, A, B>(f: (a: A) => B, fa: These<L, A>): These<L, B> {
-  return fa.map(f)
-}
+export const map = <L, A, B>(f: (a: A) => B, fa: These<L, A>): These<L, B> => fa.map(f)
 
-export function of<L, A>(a: A): These<L, A> {
-  return new That(a)
-}
+export const of = <L, A>(a: A): These<L, A> => new That(a)
 
-export function ap<L, A, B>(SL: Semigroup<L>, fab: These<L, (a: A) => B>, fa: These<L, A>): These<L, B> {
-  return fa.ap(SL, fab)
-}
+export const ap = <L, A, B>(SL: Semigroup<L>, fab: These<L, (a: A) => B>, fa: These<L, A>): These<L, B> =>
+  fa.ap(SL, fab)
 
-export function chain<L, A, B>(SL: Semigroup<L>, f: (a: A) => These<L, B>, fa: These<L, A>): These<L, B> {
-  return fa.chain(SL, f)
-}
+export const chain = <L, A, B>(SL: Semigroup<L>, f: (a: A) => These<L, B>, fa: These<L, A>): These<L, B> =>
+  fa.chain(SL, f)
 
-export function bimap<L, M, A, B>(f: (l: L) => M, g: (a: A) => B): (fla: These<L, A>) => These<M, B> {
-  return fla => fla.bimap(f, g)
-}
+export const bimap = <L, M, A, B>(f: (l: L) => M, g: (a: A) => B): ((fla: These<L, A>) => These<M, B>) => fla =>
+  fla.bimap(f, g)
 
-export function reduce<L, A, B>(f: (b: B, a: A) => B, b: B, fa: These<L, A>): B {
-  return fa.reduce(f, b)
-}
+export const reduce = <L, A, B>(f: (b: B, a: A) => B, b: B, fa: These<L, A>): B => fa.reduce(f, b)
 
 export class Ops {
   traverse<F extends HKT2S>(
@@ -238,46 +220,31 @@ export class Ops {
   ): <L, A, B>(f: (a: A) => HKTAs<F, B>, ta: These<L, A>) => HKTAs<F, These<L, B>>
   traverse<F>(F: Applicative<F>): <L, A, B>(f: (a: A) => HKT<F, B>, ta: These<L, A>) => HKT<F, These<L, B>>
   traverse<F>(F: Applicative<F>): <L, A, B>(f: (a: A) => HKT<F, B>, ta: These<L, A>) => HKT<F, These<L, B>> {
-    return <L, A, B>(f: (a: A) => HKT<F, B>, ta: These<L, A>) => ta.traverse(F)(f)
+    return (f, ta) => ta.traverse(F)(f)
   }
 }
 
 const ops = new Ops()
 export const traverse: Ops['traverse'] = ops.traverse
 
-export function isThis<L, A>(fa: These<L, A>): fa is This<L, A> {
-  return fa._tag === 'This'
-}
+export const isThis = <L, A>(fa: These<L, A>): fa is This<L, A> => fa._tag === 'This'
 
-export function isThat<L, A>(fa: These<L, A>): fa is That<L, A> {
-  return fa._tag === 'That'
-}
+export const isThat = <L, A>(fa: These<L, A>): fa is That<L, A> => fa._tag === 'That'
 
-export function isBoth<L, A>(fa: These<L, A>): fa is Both<L, A> {
-  return fa._tag === 'Both'
-}
+export const isBoth = <L, A>(fa: These<L, A>): fa is Both<L, A> => fa._tag === 'Both'
 
-export function this_<L, A>(l: L): These<L, A> {
-  return new This(l)
-}
+export const this_ = <L, A>(l: L): These<L, A> => new This(l)
 
 export const that = of
 
-export function both<L, A>(l: L, a: A): These<L, A> {
-  return new Both(l, a)
-}
+export const both = <L, A>(l: L, a: A): These<L, A> => new Both(l, a)
 
-export function fromThese<L, A>(defaultThis: L, defaultThat: A, fa: These<L, A>): [L, A] {
-  return fa.fold<[L, A]>(l => [l, defaultThat], a => [defaultThis, a], (l, a) => [l, a])
-}
+export const fromThese = <L, A>(defaultThis: L, defaultThat: A) => (fa: These<L, A>): [L, A] =>
+  fa.fold<[L, A]>(l => [l, defaultThat], a => [defaultThis, a], (l, a) => [l, a])
 
-export function theseLeft<L, A>(fa: These<L, A>): Option<L> {
-  return fa.fold(l => some(l), () => none, (l, _) => some(l))
-}
+export const theseLeft = <L, A>(fa: These<L, A>): Option<L> => fa.fold(l => some(l), () => none, (l, _) => some(l))
 
-export function theseRight<L, A>(fa: These<L, A>): Option<A> {
-  return fa.fold(() => none, a => some(a), (_, a) => some(a))
-}
+export const theseRight = <L, A>(fa: These<L, A>): Option<A> => fa.fold(() => none, a => some(a), (_, a) => some(a))
 
 export const these: Functor<URI> & Bifunctor<URI> & Foldable<URI> & Traversable<URI> = {
   URI,

--- a/src/These.ts
+++ b/src/These.ts
@@ -36,7 +36,7 @@ export class This<L, A>
     return this as any
   }
   ap<B>(SL: Semigroup<L>, fab: These<L, (a: A) => B>): These<L, B> {
-    return fab.fold(() => fab as any, () => this as any, (l, _) => this_(SL.concat(l, this.value)))
+    return fab.fold(() => fab as any, () => this as any, (l, _) => this_(SL.concat(l)(this.value)))
   }
   chain<B>(SL: Semigroup<L>, f: (a: A) => These<L, B>): These<L, B> {
     return this as any
@@ -61,9 +61,9 @@ export class This<L, A>
   }
   concat(SL: Semigroup<L>, SA: Semigroup<A>, fy: These<L, A>): These<L, A> {
     return fy.fold(
-      l => this_(SL.concat(this.value, l)),
+      l => this_(SL.concat(this.value)(l)),
       a => both(this.value, a),
-      (l, a) => both(SL.concat(this.value, l), a)
+      (l, a) => both(SL.concat(this.value)(l), a)
     )
   }
   inspect() {
@@ -112,8 +112,8 @@ export class That<L, A>
   concat(SL: Semigroup<L>, SA: Semigroup<A>, fy: These<L, A>): These<L, A> {
     return fy.fold(
       l => both(l, this.value),
-      a => that(SA.concat(this.value, a)),
-      (l, a) => both(l, SA.concat(this.value, a))
+      a => that(SA.concat(this.value)(a)),
+      (l, a) => both(l, SA.concat(this.value)(a))
     )
   }
   inspect() {
@@ -136,13 +136,13 @@ export class Both<L, A>
     return new Both(this.l, f(this.a))
   }
   ap<B>(SL: Semigroup<L>, fab: These<L, (a: A) => B>): These<L, B> {
-    return fab.fold(() => fab as any, f => both(this.l, f(this.a)), (l, f) => both(SL.concat(l, this.l), f(this.a)))
+    return fab.fold(() => fab as any, f => both(this.l, f(this.a)), (l, f) => both(SL.concat(l)(this.l), f(this.a)))
   }
   chain<B>(SL: Semigroup<L>, f: (a: A) => These<L, B>): These<L, B> {
     return f(this.a).fold(
-      l => this_(SL.concat(this.l, l)),
+      l => this_(SL.concat(this.l)(l)),
       a => both(this.l, a),
-      (l, a) => both(SL.concat(this.l, l), a)
+      (l, a) => both(SL.concat(this.l)(l), a)
     )
   }
   bimap<M, B>(f: (l: L) => M, g: (a: A) => B): These<M, B> {
@@ -165,9 +165,9 @@ export class Both<L, A>
   }
   concat(SL: Semigroup<L>, SA: Semigroup<A>, fy: These<L, A>): These<L, A> {
     return fy.fold(
-      l => both(SL.concat(this.l, l), this.a),
-      a => both(this.l, SA.concat(this.a, a)),
-      (l, a) => both(SL.concat(this.l, l), SA.concat(this.a, a))
+      l => both(SL.concat(this.l)(l), this.a),
+      a => both(this.l, SA.concat(this.a)(a)),
+      (l, a) => both(SL.concat(this.l)(l), SA.concat(this.a)(a))
     )
   }
   inspect() {
@@ -188,8 +188,11 @@ export function getSetoid<L, A>(SL: Setoid<L>, SA: Setoid<A>): Setoid<These<L, A
   }
 }
 
-export function concat<L, A>(SL: Semigroup<L>, SA: Semigroup<A>): (fx: These<L, A>, fy: These<L, A>) => These<L, A> {
-  return (fx, fy) => fx.concat(SL, SA, fy)
+export function concat<L, A>(
+  SL: Semigroup<L>,
+  SA: Semigroup<A>
+): ((fx: These<L, A>) => (fy: These<L, A>) => These<L, A>) {
+  return fx => fy => fx.concat(SL, SA, fy)
 }
 
 export function getSemigroup<L, A>(SL: Semigroup<L>, SA: Semigroup<A>): Semigroup<These<L, A>> {

--- a/src/These.ts
+++ b/src/These.ts
@@ -221,8 +221,8 @@ export function chain<L, A, B>(SL: Semigroup<L>, f: (a: A) => These<L, B>, fa: T
   return fa.chain(SL, f)
 }
 
-export function bimap<L, M, A, B>(f: (l: L) => M, g: (a: A) => B, fa: These<L, A>): These<M, B> {
-  return fa.bimap(f, g)
+export function bimap<L, M, A, B>(f: (l: L) => M, g: (a: A) => B): (fla: These<L, A>) => These<M, B> {
+  return fla => fla.bimap(f, g)
 }
 
 export function reduce<L, A, B>(f: (b: B, a: A) => B, b: B, fa: These<L, A>): B {
@@ -263,8 +263,8 @@ export function this_<L, A>(l: L): These<L, A> {
 
 export const that = of
 
-export function both<L, A>(b: L, a: A): These<L, A> {
-  return new Both(b, a)
+export function both<L, A>(l: L, a: A): These<L, A> {
+  return new Both(l, a)
 }
 
 export function fromThese<L, A>(defaultThis: L, defaultThat: A, fa: These<L, A>): [L, A] {

--- a/src/Trace.ts
+++ b/src/Trace.ts
@@ -9,13 +9,13 @@ import { Monad } from './Monad'
  * return a value. This will log the value's underlying representation for
  * low-level debugging
  */
-export const trace = (message: any) => <A>(out: Lazy<A>): A => {
+export const trace = <A>(message: any, out: Lazy<A>): A => {
   console.log(message)
   return out()
 }
 
 /** Log any value and return it */
-export const spy = <A>(a: A): A => trace(a)(() => a)
+export const spy = <A>(a: A): A => trace(a, () => a)
 
 export class Ops {
   /** Log a message to the console for debugging purposes and then return the
@@ -25,7 +25,7 @@ export class Ops {
   traceA<F extends HKTS>(F: Applicative<F>): (message: any) => HKTAs<F, void>
   traceA<F>(F: Applicative<F>): (message: any) => HKT<F, void>
   traceA<F>(F: Applicative<F>): (message: any) => HKT<F, void> {
-    return x => trace(x)(() => F.of(undefined))
+    return x => trace(x, () => F.of(undefined))
   }
 
   /** Log any value to the console and return it in `Monad`
@@ -34,7 +34,7 @@ export class Ops {
   traceM<F extends HKT2S>(F: Monad<F>): <L, A>(a: A) => HKT2As<F, L, A>
   traceM<F extends HKTS>(F: Monad<F>): <A>(a: A) => HKTAs<F, A>
   traceM<F>(F: Monad<F>): <A>(a: A) => HKT<F, A> {
-    return a => trace(a)(() => F.of(a))
+    return a => trace(a, () => F.of(a))
   }
 }
 

--- a/src/Trace.ts
+++ b/src/Trace.ts
@@ -9,13 +9,13 @@ import { Monad } from './Monad'
  * return a value. This will log the value's underlying representation for
  * low-level debugging
  */
-export const trace = <A>(message: any, out: Lazy<A>): A => {
+export const trace = (message: any) => <A>(out: Lazy<A>): A => {
   console.log(message)
   return out()
 }
 
 /** Log any value and return it */
-export const spy = <A>(a: A): A => trace(a, () => a)
+export const spy = <A>(a: A): A => trace(a)(() => a)
 
 export class Ops {
   /** Log a message to the console for debugging purposes and then return the
@@ -25,7 +25,7 @@ export class Ops {
   traceA<F extends HKTS>(F: Applicative<F>): (message: any) => HKTAs<F, void>
   traceA<F>(F: Applicative<F>): (message: any) => HKT<F, void>
   traceA<F>(F: Applicative<F>): (message: any) => HKT<F, void> {
-    return x => trace(x, () => F.of(undefined))
+    return x => trace(x)(() => F.of(undefined))
   }
 
   /** Log any value to the console and return it in `Monad`
@@ -34,7 +34,7 @@ export class Ops {
   traceM<F extends HKT2S>(F: Monad<F>): <L, A>(a: A) => HKT2As<F, L, A>
   traceM<F extends HKTS>(F: Monad<F>): <A>(a: A) => HKTAs<F, A>
   traceM<F>(F: Monad<F>): <A>(a: A) => HKT<F, A> {
-    return a => trace(a, () => F.of(a))
+    return a => trace(a)(() => F.of(a))
   }
 }
 

--- a/src/Trace.ts
+++ b/src/Trace.ts
@@ -9,15 +9,13 @@ import { Monad } from './Monad'
  * return a value. This will log the value's underlying representation for
  * low-level debugging
  */
-export function trace<A>(message: any, out: Lazy<A>): A {
+export const trace = <A>(message: any, out: Lazy<A>): A => {
   console.log(message)
   return out()
 }
 
 /** Log any value and return it */
-export function spy<A>(a: A): A {
-  return trace(a, () => a)
-}
+export const spy = <A>(a: A): A => trace(a, () => a)
 
 export class Ops {
   /** Log a message to the console for debugging purposes and then return the

--- a/src/Traversable.ts
+++ b/src/Traversable.ts
@@ -2,18 +2,19 @@ import { HKT, HKTS, HKT2S, HKTAs, HKT2As } from './HKT'
 import { Functor, FantasyFunctor, FunctorComposition, getFunctorComposition } from './Functor'
 import { Foldable, FantasyFoldable, FoldableComposition, getFoldableComposition } from './Foldable'
 import { Applicative } from './Applicative'
-// import './overloadings'
 
 export interface Traversable<T> extends Functor<T>, Foldable<T> {
-  traverse<F>(F: Applicative<F>): <A, B>(f: (a: A) => HKT<F, B>, ta: HKT<T, A>) => HKT<F, HKT<T, B>>
+  traverse: <F>(F: Applicative<F>) => <A, B>(f: (a: A) => HKT<F, B>, ta: HKT<T, A>) => HKT<F, HKT<T, B>>
 }
 
 export interface FantasyTraversable<T, A> extends FantasyFunctor<T, A>, FantasyFoldable<A> {
-  traverse<F>(F: Applicative<F>): <B>(f: (a: A) => HKT<F, B>) => HKT<F, HKT<T, B>>
+  traverse: <F>(F: Applicative<F>) => <B>(f: (a: A) => HKT<F, B>) => HKT<F, HKT<T, B>>
 }
 
 export interface TraversableComposition<F, G> extends FoldableComposition<F, G>, FunctorComposition<F, G> {
-  traverse<H>(H: Applicative<H>): <A, B>(f: (a: A) => HKT<H, B>, fga: HKT<F, HKT<G, A>>) => HKT<H, HKT<F, HKT<G, B>>>
+  traverse: <H>(
+    H: Applicative<H>
+  ) => <A, B>(f: (a: A) => HKT<H, B>, fga: HKT<F, HKT<G, A>>) => HKT<H, HKT<F, HKT<G, B>>>
 }
 
 export interface TraversableComposition11<F extends HKTS, G extends HKTS>
@@ -47,19 +48,10 @@ export class Ops {
   ): TraversableComposition11<F, G>
   getTraversableComposition<F, G>(F: Traversable<F>, G: Traversable<G>): TraversableComposition<F, G>
   getTraversableComposition<F, G>(F: Traversable<F>, G: Traversable<G>): TraversableComposition<F, G> {
-    const { map } = getFunctorComposition(F, G)
-    const { reduce } = getFoldableComposition(F, G)
-
-    function traverse<H>(
-      H: Applicative<H>
-    ): <A, B>(f: (a: A) => HKT<H, B>, fga: HKT<F, HKT<G, A>>) => HKT<H, HKT<F, HKT<G, B>>> {
-      return (f, fga) => F.traverse(H)(ga => G.traverse(H)(a => f(a), ga), fga)
-    }
-
     return {
-      map,
-      reduce,
-      traverse
+      ...getFunctorComposition(F, G),
+      ...getFoldableComposition(F, G),
+      traverse: H => (f, fga) => F.traverse(H)(ga => G.traverse(H)(a => f(a), ga), fga)
     }
   }
 }

--- a/src/Tuple.ts
+++ b/src/Tuple.ts
@@ -72,7 +72,8 @@ export class Tuple<L, A>
     return `new Tuple(${toString(this.value)})`
   }
 }
-export function compose<L, A, B>(bc: Tuple<A, B>, fa: Tuple<L, A>): Tuple<L, B> {
+
+export const compose = <A, B>(bc: Tuple<A, B>) => <L>(fa: Tuple<L, A>): Tuple<L, B> => {
   return fa.compose(bc)
 }
 

--- a/src/Tuple.ts
+++ b/src/Tuple.ts
@@ -81,8 +81,8 @@ export function map<L, A, B>(f: (b: A) => B, fa: Tuple<L, A>): Tuple<L, B> {
   return fa.map(f)
 }
 
-export function bimap<L, A, M, B>(f: (l: L) => M, g: (a: A) => B, fla: Tuple<L, A>): Tuple<M, B> {
-  return fla.bimap(f, g)
+export function bimap<L, A, M, B>(f: (l: L) => M, g: (a: A) => B): (fla: Tuple<L, A>) => Tuple<M, B> {
+  return fla => fla.bimap(f, g)
 }
 
 export const extract = snd

--- a/src/Tuple.ts
+++ b/src/Tuple.ts
@@ -103,10 +103,10 @@ export function traverse<F>(
 
 export function getSetoid<L, A>(setoidA: Setoid<L>, setoidB: Setoid<A>): Setoid<Tuple<L, A>> {
   return {
-    equals(x, y) {
+    equals: x => y => {
       const [xa, xb] = x.value
       const [ya, yb] = y.value
-      return setoidA.equals(xa, ya) && setoidB.equals(xb, yb)
+      return setoidA.equals(xa)(ya) && setoidB.equals(xb)(yb)
     }
   }
 }

--- a/src/Tuple.ts
+++ b/src/Tuple.ts
@@ -127,10 +127,10 @@ export function getOrd<L, A>(ordA: Ord<L>, ordB: Ord<A>): Ord<Tuple<L, A>> {
 
 export function getSemigroup<L, A>(semigroupA: Semigroup<L>, semigroupB: Semigroup<A>): Semigroup<Tuple<L, A>> {
   return {
-    concat(x, y) {
+    concat: x => y => {
       const [xa, xb] = x.value
       const [ya, yb] = y.value
-      return new Tuple([semigroupA.concat(xa, ya), semigroupB.concat(xb, yb)])
+      return new Tuple([semigroupA.concat(xa)(ya), semigroupB.concat(xb)(yb)])
     }
   }
 }
@@ -148,7 +148,7 @@ export function getApply<L>(semigroupA: Semigroup<L>): Apply<URI> {
     URI,
     map,
     ap<A, B>(fab: Tuple<L, (b: A) => B>, fa: Tuple<L, A>): Tuple<L, B> {
-      return new Tuple([semigroupA.concat(fa.fst(), fab.fst()), fab.snd()(fa.snd())])
+      return new Tuple([semigroupA.concat(fa.fst())(fab.fst()), fab.snd()(fa.snd())])
     }
   }
 }
@@ -169,7 +169,7 @@ export function getChain<L>(M: Monoid<L>): Chain<URI> {
     ...getApply(M),
     chain<A, B>(f: (b: A) => Tuple<L, B>, fa: Tuple<L, A>): Tuple<L, B> {
       const lb = f(fa.snd())
-      return new Tuple([M.concat(fa.fst(), lb.fst()), lb.snd()])
+      return new Tuple([M.concat(fa.fst())(lb.fst()), lb.snd()])
     }
   }
 }
@@ -189,10 +189,10 @@ export function chainRec<L>(M: Monoid<L>): <A, B>(f: (a: A) => Tuple<L, Either<A
     let result = f(a)
     let acc = M.empty()
     while (isLeft(result.snd())) {
-      acc = M.concat(acc, result.fst())
+      acc = M.concat(acc)(result.fst())
       result = f((result.snd() as Left<A, B>).value)
     }
-    return new Tuple([M.concat(acc, result.fst()), (result.snd() as Right<A, B>).value])
+    return new Tuple([M.concat(acc)(result.fst()), (result.snd() as Right<A, B>).value])
   }
   return chainRec
 }

--- a/src/Tuple.ts
+++ b/src/Tuple.ts
@@ -117,11 +117,11 @@ export function getSetoid<L, A>(setoidA: Setoid<L>, setoidB: Setoid<A>): Setoid<
 export function getOrd<L, A>(ordA: Ord<L>, ordB: Ord<A>): Ord<Tuple<L, A>> {
   return {
     equals: getSetoid(ordA, ordB).equals,
-    compare(x, y) {
+    compare: x => y => {
       const [xa, xb] = x.value
       const [ya, yb] = y.value
-      const ordering = ordA.compare(xa, ya)
-      return ordering === 'EQ' ? ordB.compare(xb, yb) : ordering
+      const ordering = ordA.compare(xa)(ya)
+      return ordering === 'EQ' ? ordB.compare(xb)(yb) : ordering
     }
   }
 }

--- a/src/Validation.ts
+++ b/src/Validation.ts
@@ -26,29 +26,25 @@ export type Validation<L, A> = Failure<L, A> | Success<L, A>
 
 export class Failure<L, A>
   implements FantasyApply<URI, A>, FantasyFoldable<A>, FantasyTraversable<URI, A>, FantasyAlt<URI, A> {
-  static of = of
   readonly _tag: 'Failure' = 'Failure'
   readonly _L: L
   readonly _A: A
   readonly _URI: URI
-  constructor(public readonly semigroup: Semigroup<L>, public readonly value: L) {}
+  constructor(readonly semigroup: Semigroup<L>, readonly value: L) {}
   map<B>(f: (a: A) => B): Validation<L, B> {
     return this as any
   }
-  of<M, B>(b: B): Validation<M, B> {
-    return of(b)
-  }
   ap<B>(fab: Validation<L, (a: A) => B>): Validation<L, B> {
     if (isFailure(fab)) {
-      return failure(this.semigroup, this.semigroup.concat(fab.value)(this.value))
+      return failure(this.semigroup)(this.semigroup.concat(fab.value)(this.value))
     }
     return this as any
   }
   ap_<B, C>(this: Validation<L, (a: B) => C>, fb: Validation<L, B>): Validation<L, C> {
     return fb.ap(this)
   }
-  bimap<M, B>(S: Semigroup<M>, f: (l: L) => M, g: (a: A) => B): Validation<M, B> {
-    return failure(S, f(this.value))
+  bimap<M>(S: Semigroup<M>): <B>(f: (l: L) => M, g: (a: A) => B) => Validation<M, B> {
+    return (f, g) => failure(S)(f(this.value))
   }
   alt(fy: Validation<L, A>): Validation<L, A> {
     return fy
@@ -65,14 +61,14 @@ export class Failure<L, A>
   fold<B>(failure: (l: L) => B, success: (a: A) => B): B {
     return failure(this.value)
   }
-  equals(S: Setoid<A>, fy: Validation<L, A>): boolean {
-    return fy.fold(constTrue, constFalse)
+  equals(S: Setoid<A>): (fy: Validation<L, A>) => boolean {
+    return fy => fy.fold(constTrue, constFalse)
   }
   concat(fy: Validation<L, A>): Validation<L, A> {
-    return fy.fold(l => failure<L, A>(this.semigroup, this.semigroup.concat(l)(this.value)), () => this)
+    return fy.fold(l => failure<L>(this.semigroup)<A>(this.semigroup.concat(l)(this.value)), () => this)
   }
-  mapFailure<M>(S: Semigroup<M>, f: (l: L) => M): Validation<M, A> {
-    return failure(S, f(this.value))
+  mapFailure<M>(S: Semigroup<M>): (f: (l: L) => M) => Validation<M, A> {
+    return f => failure(S)(f(this.value))
   }
   swap(S: Semigroup<A>): Validation<A, L> {
     return success(this.value)
@@ -85,7 +81,7 @@ export class Failure<L, A>
   }
   /** Lift the Invalid value into a NonEmptyArray */
   toValidationNea(): Option<Validation<nonEmptyArray.NonEmptyArray<L>, A>> {
-    return some(failure(nonEmptyArray, nonEmptyArray.of(this.value)))
+    return some(failure(nonEmptyArray)(nonEmptyArray.of(this.value)))
   }
   inspect() {
     return this.toString()
@@ -97,17 +93,13 @@ export class Failure<L, A>
 
 export class Success<L, A>
   implements FantasyApply<URI, A>, FantasyFoldable<A>, FantasyTraversable<URI, A>, FantasyAlt<URI, A> {
-  static of = of
   readonly _tag: 'Success' = 'Success'
   readonly _L: L
   readonly _A: A
   readonly _URI: URI
-  constructor(public readonly value: A) {}
+  constructor(readonly value: A) {}
   map<B>(f: (a: A) => B): Validation<L, B> {
     return new Success<L, B>(f(this.value))
-  }
-  of<M, B>(b: B): Validation<M, B> {
-    return of(b)
   }
   ap<B>(fab: Validation<L, (a: A) => B>): Validation<L, B> {
     if (isSuccess(fab)) {
@@ -118,8 +110,8 @@ export class Success<L, A>
   ap_<B, C>(this: Validation<L, (a: B) => C>, fb: Validation<L, B>): Validation<L, C> {
     return fb.ap(this)
   }
-  bimap<M, B>(S: Semigroup<M>, f: (l: L) => M, g: (a: A) => B): Validation<M, B> {
-    return success(g(this.value))
+  bimap<M>(S: Semigroup<M>): <B>(f: (l: L) => M, g: (a: A) => B) => Validation<M, B> {
+    return (f, g) => success(g(this.value))
   }
   alt(fy: Validation<L, A>): Validation<L, A> {
     return this
@@ -136,17 +128,17 @@ export class Success<L, A>
   fold<B>(failure: (l: L) => B, success: (a: A) => B): B {
     return success(this.value)
   }
-  equals(S: Setoid<A>, fy: Validation<L, A>): boolean {
-    return fy.fold(constFalse, y => S.equals(this.value)(y))
+  equals(S: Setoid<A>): (fy: Validation<L, A>) => boolean {
+    return fy => fy.fold(constFalse, y => S.equals(this.value)(y))
   }
   concat(fy: Validation<L, A>): Validation<L, A> {
     return this
   }
-  mapFailure<M>(S: Semigroup<M>, f: (l: L) => M): Validation<M, A> {
-    return this as any
+  mapFailure<M>(S: Semigroup<M>): (f: (l: L) => M) => Validation<M, A> {
+    return f => this as any
   }
   swap(S: Semigroup<A>): Validation<A, L> {
-    return failure(S, this.value)
+    return failure(S)(this.value)
   }
   toOption(): Option<A> {
     return some(this.value)
@@ -166,48 +158,29 @@ export class Success<L, A>
   }
 }
 
-export function equals<L, A>(S: Setoid<A>, fx: Validation<L, A>, fy: Validation<L, A>): boolean {
-  return fx.equals(S, fy)
-}
+export const equals = <L, A>(S: Setoid<A>) => (fx: Validation<L, A>) => (fy: Validation<L, A>): boolean =>
+  fx.equals(S)(fy)
 
-export function getSetoid<L, A>(S: Setoid<A>): Setoid<Validation<L, A>> {
-  return {
-    equals: x => y => equals(S, x, y)
-  }
-}
+export const getSetoid = <L, A>(S: Setoid<A>): Setoid<Validation<L, A>> => ({
+  equals: equals(S)
+})
 
-export function fold<L, A, B>(failure: (l: L) => B, success: (a: A) => B, fa: Validation<L, A>): B {
-  return fa.fold(failure, success)
-}
+export const fold = <L, A, B>(failure: (l: L) => B, success: (a: A) => B, fa: Validation<L, A>): B =>
+  fa.fold(failure, success)
 
-export function map<L, A, B>(f: (a: A) => B, fa: Validation<L, A>): Validation<L, B> {
-  return fa.map(f)
-}
+export const map = <L, A, B>(f: (a: A) => B, fa: Validation<L, A>): Validation<L, B> => fa.map(f)
 
-export function of<L, A>(a: A): Validation<L, A> {
-  return new Success(a)
-}
+export const of = <L, A>(a: A): Validation<L, A> => new Success(a)
 
-export function ap<L, A, B>(fab: Validation<L, (a: A) => B>, fa: Validation<L, A>): Validation<L, B> {
-  return fa.ap(fab)
-}
+export const ap = <L, A, B>(fab: Validation<L, (a: A) => B>, fa: Validation<L, A>): Validation<L, B> => fa.ap(fab)
 
-export function bimap<L, M, A, B>(
-  S: Semigroup<M>,
-  f: (l: L) => M,
-  g: (a: A) => B,
+export const bimap = <M>(S: Semigroup<M>) => <L, A, B>(f: (l: L) => M, g: (a: A) => B) => (
   fa: Validation<L, A>
-): Validation<M, B> {
-  return fa.bimap(S, f, g)
-}
+): Validation<M, B> => fa.bimap(S)(f, g)
 
-export const alt = <L, A>(fx: Validation<L, A>) => (fy: Validation<L, A>): Validation<L, A> => {
-  return fx.alt(fy)
-}
+export const alt = <L, A>(fx: Validation<L, A>) => (fy: Validation<L, A>): Validation<L, A> => fx.alt(fy)
 
-export function reduce<L, A, B>(f: (b: B, a: A) => B, b: B, fa: Validation<L, A>): B {
-  return fa.reduce(f, b)
-}
+export const reduce = <L, A, B>(f: (b: B, a: A) => B, b: B, fa: Validation<L, A>): B => fa.reduce(f, b)
 
 export class Ops {
   traverse<F extends HKT2S>(
@@ -225,57 +198,43 @@ export class Ops {
 const ops = new Ops()
 export const traverse: Ops['traverse'] = ops.traverse
 
-export function isFailure<L, A>(fa: Validation<L, A>): fa is Failure<L, A> {
-  return fa._tag === 'Failure'
-}
+export const isFailure = <L, A>(fa: Validation<L, A>): fa is Failure<L, A> => fa._tag === 'Failure'
 
-export function isSuccess<L, A>(fa: Validation<L, A>): fa is Success<L, A> {
-  return fa._tag === 'Success'
-}
+export const isSuccess = <L, A>(fa: Validation<L, A>): fa is Success<L, A> => fa._tag === 'Success'
 
-export function failure<L, A>(L: Semigroup<L>, l: L): Validation<L, A> {
-  return new Failure(L, l)
-}
+export const failure = <L>(L: Semigroup<L>) => <A>(l: L): Validation<L, A> => new Failure(L, l)
 
 export const success = of
 
-export function fromPredicate<L, A>(
-  S: Semigroup<L>,
-  predicate: Predicate<A>,
-  l: (a: A) => L
-): (a: A) => Validation<L, A> {
-  return a => (predicate(a) ? success(a) : failure(S, l(a)))
-}
+export const fromPredicate = <L>(S: Semigroup<L>) => <A>(predicate: Predicate<A>, f: (a: A) => L) => (
+  a: A
+): Validation<L, A> => (predicate(a) ? success(a) : failure(S)(f(a)))
 
-export function concat<L, A>(fx: Validation<L, A>, fy: Validation<L, A>): Validation<L, A> {
-  return fx.concat(fy)
-}
+export const concat = <L, A>(fx: Validation<L, A>) => (fy: Validation<L, A>): Validation<L, A> => fx.concat(fy)
 
-export function mapFailure<L, M, A>(S: Semigroup<M>, f: (l: L) => M, fa: Validation<L, A>): Validation<M, A> {
-  return fa.mapFailure(S, f)
-}
+export const mapFailure = <M>(S: Semigroup<M>) => <L>(f: (l: L) => M) => <A>(fa: Validation<L, A>): Validation<M, A> =>
+  fa.mapFailure(S)(f)
 
-export function swap<L, A>(S: Semigroup<A>, fa: Validation<L, A>): Validation<A, L> {
-  return fa.swap(S)
-}
+export const swap = <L, A>(S: Semigroup<A>) => (fa: Validation<L, A>): Validation<A, L> => fa.swap(S)
 
-export function toOption<L, A>(fa: Validation<L, A>): Option<A> {
-  return fa.toOption()
-}
+export const toOption = <L, A>(fa: Validation<L, A>): Option<A> => fa.toOption()
 
-export function toEither<L, A>(fa: Validation<L, A>): Either<L, A> {
-  return fa.toEither()
-}
+export const toEither = <L, A>(fa: Validation<L, A>): Either<L, A> => fa.toEither()
 
-export function toValidationNea<L, A>(fa: Validation<L, A>): Option<Validation<nonEmptyArray.NonEmptyArray<L>, A>> {
-  return fa.toValidationNea()
-}
+export const toValidationNea = <L, A>(fa: Validation<L, A>): Option<Validation<nonEmptyArray.NonEmptyArray<L>, A>> =>
+  fa.toValidationNea()
 
-export const validation: Functor<URI> & Applicative<URI> & Foldable<URI> & Traversable<URI> & Alt<URI> = {
+export const validation: Semigroup<Validation<any, any>> &
+  Functor<URI> &
+  Applicative<URI> &
+  Foldable<URI> &
+  Traversable<URI> &
+  Alt<URI> = {
   URI,
   ap,
   map,
   of,
+  concat,
   reduce,
   traverse,
   alt

--- a/src/Validation.ts
+++ b/src/Validation.ts
@@ -40,7 +40,7 @@ export class Failure<L, A>
   }
   ap<B>(fab: Validation<L, (a: A) => B>): Validation<L, B> {
     if (isFailure(fab)) {
-      return failure(this.semigroup, this.semigroup.concat(fab.value, this.value))
+      return failure(this.semigroup, this.semigroup.concat(fab.value)(this.value))
     }
     return this as any
   }
@@ -69,7 +69,7 @@ export class Failure<L, A>
     return fy.fold(constTrue, constFalse)
   }
   concat(fy: Validation<L, A>): Validation<L, A> {
-    return fy.fold(l => failure<L, A>(this.semigroup, this.semigroup.concat(l, this.value)), () => this)
+    return fy.fold(l => failure<L, A>(this.semigroup, this.semigroup.concat(l)(this.value)), () => this)
   }
   mapFailure<M>(S: Semigroup<M>, f: (l: L) => M): Validation<M, A> {
     return failure(S, f(this.value))

--- a/src/Validation.ts
+++ b/src/Validation.ts
@@ -201,7 +201,7 @@ export function bimap<L, M, A, B>(
   return fa.bimap(S, f, g)
 }
 
-export function alt<L, A>(fx: Validation<L, A>, fy: Validation<L, A>): Validation<L, A> {
+export const alt = <L, A>(fx: Validation<L, A>) => (fy: Validation<L, A>): Validation<L, A> => {
   return fx.alt(fy)
 }
 

--- a/src/Validation.ts
+++ b/src/Validation.ts
@@ -137,7 +137,7 @@ export class Success<L, A>
     return success(this.value)
   }
   equals(S: Setoid<A>, fy: Validation<L, A>): boolean {
-    return fy.fold(constFalse, y => S.equals(this.value, y))
+    return fy.fold(constFalse, y => S.equals(this.value)(y))
   }
   concat(fy: Validation<L, A>): Validation<L, A> {
     return this
@@ -172,7 +172,7 @@ export function equals<L, A>(S: Setoid<A>, fx: Validation<L, A>, fy: Validation<
 
 export function getSetoid<L, A>(S: Setoid<A>): Setoid<Validation<L, A>> {
   return {
-    equals: (x, y) => equals(S, x, y)
+    equals: x => y => equals(S, x, y)
   }
 }
 

--- a/src/Witherable.ts
+++ b/src/Witherable.ts
@@ -16,11 +16,11 @@ export type Wilt1<T extends HKTS, L, R> = {
 }
 
 export interface Witherable<T> extends Traversable<T>, Filterable<T> {
-  wilt<F>(F: Applicative<F>): <A, L, R>(f: (a: A) => HKT<F, Either<L, R>>, ta: HKT<T, A>) => HKT<F, Wilt<T, L, R>>
+  wilt: <F>(F: Applicative<F>) => <A, L, R>(f: (a: A) => HKT<F, Either<L, R>>, ta: HKT<T, A>) => HKT<F, Wilt<T, L, R>>
 }
 
 export interface FantasyWitherable<T, A> extends FantasyTraversable<T, A>, FantasyFilterable<T, A> {
-  wilt<F>(F: Applicative<F>): <L, R>(f: (a: A) => HKT<F, Either<L, R>>) => HKT<F, Wilt<T, L, R>>
+  wilt: <F>(F: Applicative<F>) => <L, R>(f: (a: A) => HKT<F, Either<L, R>>) => HKT<F, Wilt<T, L, R>>
 }
 
 export class Ops {

--- a/src/Writer.ts
+++ b/src/Writer.ts
@@ -41,7 +41,7 @@ export class Writer<W, A> implements FantasyMonad<URI, A> {
     return new Writer(this.monoid, () => {
       const [a, w1] = this.run()
       const [b, w2] = f(a).run()
-      return [b, this.monoid.concat(w1, w2)]
+      return [b, this.monoid.concat(w1)(w2)]
     })
   }
 }

--- a/src/Writer.ts
+++ b/src/Writer.ts
@@ -17,13 +17,7 @@ export class Writer<W, A> implements FantasyMonad<URI, A> {
   readonly _L: W
   readonly _A: A
   readonly _URI: URI
-  of: <A>(a: A) => Writer<W, A>
-  constructor(public readonly monoid: Monoid<W>, public readonly value: Lazy<[A, W]>) {
-    this.of = of<W>(monoid)
-  }
-  run(): [A, W] {
-    return this.value()
-  }
+  constructor(readonly monoid: Monoid<W>, readonly run: Lazy<[A, W]>) {}
   eval(): A {
     return this.run()[0]
   }
@@ -46,35 +40,23 @@ export class Writer<W, A> implements FantasyMonad<URI, A> {
   }
 }
 
-export function map<W, A, B>(f: (a: A) => B, fa: Writer<W, A>): Writer<W, B> {
-  return fa.map(f)
-}
+export const map = <W, A, B>(f: (a: A) => B, fa: Writer<W, A>): Writer<W, B> => fa.map(f)
 
-export function of<W>(M: Monoid<W>): <A>(a: A) => Writer<W, A> {
-  return a => new Writer(M, () => [a, M.empty()])
-}
+export const of = <W>(M: Monoid<W>) => <A>(a: A): Writer<W, A> => new Writer(M, () => [a, M.empty()])
 
-export function ap<W, A, B>(fab: Writer<W, (a: A) => B>, fa: Writer<W, A>): Writer<W, B> {
-  return fa.ap(fab)
-}
+export const ap = <W, A, B>(fab: Writer<W, (a: A) => B>, fa: Writer<W, A>): Writer<W, B> => fa.ap(fab)
 
-export function chain<W, A, B>(f: (a: A) => Writer<W, B>, fa: Writer<W, A>): Writer<W, B> {
-  return fa.chain(f)
-}
+export const chain = <W, A, B>(f: (a: A) => Writer<W, B>, fa: Writer<W, A>): Writer<W, B> => fa.chain(f)
 
-export function tell<W>(M: Monoid<W>): (w: W) => Writer<W, void> {
-  return w => new Writer(M, () => [undefined, w])
-}
+export const tell = <W>(M: Monoid<W>) => (w: W): Writer<W, void> => new Writer(M, () => [undefined, w])
 
-export function getMonad<W>(monoid: Monoid<W>): Monad<URI> {
-  return {
-    URI,
-    map,
-    of: of(monoid),
-    ap,
-    chain
-  }
-}
+export const getMonad = <W>(monoid: Monoid<W>): Monad<URI> => ({
+  URI,
+  map,
+  of: of(monoid),
+  ap,
+  chain
+})
 
 export const writer: Functor<URI> = {
   URI,

--- a/src/function.ts
+++ b/src/function.ts
@@ -228,3 +228,5 @@ export function toString(x: any): string {
 export function tuple<A, B>(a: A, b: B): [A, B] {
   return [a, b]
 }
+
+export const curriedTuple = <A>(a: A) => <B>(b: B): [A, B] => [a, b]

--- a/test/Applicative.ts
+++ b/test/Applicative.ts
@@ -44,9 +44,9 @@ describe('Applicative', () => {
     const action = new io.IO(() => {
       log.push('action called')
     })
-    when(io)(false, action).run()
+    when(io)(false)(action).run()
     assert.deepEqual(log, [])
-    when(io)(true, action).run()
+    when(io)(true)(action).run()
     assert.deepEqual(log, ['action called'])
   })
 })

--- a/test/Applicative.ts
+++ b/test/Applicative.ts
@@ -18,8 +18,8 @@ describe('Applicative', () => {
 
     const somefailure = [
       validation.success<string, number>(1),
-      validation.failure<string, number>(monoidString, '[fail 1]'),
-      validation.failure<string, number>(monoidString, '[fail 2]')
+      validation.failure(monoidString)('[fail 1]'),
+      validation.failure(monoidString)('[fail 2]')
     ].map(a => new taskValidation.TaskValidation(task.of(a)))
 
     const p1 = sequence(taskValidation, array)(allsuccess).value.run()

--- a/test/Apply.ts
+++ b/test/Apply.ts
@@ -5,43 +5,45 @@ import { eqOptions, eqEithers } from './helpers'
 
 describe('Apply', () => {
   it('applyFirst', () => {
-    eqOptions(applyFirst(option)(option.some(5), option.some(6)), option.some(5))
-    eqOptions(applyFirst(option)(option.some(5), option.empty()), option.empty())
-    eqOptions(applyFirst(option)(option.empty(), option.some(6)), option.empty())
+    eqOptions(applyFirst(option)(option.some(5))(option.some(6)), option.some(5))
+    eqOptions(applyFirst(option)(option.some(5))(option.empty()), option.empty())
+    eqOptions(applyFirst(option)(option.empty())(option.some(6)), option.empty())
 
-    eqEithers(applyFirst(either)(either.right(1), either.right(2)), either.right(1))
-    eqEithers(applyFirst(either)(either.left(3), either.right(4)), either.left(3))
-    eqEithers(applyFirst(either)(either.right(5), either.left(6)), either.left(6))
-    eqEithers(applyFirst(either)(either.left(7), either.left(8)), either.left(7))
+    eqEithers(applyFirst(either)(either.right(1))(either.right(2)), either.right(1))
+    eqEithers(applyFirst(either)(either.left(3))(either.right(4)), either.left(3))
+    eqEithers(applyFirst(either)(either.right(5))(either.left(6)), either.left(6))
+    eqEithers(applyFirst(either)(either.left(7))(either.left(8)), either.left(7))
   })
 
   it('applySecond', () => {
-    eqOptions(applySecond(option)(option.some(5), option.some(6)), option.some(6))
-    eqOptions(applySecond(option)(option.some(5), option.empty()), option.empty())
-    eqOptions(applySecond(option)(option.empty(), option.some(6)), option.empty())
+    eqOptions(applySecond(option)(option.some(5))(option.some(6)), option.some(6))
+    eqOptions(applySecond(option)(option.some(5))(option.empty()), option.empty())
+    eqOptions(applySecond(option)(option.empty())(option.some(6)), option.empty())
 
-    eqEithers(applySecond(either)(either.right(1), either.right(2)), either.right(2))
-    eqEithers(applySecond(either)(either.left(3), either.right(4)), either.left(3))
-    eqEithers(applySecond(either)(either.right(5), either.left(6)), either.left(6))
-    eqEithers(applySecond(either)(either.left(7), either.left(8)), either.left(7))
+    eqEithers(applySecond(either)(either.right(1))(either.right(2)), either.right(2))
+    eqEithers(applySecond(either)(either.left(3))(either.right(4)), either.left(3))
+    eqEithers(applySecond(either)(either.right(5))(either.left(6)), either.left(6))
+    eqEithers(applySecond(either)(either.left(7))(either.left(8)), either.left(7))
   })
 
   it('liftA2', () => {
     const f = (a: number) => (b: number) => a + b
-    eqOptions(liftA2(option, f)(option.some(2), option.some(3)), option.some(5))
-    eqEithers(liftA2(either, f)(either.right(2), either.right(3)), either.right(5))
+    eqOptions(liftA2(option)(f)(option.some(2))(option.some(3)), option.some(5))
+    eqEithers(liftA2(either)(f)(either.right(2))(either.right(3)), either.right(5))
   })
 
   it('liftA3', () => {
     const f = (a: number) => (b: number) => (c: number) => a + b + c
-    eqOptions(liftA3(option, f)(option.some(2), option.some(3), option.some(4)), option.some(9))
-    eqEithers(liftA3(either, f)(either.right(2), either.right(3), either.right(4)), either.right(9))
+    eqOptions(liftA3(option)(f)(option.some(2))(option.some(3))(option.some(4)), option.some(9))
+    eqEithers(liftA3(either)(f)(either.right(2))(either.right(3))(either.right(4)), either.right(9))
   })
 
   it('liftA4', () => {
     const f = (a: number) => (b: number) => (c: number) => (d: number) => a + b + c + d
-    eqOptions(liftA4(option, f)(option.some(2), option.some(3), option.some(4), option.some(5)), option.some(14))
-    eqEithers(liftA4(either, f)(either.right(2), either.right(3), either.right(4), either.right(5)), either.right(14))
+    const optionf = liftA4(option)(f)
+    eqOptions(optionf(option.some(2))(option.some(3))(option.some(4))(option.some(5)), option.some(14))
+    const eitherf = liftA4(either)(f)
+    eqEithers(eitherf(either.right(2))(either.right(3))(either.right(4))(either.right(5)), either.right(14))
   })
 
   it('ap_', () => {

--- a/test/Array.ts
+++ b/test/Array.ts
@@ -140,7 +140,7 @@ describe('Array', () => {
   })
 
   it('extend', () => {
-    const sum = (as: Array<number>) => fold(monoidSum, as)
+    const sum = (as: Array<number>) => fold(monoidSum)(as)
     assert.deepEqual(array.extend(sum, [1, 2, 3, 4]), [10, 9, 7, 4])
   })
 

--- a/test/Array.ts
+++ b/test/Array.ts
@@ -37,21 +37,17 @@ describe('Array', () => {
   })
 
   it('index', () => {
-    eq(array.index(as, 1), some(2))
+    eq(array.index(1)(as), some(2))
   })
 
   it('cons', () => {
-    assert.deepEqual(array.cons(0, as), [0, 1, 2, 3])
-    assert.deepEqual(array.cons([1], [[2]]), [[1], [2]])
+    assert.deepEqual(array.cons(0)(as), [0, 1, 2, 3])
+    assert.deepEqual(array.cons([1])([[2]]), [[1], [2]])
   })
 
   it('snoc', () => {
-    assert.deepEqual(array.snoc(as, 4), [1, 2, 3, 4])
-    assert.deepEqual(array.snoc([[1]], [2]), [[1], [2]])
-  })
-
-  it('curriedSnoc', () => {
-    assert.deepEqual(array.curriedSnoc(as)(4), [1, 2, 3, 4])
+    assert.deepEqual(array.snoc(as)(4), [1, 2, 3, 4])
+    assert.deepEqual(array.snoc([[1]])([2]), [[1], [2]])
   })
 
   it('head', () => {
@@ -68,20 +64,20 @@ describe('Array', () => {
   })
 
   it('take', () => {
-    assert.deepEqual(array.take(2, empty), [])
-    assert.deepEqual(array.take(2, as), [1, 2])
+    assert.deepEqual(array.take(2)(empty), [])
+    assert.deepEqual(array.take(2)(as), [1, 2])
   })
 
   it('takeWhile', () => {
-    assert.deepEqual(array.takeWhile(n => n % 2 === 0, as), [2])
+    assert.deepEqual(array.takeWhile((n: number) => n % 2 === 0)(as), [2])
   })
 
   it('drop', () => {
-    assert.deepEqual(array.drop(2, as), [3])
+    assert.deepEqual(array.drop(2)(as), [3])
   })
 
   it('dropWhile', () => {
-    assert.deepEqual(array.dropWhile(n => n % 2 === 0, as), [1, 3])
+    assert.deepEqual(array.dropWhile((n: number) => n % 2 === 0)(as), [1, 3])
   })
 
   it('init', () => {
@@ -90,37 +86,38 @@ describe('Array', () => {
   })
 
   it('slice', () => {
-    assert.deepEqual(array.slice(1, 2, as), [2])
+    assert.deepEqual(array.slice(1, 2)(as), [2])
   })
 
   it('findIndex', () => {
-    eq(array.findIndex(x => x === 2, empty), none)
-    eq(array.findIndex(x => x === 2, as), some(1))
+    eq(array.findIndex(x => x === 2)(empty), none)
+    eq(array.findIndex(x => x === 2)(as), some(1))
   })
 
   it('insertAt', () => {
-    eq(array.insertAt(1, 1, empty), none)
-    eq(array.insertAt(0, 1, empty), some([1]))
+    eq(array.insertAt(1)(1)(empty), none)
+    eq(array.insertAt(0)(1)(empty), some([1]))
   })
 
   it('updateAt', () => {
-    eq(array.updateAt(1, 1, empty), none)
-    eq(array.updateAt(1, 1, as), some([1, 1, 3]))
+    eq(array.updateAt(1)(1)(empty), none)
+    eq(array.updateAt(1)(1)(as), some([1, 1, 3]))
   })
 
   it('deleteAt', () => {
-    eq(array.deleteAt(1, empty), none)
-    eq(array.deleteAt(0, as), some([2, 3]))
+    eq(array.deleteAt(1)(empty), none)
+    eq(array.deleteAt(0)(as), some([2, 3]))
   })
 
   it('modifyAt', () => {
-    eq(array.modifyAt(1, x => 2 * x, empty), none)
-    eq(array.modifyAt(1, x => 2 * x, as), some([1, 4, 3]))
+    const double = (x: number) => 2 * x
+    eq(array.modifyAt(1)(double)(empty), none)
+    eq(array.modifyAt(1)(double)(as), some([1, 4, 3]))
   })
 
   it('mapOption', () => {
     const f = (a: number) => (a % 2 === 0 ? none : some(a))
-    assert.deepEqual(array.mapOption(f, as), [1, 3])
+    assert.deepEqual(array.mapOption(f)(as), [1, 3])
   })
 
   it('catOptions', () => {
@@ -129,7 +126,7 @@ describe('Array', () => {
   })
 
   it('sort', () => {
-    assert.deepEqual(array.sort(numberOrd, [3, 2, 1]), [1, 2, 3])
+    assert.deepEqual(array.sort(numberOrd)([3, 2, 1]), [1, 2, 3])
   })
 
   it('refine', () => {
@@ -145,6 +142,6 @@ describe('Array', () => {
   })
 
   it('zip', () => {
-    assert.deepEqual(array.zip([1, 2, 3], ['a', 'b', 'c', 'd']), [[1, 'a'], [2, 'b'], [3, 'c']])
+    assert.deepEqual(array.zip([1, 2, 3])(['a', 'b', 'c', 'd']), [[1, 'a'], [2, 'b'], [3, 'c']])
   })
 })

--- a/test/Array.ts
+++ b/test/Array.ts
@@ -2,7 +2,7 @@ import * as array from '../src/Array'
 import { some, none } from '../src/Option'
 import * as option from '../src/Option'
 import * as assert from 'assert'
-import { numberOrd } from '../src/Ord'
+import { ordNumber } from '../src/Ord'
 import { eqOptions as eq } from './helpers'
 import { monoidSum, fold } from '../src/Monoid'
 import { tuple } from '../src/function'
@@ -126,7 +126,7 @@ describe('Array', () => {
   })
 
   it('sort', () => {
-    assert.deepEqual(array.sort(numberOrd)([3, 2, 1]), [1, 2, 3])
+    assert.deepEqual(array.sort(ordNumber)([3, 2, 1]), [1, 2, 3])
   })
 
   it('refine', () => {

--- a/test/Contravariant.ts
+++ b/test/Contravariant.ts
@@ -1,0 +1,35 @@
+import * as assert from 'assert'
+import { Contravariant, lift } from '../src/Contravariant'
+
+const URI = 'Predicate'
+
+type URI = typeof URI
+
+declare module '../src/HKT' {
+  interface URI2HKT<A> {
+    Predicate: Predicate<A>
+  }
+}
+
+class Predicate<A> {
+  readonly _A: A
+  readonly _URI: URI
+  constructor(public readonly run: (a: A) => boolean) {}
+}
+
+const contramap = <A>(fa: Predicate<A>) => <B>(f: (b: B) => A): Predicate<B> => new Predicate(b => fa.run(f(b)))
+
+const predicate: Contravariant<URI> = {
+  URI,
+  contramap
+}
+
+describe('Contravariant', () => {
+  it('lift', () => {
+    const length = (s: string) => s.length
+    const liftPredicate = lift(predicate)
+    const f = liftPredicate(length)
+    assert.deepEqual(f(new Predicate(n => n > 2)).run('fo'), false)
+    assert.deepEqual(f(new Predicate(n => n > 2)).run('foo'), true)
+  })
+})

--- a/test/Either.ts
+++ b/test/Either.ts
@@ -51,12 +51,12 @@ describe('Either', () => {
   })
 
   it('getOrElse', () => {
-    assert.equal(getOrElse(() => 17, right(12)), 12)
-    assert.equal(getOrElse(() => 17, left(12)), 17)
+    assert.equal(getOrElse(() => 17)(right(12)), 12)
+    assert.equal(getOrElse(() => 17)(left(12)), 17)
   })
 
   it('fromOption', () => {
-    assert.deepEqual(fromOption('default', none), left('default'))
-    assert.deepEqual(fromOption('default', some(1)), right(1))
+    assert.deepEqual(fromOption('default')(none), left('default'))
+    assert.deepEqual(fromOption('default')(some(1)), right(1))
   })
 })

--- a/test/Either.ts
+++ b/test/Either.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert'
-import { right, left, map, fold, getOrElse, ap, chain, fromPredicate, tryCatch, fromOption } from '../src/Either'
+import { right, left, map, fold, getOrElse, ap, chain, fromPredicate, tryCatch, fromOption, bimap } from '../src/Either'
 import { eqEithers as eq } from './helpers'
 import { none, some } from '../src/Option'
 
@@ -15,6 +15,12 @@ describe('Either', () => {
     const f = (s: string): number => s.length
     eq(map(f, right('abc')), right(3))
     eq(map(f, left('s')), left('s'))
+  })
+
+  it('bimap', () => {
+    const f = (s: string): number => s.length
+    const g = (n: number): boolean => n > 2
+    eq(bimap(f, g)(right(1)), right(false))
   })
 
   it('ap', () => {

--- a/test/Exception.ts
+++ b/test/Exception.ts
@@ -24,7 +24,7 @@ describe('Exception', () => {
 
   it('catchException', () => {
     const eio = exception.throwException<number>(new Error('bum!'))
-    const io = exception.catchException(e => new IO(() => 1), eio)
+    const io = exception.catchException(e => new IO(() => 1))(eio)
     assert.strictEqual(io.run(), 1)
   })
 

--- a/test/Field.ts
+++ b/test/Field.ts
@@ -5,13 +5,13 @@ import * as setoid from '../src/Setoid'
 describe('Field', () => {
   it('gcd', () => {
     const gcd = field.gcd(setoid.setoidNumber, field.fieldNumber)
-    assert.strictEqual(gcd(10, 5), 5)
-    assert.strictEqual(gcd(10, 2), 2)
-    assert.strictEqual(gcd(10, 3), 1)
+    assert.strictEqual(gcd(10)(5), 5)
+    assert.strictEqual(gcd(10)(2), 2)
+    assert.strictEqual(gcd(10)(3), 1)
   })
 
   it('lcm', () => {
     const lcm = field.lcm(setoid.setoidNumber, field.fieldNumber)
-    assert.strictEqual(lcm(4, 6), 12)
+    assert.strictEqual(lcm(4)(6), 12)
   })
 })

--- a/test/Filterable.ts
+++ b/test/Filterable.ts
@@ -17,22 +17,23 @@ describe('Filterable', () => {
 
   it('partition', () => {
     const isEven = (n: number) => n % 2 === 0
-    const { no, yes } = filterable.partition(array)(isEven, [1, 2, 3])
+    const { no, yes } = filterable.partition(array)(isEven)([1, 2, 3])
     assert.deepEqual(no, [1, 3])
     assert.deepEqual(yes, [2])
   })
 
   it('filterMap', () => {
-    const xs = filterable.filterMap(array)(
-      (s: string): option.Option<number> => (s.length >= 2 ? option.some(s.length) : option.none),
-      ['a', 'bb', 'ccc']
-    )
+    const xs = filterable.filterMap(array)((s: string) => (s.length >= 2 ? option.some(s.length) : option.none))([
+      'a',
+      'bb',
+      'ccc'
+    ])
     assert.deepEqual(xs, [2, 3])
   })
 
   it('filter', () => {
     const isEven = (n: number) => n % 2 === 0
-    const xs = filterable.filter(array)(isEven, [1, 2, 3])
+    const xs = filterable.filter(array)(isEven)([1, 2, 3])
     assert.deepEqual(xs, [2])
   })
 

--- a/test/Foldable.ts
+++ b/test/Foldable.ts
@@ -15,7 +15,7 @@ describe('Foldable', () => {
   })
 
   it('foldMap', () => {
-    assert.deepEqual(foldMap(array, monoidString)(s => s, ['a', 'b', 'c']), 'abc')
+    assert.deepEqual(foldMap(array, monoidString)((s: string) => s)(['a', 'b', 'c']), 'abc')
   })
 
   it('getFoldableComposition', () => {
@@ -40,10 +40,10 @@ describe('Foldable', () => {
         return arrayOptionFoldable.reduce(f, b, fa.value)
       }
     }
-    const join = intercalate(arrayOption, monoidString)
-    assert.strictEqual(join(' ', new ArrayOption([])), '')
-    assert.strictEqual(join(' ', new ArrayOption([option.some('a')])), 'a')
-    assert.strictEqual(join(' ', new ArrayOption([option.some('a'), option.none, option.some('b')])), 'a b')
+    const join = intercalate(arrayOption, monoidString)(' ')
+    assert.strictEqual(join(new ArrayOption([])), '')
+    assert.strictEqual(join(new ArrayOption([option.some('a')])), 'a')
+    assert.strictEqual(join(new ArrayOption([option.some('a'), option.none, option.some('b')])), 'a b')
   })
 
   it('traverse_', () => {

--- a/test/Functor.ts
+++ b/test/Functor.ts
@@ -7,7 +7,7 @@ import { eqOptions as eq } from './helpers'
 describe('Functor', () => {
   it('lift', () => {
     const double = (a: number) => a * 2
-    const f = lift(option, double)
+    const f = lift(option)(double)
     const actual = f(option.some(2))
     eq(actual, option.some(4))
   })
@@ -19,11 +19,11 @@ describe('Functor', () => {
   })
 
   it('voidRight', () => {
-    assert.deepEqual(voidRight(option, 1, option.some('a')), option.some(1))
+    assert.deepEqual(voidRight(option)(1)(option.some('a')), option.some(1))
   })
 
   it('voidLeft', () => {
-    assert.deepEqual(voidLeft(option, option.some(1), 'a'), option.some('a'))
+    assert.deepEqual(voidLeft(option)(option.some(1))('a'), option.some('a'))
   })
 
   it('flap', () => {

--- a/test/Functor.ts
+++ b/test/Functor.ts
@@ -30,6 +30,6 @@ describe('Functor', () => {
     const gt3 = (n: number) => n >= 3
     const lt5 = (n: number) => n <= 5
     const fs = [gt3, lt5]
-    assert.deepEqual(flap(array)(fs, 4), [true, true])
+    assert.deepEqual(flap(array)(fs)(4), [true, true])
   })
 })

--- a/test/IxIO.ts
+++ b/test/IxIO.ts
@@ -69,14 +69,14 @@ describe('IxIO', () => {
 
   it('iapplyFirst', () => {
     log = []
-    const action = iapplyFirst(ixIO)(new Open(), new Close())
+    const action = iapplyFirst(ixIO)(new Open())(new Close())
     action.run()
     assert.deepEqual(log, ['Opening the door', 'Closing the door'])
   })
 
   it('iapplySecond', () => {
     log = []
-    const action = iapplySecond(ixIO)(new Open(), new Close())
+    const action = iapplySecond(ixIO)(new Open())(new Close())
     action.run()
     assert.deepEqual(log, ['Opening the door', 'Closing the door'])
   })

--- a/test/Monoid.ts
+++ b/test/Monoid.ts
@@ -4,7 +4,7 @@ import { filter } from '../src/Array'
 
 describe('Monoid', () => {
   it('fold', () => {
-    assert.strictEqual(fold(monoidSum, [1, 2, 3]), 6)
+    assert.strictEqual(fold(monoidSum)([1, 2, 3]), 6)
   })
 
   it('getFunctionMonoid', () => {
@@ -14,8 +14,8 @@ describe('Monoid', () => {
     const isLessThan10 = (n: number) => n <= 10
     const isEven = (n: number) => n % 2 === 0
 
-    assert.deepEqual(filter(fold(getPredicateMonoidAll<number>(), [isLessThan10, isEven]), [1, 2, 3, 40]), [2])
-    assert.deepEqual(filter(fold(getPredicateMonoidAny<number>(), [isLessThan10, isEven]), [1, 2, 3, 40, 41]), [
+    assert.deepEqual(filter(fold(getPredicateMonoidAll<number>())([isLessThan10, isEven]), [1, 2, 3, 40]), [2])
+    assert.deepEqual(filter(fold(getPredicateMonoidAny<number>())([isLessThan10, isEven]), [1, 2, 3, 40, 41]), [
       1,
       2,
       3,

--- a/test/Monoid.ts
+++ b/test/Monoid.ts
@@ -24,10 +24,10 @@ describe('Monoid', () => {
   })
 
   it('monoidArray', () => {
-    assert.deepEqual(monoidArray.concat([1], ['a']), [1, 'a'])
+    assert.deepEqual(monoidArray.concat([1])(['a']), [1, 'a'])
   })
 
   it('getArrayMonoid', () => {
-    assert.deepEqual(getArrayMonoid<number>().concat([1], [2]), [1, 2])
+    assert.deepEqual(getArrayMonoid<number>().concat([1])([2]), [1, 2])
   })
 })

--- a/test/Monoid.ts
+++ b/test/Monoid.ts
@@ -14,8 +14,8 @@ describe('Monoid', () => {
     const isLessThan10 = (n: number) => n <= 10
     const isEven = (n: number) => n % 2 === 0
 
-    assert.deepEqual(filter(fold(getPredicateMonoidAll<number>())([isLessThan10, isEven]), [1, 2, 3, 40]), [2])
-    assert.deepEqual(filter(fold(getPredicateMonoidAny<number>())([isLessThan10, isEven]), [1, 2, 3, 40, 41]), [
+    assert.deepEqual(filter(fold(getPredicateMonoidAll<number>())([isLessThan10, isEven]))([1, 2, 3, 40]), [2])
+    assert.deepEqual(filter(fold(getPredicateMonoidAny<number>())([isLessThan10, isEven]))([1, 2, 3, 40, 41]), [
       1,
       2,
       3,

--- a/test/Monoidal.ts
+++ b/test/Monoidal.ts
@@ -6,11 +6,11 @@ import * as either from '../src/Either'
 describe('Monoidal', () => {
   it('fromApplicative', () => {
     const monoidalOption = fromApplicative(option)
-    assert.deepEqual(monoidalOption.mult(option.some(1), option.some('a')), option.some([1, 'a']))
-    assert.deepEqual(monoidalOption.mult(option.some(1), option.none), option.none)
+    assert.deepEqual(monoidalOption.mult(option.some(1))(option.some('a')), option.some([1, 'a']))
+    assert.deepEqual(monoidalOption.mult(option.some(1))(option.none), option.none)
     const monoidalEither = fromApplicative(either)
-    assert.deepEqual(monoidalEither.mult(either.right(1), either.right('a')), either.right([1, 'a']))
-    assert.deepEqual(monoidalEither.mult(either.right(1), either.left('error')), either.left('error'))
+    assert.deepEqual(monoidalEither.mult(either.right(1))(either.right('a')), either.right([1, 'a']))
+    assert.deepEqual(monoidalEither.mult(either.right(1))(either.left('error')), either.left('error'))
   })
 
   it('toApplicative', () => {

--- a/test/NonEmptyArray.ts
+++ b/test/NonEmptyArray.ts
@@ -6,7 +6,7 @@ describe('NonEmptyArray', () => {
   it('concat', () => {
     const x = new NonEmptyArray(1, [2])
     const y = new NonEmptyArray(3, [4])
-    assert.deepEqual(concat(x, y).toArray(), [1, 2, 3, 4])
+    assert.deepEqual(concat(x)(y).toArray(), [1, 2, 3, 4])
   })
 
   it('map', () => {

--- a/test/NonEmptyArray.ts
+++ b/test/NonEmptyArray.ts
@@ -22,7 +22,7 @@ describe('NonEmptyArray', () => {
   })
 
   it('extend', () => {
-    const sum = (as: NonEmptyArray<number>) => fold(monoidSum, as.toArray())
+    const sum = (as: NonEmptyArray<number>) => fold(monoidSum)(as.toArray())
     assert.deepEqual(new NonEmptyArray(1, [2, 3, 4]).extend(sum), new NonEmptyArray(10, [9, 7, 4]))
   })
 

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -72,10 +72,10 @@ describe('Option', () => {
   })
 
   it('alt', () => {
-    eq(alt(some(1), some(2)), some(1))
-    eq(alt(none, some(2)), some(2))
-    eq(alt(some(1), none), some(1))
-    eq(alt(none, none), none)
+    eq(alt(some(1))(some(2)), some(1))
+    eq(alt(none)(some(2)), some(2))
+    eq(alt(some(1))(none), some(1))
+    eq(alt(none)(none), none)
   })
 
   it('fromNullable', () => {

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -62,13 +62,13 @@ describe('Option', () => {
 
   it('getMonoid', () => {
     const { concat } = getMonoid({
-      concat(x: number, y: number) {
+      concat: (x: number) => (y: number) => {
         return x + y
       }
     })
-    eq(concat(none, some(1)), some(1))
-    eq(concat(some(2), none), some(2))
-    eq(concat(some(2), some(1)), some(3))
+    eq(concat(none)(some(1)), some(1))
+    eq(concat(some(2))(none), some(2))
+    eq(concat(some(2))(some(1)), some(3))
   })
 
   it('alt', () => {
@@ -98,18 +98,18 @@ describe('Option', () => {
 
   it('getFirstMonoid', () => {
     const first = getFirstMonoid<number>()
-    assert.deepEqual(first.concat(none, some(1)), some(1))
-    assert.deepEqual(first.concat(some(1), none), some(1))
-    assert.deepEqual(first.concat(none, none), none)
-    assert.deepEqual(first.concat(some(1), some(2)), some(1))
+    assert.deepEqual(first.concat(none)(some(1)), some(1))
+    assert.deepEqual(first.concat(some(1))(none), some(1))
+    assert.deepEqual(first.concat(none)(none), none)
+    assert.deepEqual(first.concat(some(1))(some(2)), some(1))
   })
 
   it('getLastMonoid', () => {
     const last = getLastMonoid<number>()
-    assert.deepEqual(last.concat(none, some(1)), some(1))
-    assert.deepEqual(last.concat(some(1), none), some(1))
-    assert.deepEqual(last.concat(none, none), none)
-    assert.deepEqual(last.concat(some(1), some(2)), some(2))
+    assert.deepEqual(last.concat(none)(some(1)), some(1))
+    assert.deepEqual(last.concat(some(1))(none), some(1))
+    assert.deepEqual(last.concat(none)(none), none)
+    assert.deepEqual(last.concat(some(1))(some(2)), some(2))
   })
 
   it('contains', () => {

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -34,10 +34,11 @@ describe('Option', () => {
   })
 
   it('equals', () => {
-    assert.strictEqual(equals(setoidNumber, none, none), true)
-    assert.strictEqual(equals(setoidNumber, none, some(1)), false)
-    assert.strictEqual(equals(setoidNumber, some(2), some(1)), false)
-    assert.strictEqual(equals(setoidNumber, some(2), some(2)), true)
+    const eq = equals(setoidNumber)
+    assert.strictEqual(eq(none)(none), true)
+    assert.strictEqual(eq(none)(some(1)), false)
+    assert.strictEqual(eq(some(2))(some(1)), false)
+    assert.strictEqual(eq(some(2))(some(2)), true)
   })
 
   it('map', () => {
@@ -73,7 +74,7 @@ describe('Option', () => {
 
   it('alt', () => {
     eq(alt(some(1))(some(2)), some(1))
-    eq(alt(none)(some(2)), some(2))
+    eq(alt(none as Option<number>)(some(2)), some(2))
     eq(alt(some(1))(none), some(1))
     eq(alt(none)(none), none)
   })

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -74,7 +74,7 @@ describe('Option', () => {
 
   it('alt', () => {
     eq(alt(some(1))(some(2)), some(1))
-    eq(alt(none as Option<number>)(some(2)), some(2))
+    eq(alt(none)(some(2)), some(2))
     eq(alt(some(1))(none), some(1))
     eq(alt(none)(none), none)
   })

--- a/test/OptionT.ts
+++ b/test/OptionT.ts
@@ -30,10 +30,11 @@ describe('OptionT', () => {
 
   it('getOrElse', () => {
     const greetingT = taskOption.of('welcome')
-    const p1 = optionT.getOrElse(task)(() => 'hello, there!', greetingT).run().then(s => {
+    const getOrElse = optionT.getOrElse(task)(() => 'hello, there!')
+    const p1 = getOrElse(greetingT).run().then(s => {
       assert.strictEqual(s, 'welcome')
     })
-    const p2 = optionT.getOrElse(task)(() => 'hello, there!', none).run().then(s => {
+    const p2 = getOrElse(none).run().then(s => {
       assert.strictEqual(s, 'hello, there!')
     })
     return Promise.all([p1, p2])

--- a/test/ReaderT.ts
+++ b/test/ReaderT.ts
@@ -8,7 +8,7 @@ const readerOption = getReaderT(option)
 describe('ReaderT', () => {
   it('ReaderOption', () => {
     function configure(key: string) {
-      return (e: StrMap<string>) => lookup(key, e)
+      return (e: StrMap<string>) => lookup(key)(e)
     }
 
     const setupConnection = readerOption.chain(host => {

--- a/test/Semigroup.ts
+++ b/test/Semigroup.ts
@@ -4,6 +4,6 @@ import { monoidString } from '../src/Monoid'
 
 describe('Semigroup', () => {
   it('fold', () => {
-    assert.strictEqual(fold(monoidString, '', ['a', 'b', 'c']), 'abc')
+    assert.strictEqual(fold(monoidString)('')(['a', 'b', 'c']), 'abc')
   })
 })

--- a/test/StateT.ts
+++ b/test/StateT.ts
@@ -6,7 +6,7 @@ const stateTOption = stateT.getStateT(option)
 
 describe('StateT', () => {
   it('put', () => {
-    assert.deepEqual(stateT.put(option)(2)(1), option.some([undefined, 2]))
+    assert.deepEqual(stateT.put(option)(2)(), option.some([undefined, 2]))
   })
 
   it('get', () => {

--- a/test/StrMap.ts
+++ b/test/StrMap.ts
@@ -65,11 +65,11 @@ describe('StrMap', () => {
 
   it('fromFoldable', () => {
     assert.deepEqual(
-      fromFoldable(array)((existing, a) => existing)([['a', 1]] as Array<[string, number]>),
+      fromFoldable(array)(existing => a => existing)([['a', 1]] as Array<[string, number]>),
       new StrMap({ a: 1 })
     )
     assert.deepEqual(
-      fromFoldable(array)((existing, a) => existing)([['a', 1], ['a', 2]] as Array<[string, number]>),
+      fromFoldable(array)(existing => a => existing)([['a', 1], ['a', 2]] as Array<[string, number]>),
       new StrMap({
         a: 1
       })

--- a/test/StrMap.ts
+++ b/test/StrMap.ts
@@ -59,17 +59,17 @@ describe('StrMap', () => {
   })
 
   it('lookup', () => {
-    eq(lookup('a', new StrMap({ a: 1 })), option.some(1))
-    eq(lookup('b', new StrMap({ a: 1 })), option.none)
+    eq(lookup('a')(new StrMap({ a: 1 })), option.some(1))
+    eq(lookup('b')(new StrMap({ a: 1 })), option.none)
   })
 
   it('fromFoldable', () => {
     assert.deepEqual(
-      fromFoldable(array)((existing, a) => existing, [['a', 1]] as Array<[string, number]>),
+      fromFoldable(array)((existing, a) => existing)([['a', 1]] as Array<[string, number]>),
       new StrMap({ a: 1 })
     )
     assert.deepEqual(
-      fromFoldable(array)((existing, a) => existing, [['a', 1], ['a', 2]] as Array<[string, number]>),
+      fromFoldable(array)((existing, a) => existing)([['a', 1], ['a', 2]] as Array<[string, number]>),
       new StrMap({
         a: 1
       })
@@ -108,15 +108,15 @@ describe('StrMap', () => {
   })
 
   it('insert', () => {
-    assert.deepEqual(insert('a', 1, new StrMap({})), new StrMap({ a: 1 }))
+    assert.deepEqual(insert('a')(1)(new StrMap({})), new StrMap({ a: 1 }))
   })
 
   it('remove', () => {
-    assert.deepEqual(remove('a', new StrMap({ a: 1, b: 2 })), new StrMap({ b: 2 }))
+    assert.deepEqual(remove('a')(new StrMap({ a: 1, b: 2 })), new StrMap({ b: 2 }))
   })
 
   it('pop', () => {
-    assert.deepEqual(pop('a', new StrMap({ a: 1, b: 2 })), option.some([1, new StrMap({ b: 2 })]))
-    assert.deepEqual(pop('c', new StrMap({ a: 1, b: 2 })), option.none)
+    assert.deepEqual(pop('a')(new StrMap({ a: 1, b: 2 })), option.some([1, new StrMap({ b: 2 })]))
+    assert.deepEqual(pop('c')(new StrMap({ a: 1, b: 2 })), option.none)
   })
 })

--- a/test/StrMap.ts
+++ b/test/StrMap.ts
@@ -27,7 +27,7 @@ describe('StrMap', () => {
   it('concat', () => {
     const d1 = new StrMap<number>({ k1: 1 })
     const d2 = new StrMap<number>({ k2: 2 })
-    assert.deepEqual(concat(d1, d2), new StrMap({ k1: 1, k2: 2 }))
+    assert.deepEqual(concat(d1)(d2), new StrMap({ k1: 1, k2: 2 }))
   })
 
   it('map', () => {

--- a/test/StrMap.ts
+++ b/test/StrMap.ts
@@ -53,9 +53,9 @@ describe('StrMap', () => {
   })
 
   it('getSetoid', () => {
-    assert.strictEqual(getSetoid(setoidNumber).equals(new StrMap({ a: 1 }), new StrMap({ a: 1 })), true)
-    assert.strictEqual(getSetoid(setoidNumber).equals(new StrMap({ a: 1 }), new StrMap({ a: 2 })), false)
-    assert.strictEqual(getSetoid(setoidNumber).equals(new StrMap({ a: 1 }), new StrMap({ b: 1 })), false)
+    assert.strictEqual(getSetoid(setoidNumber).equals(new StrMap({ a: 1 }))(new StrMap({ a: 1 })), true)
+    assert.strictEqual(getSetoid(setoidNumber).equals(new StrMap({ a: 1 }))(new StrMap({ a: 2 })), false)
+    assert.strictEqual(getSetoid(setoidNumber).equals(new StrMap({ a: 1 }))(new StrMap({ b: 1 })), false)
   })
 
   it('lookup', () => {

--- a/test/Task.ts
+++ b/test/Task.ts
@@ -38,8 +38,8 @@ describe('Task', () => {
 
   it('tryCatch', () => {
     const onrejected = (e: any) => `Error is: ${String(e)}`
-    const t1 = tryCatch(() => Promise.resolve(1), onrejected)
-    const t2 = tryCatch(() => Promise.reject('ouch!'), onrejected)
+    const t1 = tryCatch(() => Promise.resolve(1))(onrejected)
+    const t2 = tryCatch(() => Promise.reject('ouch!'))(onrejected)
     return Promise.all([t1.run(), t2.run()]).then(([e1, e2]) => {
       assert.deepEqual(e1, right(1))
       assert.deepEqual(e2, left('Error is: ouch!'))

--- a/test/These.ts
+++ b/test/These.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert'
-import { this_, that, both, fromThese } from '../src/These'
+import { this_, that, both, fromThese, bimap } from '../src/These'
 import { setoidNumber, setoidString } from '../src/Setoid'
 import { monoidSum, monoidString } from '../src/Monoid'
 
@@ -29,6 +29,12 @@ describe('These', () => {
     assert.strictEqual(this_(2).map(double).equals(setoidNumber, setoidNumber, this_<number, number>(2)), true)
     assert.strictEqual(that(2).map(double).equals(setoidNumber, setoidNumber, that<number, number>(4)), true)
     assert.strictEqual(both(1, 2).map(double).equals(setoidNumber, setoidNumber, both<number, number>(1, 4)), true)
+  })
+
+  it('bimap', () => {
+    const len = (s: string): number => s.length
+    const double = (n: number): number => n * 2
+    assert.deepEqual(bimap(len, double)(both('foo', 1)), both(3, 2))
   })
 
   it('fromThese', () => {

--- a/test/These.ts
+++ b/test/These.ts
@@ -5,30 +5,30 @@ import { monoidSum, monoidString } from '../src/Monoid'
 
 describe('These', () => {
   it('equals', () => {
-    assert.strictEqual(this_(2).equals(setoidNumber, setoidNumber, this_(2)), true)
-    assert.strictEqual(this_(2).equals(setoidNumber, setoidNumber, this_(3)), false)
+    assert.strictEqual(this_(2).equals(setoidNumber, setoidNumber)(this_(2)), true)
+    assert.strictEqual(this_(2).equals(setoidNumber, setoidNumber)(this_(3)), false)
   })
 
   it('concat', () => {
     assert.strictEqual(
-      this_('a')
-        .concat(monoidString, monoidSum, this_('b'))
-        .equals(setoidString, setoidNumber, this_<string, number>('ab')),
+      this_('a').concat(monoidString, monoidSum)(this_('b')).equals(setoidString, setoidNumber)(
+        this_<string, number>('ab')
+      ),
       true
     )
     assert.strictEqual(
-      this_('a')
-        .concat(monoidString, monoidSum, that<string, number>(2))
-        .equals(setoidString, setoidNumber, both<string, number>('a', 2)),
+      this_('a').concat(monoidString, monoidSum)(that<string, number>(2)).equals(setoidString, setoidNumber)(
+        both<string, number>('a', 2)
+      ),
       true
     )
   })
 
   it('map', () => {
     const double = (n: number) => n * 2
-    assert.strictEqual(this_(2).map(double).equals(setoidNumber, setoidNumber, this_<number, number>(2)), true)
-    assert.strictEqual(that(2).map(double).equals(setoidNumber, setoidNumber, that<number, number>(4)), true)
-    assert.strictEqual(both(1, 2).map(double).equals(setoidNumber, setoidNumber, both<number, number>(1, 4)), true)
+    assert.strictEqual(this_(2).map(double).equals(setoidNumber, setoidNumber)(this_<number, number>(2)), true)
+    assert.strictEqual(that(2).map(double).equals(setoidNumber, setoidNumber)(that<number, number>(4)), true)
+    assert.strictEqual(both(1, 2).map(double).equals(setoidNumber, setoidNumber)(both<number, number>(1, 4)), true)
   })
 
   it('bimap', () => {
@@ -38,15 +38,16 @@ describe('These', () => {
   })
 
   it('fromThese', () => {
-    assert.deepEqual(fromThese('a', 1, this_<string, number>('b')), ['b', 1])
-    assert.deepEqual(fromThese('a', 1, that<string, number>(2)), ['a', 2])
-    assert.deepEqual(fromThese('a', 1, both('b', 2)), ['b', 2])
+    const fromThese_ = fromThese('a', 1)
+    assert.deepEqual(fromThese_(this_<string, number>('b')), ['b', 1])
+    assert.deepEqual(fromThese_(that<string, number>(2)), ['a', 2])
+    assert.deepEqual(fromThese_(both('b', 2)), ['b', 2])
   })
 
   it('bimap', () => {
     const double = (n: number) => n * 2
     const len = (s: string) => s.length
-    assert.strictEqual(this_('a').bimap(len, double).equals(setoidNumber, setoidNumber, this_<number, number>(1)), true)
-    assert.strictEqual(that(2).bimap(len, double).equals(setoidNumber, setoidNumber, that<number, number>(4)), true)
+    assert.strictEqual(this_('a').bimap(len, double).equals(setoidNumber, setoidNumber)(this_<number, number>(1)), true)
+    assert.strictEqual(that(2).bimap(len, double).equals(setoidNumber, setoidNumber)(that<number, number>(4)), true)
   })
 })

--- a/test/Tuple.ts
+++ b/test/Tuple.ts
@@ -5,7 +5,7 @@ import { left, right } from '../src/Either'
 
 describe('Tuple', () => {
   it('compose', () => {
-    assert.deepEqual(compose(new Tuple([1, 's']), new Tuple([true, 2])), new Tuple([true, 's']))
+    assert.deepEqual(compose(new Tuple([1, 's']))(new Tuple([true, 2])), new Tuple([true, 's']))
   })
 
   it('map', () => {

--- a/test/Tuple.ts
+++ b/test/Tuple.ts
@@ -21,7 +21,7 @@ describe('Tuple', () => {
 
   it('getSemigroup', () => {
     const semigroup = getSemigroup(monoidString, monoidSum)
-    assert.deepEqual(semigroup.concat(new Tuple(['a', 1]), new Tuple(['b', 2])), new Tuple(['ab', 3]))
+    assert.deepEqual(semigroup.concat(new Tuple(['a', 1]))(new Tuple(['b', 2])), new Tuple(['ab', 3]))
   })
 
   it('toString', () => {

--- a/test/Tuple.ts
+++ b/test/Tuple.ts
@@ -16,7 +16,7 @@ describe('Tuple', () => {
   it('bimap', () => {
     const double = (n: number): number => n * 2
     const len = (s: string): number => s.length
-    assert.deepEqual(bimap(len, double, new Tuple(['s', 1])), new Tuple([1, 2]))
+    assert.deepEqual(bimap(len, double)(new Tuple(['s', 1])), new Tuple([1, 2]))
   })
 
   it('getSemigroup', () => {

--- a/test/Validation.ts
+++ b/test/Validation.ts
@@ -14,8 +14,8 @@ describe('Validation', () => {
 
     const failure = [
       validation.success<string, number>(1),
-      validation.failure<string, number>(monoidString, '[fail 1]'),
-      validation.failure<string, number>(monoidString, '[fail 2]')
+      validation.failure(monoidString)<number>('[fail 1]'),
+      validation.failure(monoidString)<number>('[fail 2]')
     ]
 
     const x = sequence(validation, array)(success)

--- a/test/Witherable.ts
+++ b/test/Witherable.ts
@@ -1,7 +1,6 @@
 import * as assert from 'assert'
 import * as witherable from '../src/Witherable'
 import * as array from '../src/Array'
-// import * as either from '../src/Either'
 import * as option from '../src/Option'
 import * as identity from '../src/Identity'
 


### PR DESCRIPTION
This PR is a copy of #201 which tracks #200 

Migration list:
- [x] Alt 
- [x] Alternative
- [x] Applicative
  - [ ] getApplicativeComposition
- [x] Apply
  - [ ] ap
- [x] Array
  - ~fold~
  - ~slice~
- [x] Bifunctor
  - [ ] bimap (partial?)
- [x] Chain
  - [ ] chain
- [x] ChainRec
  - [ ] chainRec
  - [ ] tailRec
- [x] Comonad
- [x] Console
- [x] Const
- [x] Contravariant
  - [x] tests for Ops#lift
- [x] Either
  - [ ] fromPredicate
- [x] EitherT
- [x] Exception
- [x] Extend
  - [ ] extend
- [x] Field
- [x] Filterable
  - [ ] partitionMap
- [x] Foldable
  - [ ] reduce
  - [ ] getFoldableComposition
  - [ ] foldMap
  - [ ] foldr
  - [ ] intercalate
  - [ ] Ops#traverse_
  - [ ] Ops#sequence_
- [x] Free
- [x] Functor
  - [ ] map
  - [ ] Ops#flap
- [x] HKT
- [x] IO
- [x] Identity
- [x] IxIO
- [x] IxMonad
  - [ ] ichain
- [x] Monad
- [x] Monoid
- [x] Monoidal
- [x] NaturalTransformation
- [x] NonEmptyArray
- [x] Option
- [x] OptionT
- [x] Ord
- [x] Ordering
- [x] Pair
- [x] Plus
- [x] Profunctor
  - [ ] promap
- [x] Random
- [x] Reader
- [x] ReaderT
- [x] Ring
- [x] Semigroup
- [x] Semigroupoid
- [x] Semiring
- [x] Setoid
- [x] State
- [x] StateT
- [x] Store
- [x] StrMap
  - [ ] mapWithKey
- [x] Task
- [x] These
  - [ ] concat
- [x] Trace
  - ~trace~
- [x] Traversable
  - [ ] traverse
  - [ ] sequence
- [x] Tuple
  - [ ] getSetoid 
  - [ ] getOrd
  - [ ] getSemigroup
- [x] Unfoldable
  - [ ] replicateA
  - [ ] singleton
- [x] Validation
  - [ ] fromPredicate 
- [x] Witherable
  - [ ] Ops#wither
  - [ ] Ops#wilted
  - [ ] Ops#withered
- [x] Writer
- [ ] function
  - ~tuple~
  - [ ] or
  - [ ] and
  - [ ] on