### PR TITLE
Either: pass value to `getOrElse`

### DIFF
--- a/src/Either.ts
+++ b/src/Either.ts
@@ -71,8 +71,8 @@ export class Left<L, A>
   fold<B>(left: (l: L) => B, right: (a: A) => B): B {
     return left(this.value)
   }
-  getOrElse(f: Lazy<A>): A {
-    return f()
+  getOrElse(f: (l: L) => A): A {
+    return f(this.value)
   }
   equals(S: Setoid<A>): (fy: Either<L, A>) => boolean {
     return fy => fy.fold(constTrue, constFalse)
@@ -138,7 +138,7 @@ export class Right<L, A>
   fold<B>(left: (l: L) => B, right: (a: A) => B): B {
     return right(this.value)
   }
-  getOrElse(f: Lazy<A>): A {
+  getOrElse(f: (l: L) => A): A {
     return this.value
   }
   equals(S: Setoid<A>): (fy: Either<L, A>) => boolean {
@@ -166,7 +166,7 @@ export const getSetoid = <L, A>(S: Setoid<A>): Setoid<Either<L, A>> => ({
 
 export const fold = <L, A, B>(left: (l: L) => B, right: (a: A) => B, fa: Either<L, A>): B => fa.fold(left, right)
 
-export const getOrElse = <A>(f: () => A) => <L>(fa: Either<L, A>): A => fa.getOrElse(f)
+export const getOrElse = <L, A>(f: (l: L) => A) => (fa: Either<L, A>): A => fa.getOrElse(f)
 
 export const map = <L, A, B>(f: (a: A) => B, fa: Either<L, A>): Either<L, B> => fa.map(f)
 

--- a/test/Either.ts
+++ b/test/Either.ts
@@ -59,6 +59,7 @@ describe('Either', () => {
   it('getOrElse', () => {
     assert.equal(getOrElse(() => 17)(right(12)), 12)
     assert.equal(getOrElse(() => 17)(left(12)), 17)
+    assert.equal(getOrElse((l: number) => l + 1)(left(12)), 13)
   })
 
   it('fromOption', () => {


### PR DESCRIPTION
This PR changes `getOrElse` signature and implementation of `Either`, allowing the callback to receive the `Left` value but nevertheless keeping backward compatibility.

Note: this will diverge from Scala typings for `Either.getOrElse` but it's useful for behaviours depending on the `Left` value