### PR TITLE
The Quest of uncurried functions

### DIFF
--- a/src/Foldable.ts
+++ b/src/Foldable.ts
@@ -30,7 +30,7 @@ export const toArray = <F>(foldable: Foldable<F>) => <A>(fa: HKT<F, A>): Array<A
   foldable.reduce((b, a) => b.concat([a]), [] as Array<any>, fa)
 
 /** A default implementation of `foldr` using `foldMap` */
-export const foldr = <F>(foldable: Foldable<F>) => <A, B>(f: (a: A) => (b: B) => B, b: B) => (fa: HKT<F, A>): B =>
+export const foldr = <F>(foldable: Foldable<F>) => <A, B>(f: (a: A) => (b: B) => B) => (b: B) => (fa: HKT<F, A>): B =>
   foldMap(foldable, getEndomorphismMonoid<B>())(f)(fa)(b)
 
 type Acc<M> = { init: boolean; acc: M }

--- a/src/Ord.ts
+++ b/src/Ord.ts
@@ -22,7 +22,7 @@ export const ordNumber: Ord<number> = {
   compare: unsafeCompare
 }
 
-export const ordBooleanOrd: Ord<boolean> = {
+export const ordBoolean: Ord<boolean> = {
   ...setoidBoolean,
   compare: unsafeCompare
 }

--- a/src/Profunctor.ts
+++ b/src/Profunctor.ts
@@ -2,7 +2,7 @@ import { HKT2 } from './HKT'
 import { Functor, FantasyFunctor } from './Functor'
 
 export interface Profunctor<F> extends Functor<F> {
-  promap: <A, B, C, D>(f: (a: A) => B, g: (c: C) => D, fbc: HKT2<F, B, C>) => HKT2<F, A, D>
+  promap: <A, B, C, D>(f: (a: A) => B, g: (c: C) => D) => (fbc: HKT2<F, B, C>) => HKT2<F, A, D>
 }
 
 export interface FantasyProfunctor<F, B, C> extends FantasyFunctor<F, C> {
@@ -11,8 +11,8 @@ export interface FantasyProfunctor<F, B, C> extends FantasyFunctor<F, C> {
 
 export const lmap = <F>(profunctor: Profunctor<F>) => <A, B>(f: (a: A) => B) => <C>(
   fbc: HKT2<F, B, C>
-): HKT2<F, A, C> => profunctor.promap(f, c => c, fbc)
+): HKT2<F, A, C> => profunctor.promap(f, (c: C) => c)(fbc)
 
 export const rmap = <F>(profunctor: Profunctor<F>) => <C, D>(g: (c: C) => D) => <B>(
   fbc: HKT2<F, B, C>
-): HKT2<F, B, D> => profunctor.promap(b => b, g, fbc)
+): HKT2<F, B, D> => profunctor.promap((b: B) => b, g)(fbc)

--- a/src/Unfoldable.ts
+++ b/src/Unfoldable.ts
@@ -31,4 +31,4 @@ export const replicateA = <F, T>(
 /** The container with no elements - unfolded with zero iterations. */
 export const none = <F, A>(unfoldable: Unfoldable<F>): HKT<F, A> => unfoldable.unfoldr(constant(option.none), undefined)
 
-export const singleton = <F, A>(unfoldable: Unfoldable<F>, a: A): HKT<F, A> => replicate(unfoldable)(1)(a)
+export const singleton = <F>(unfoldable: Unfoldable<F>) => <A>(a: A): HKT<F, A> => replicate(unfoldable)(1)(a)


### PR DESCRIPTION
Legend:

- TCR: type constraint rule: all type constraints are grouped together
- TI: currying will cause bad type inference
- TU: is not curried because of the typical usage

Functions

- `Applicative.getApplicativeComposition` Won't fix: TCR
- `Apply.ap` Won't fix: TI
- `Bifunctor.bimap` Won't fix: TU
- `Chain.chain` Won't fix: TI
- `ChainRec.chainRec` Won't fix: TI
- `ChainRec.tailRec` Won't fix: TI
- `Either.fromPredicate` Won't fix: TU
- `Extend.extend` Won't fix: TI
- `Filterable.partitionMap` Won't fix: TI
- `Foldable.reduce` Won't fix: TI
- `Foldable.getFoldableComposition` Won't fix: TCR
- `Foldable.foldMap` Won't fix: TCR
- `Foldable.foldr` **fixed**
- `Foldable.intercalate` Won't fix: TCR
- `Foldable.traverse_` Won't fix: TCR
- `Foldable.sequence_` Won't fix: TCR
- `Functor.map` Won't fix: TI
- `Functor.flap` *is already curried*
- `IxMonad.ichain` Won't fix: TI
- `Profunctor.promap` **fixed** (only the `fbc` argument)
- `StrMap.mapWithKey` Won't fix: TU
- `These.concat` Won't fix: TCR
- `Traversable.traverse` Won't fix: TI
- `Traversable.sequence` Won't fix: TCR
- `Tuple.getSetoid` Won't fix: TCR
- `Tuple.getOrd` Won't fix: TCR
- `Tuple.getSemigroup` Won't fix: TCR
- `Unfoldable.replicateA` Won't fix: TCR
- `Unfoldable.singleton` **fixed**
- `Validation.fromPredicate` Won't fix: TU
- `Witherable.wither` Won't fix: TCR + TI
- `Witherable.wilted` Won't fix: TCR
- `Witherable.withered` Won't fix: TCR
