### PR TITLE
add Option#mapNullable

### DIFF
--- a/src/Option.ts
+++ b/src/Option.ts
@@ -42,6 +42,12 @@ export class None<A>
   map<B>(f: (a: A) => B): Option<B> {
     return none
   }
+  /**
+   * Maps `f` over this Option's value. If the value returned from `f` is null or undefined, returns none.
+   */
+  mapNullable<B>(f: (a: A) => B | null | undefined): Option<B> {
+    return none
+  }
   ap<B>(fab: Option<(a: A) => B>): Option<B> {
     return none
   }
@@ -135,6 +141,13 @@ export class Some<A>
   constructor(readonly value: A) {}
   map<B>(f: (a: A) => B): Option<B> {
     return new Some(f(this.value))
+  }
+
+  /**
+   * Maps `f` over this Option's value. If the value returned from `f` is null or undefined, returns none.
+   */
+  mapNullable<B>(f: (a: A) => B | null | undefined): Option<B> {
+    return this.map(f).chain(fromNullable)
   }
   ap<B>(fab: Option<(a: A) => B>): Option<B> {
     return fab.map(f => f(this.value))
@@ -231,6 +244,8 @@ export const getSetoid = <A>(S: Setoid<A>): Setoid<Option<A>> => ({
 })
 
 export const map = <A, B>(f: (a: A) => B, fa: Option<A>): Option<B> => fa.map(f)
+
+export const mapNullable = <A, B>(f: (a: A) => B | null | undefined, fa: Option<A>): Option<B> => fa.mapNullable(f)
 
 export const of = <A>(a: A): Option<A> => new Some(a)
 

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -17,6 +17,7 @@ import {
 import * as array from '../src/Array'
 import { setoidNumber } from '../src/Setoid'
 import { eqOptions as eq } from './helpers'
+import { identity } from '../src/function'
 
 describe('Option', () => {
   it('fold', () => {
@@ -51,6 +52,23 @@ describe('Option', () => {
   it('map', () => {
     const f = (n: number) => n * 2
     eq(map(f, some(2)), some(4))
+  })
+
+  it('mapNullable', () => {
+    type Nested = {
+      foo?: number
+      foo2: {
+        bar2?: string
+      }
+    }
+    const nested: Nested = {
+      foo2: {}
+    }
+    const nestedOption = some(nested)
+    assert.deepEqual(nestedOption.mapNullable(value => value.foo), none)
+    assert.deepEqual(nestedOption.mapNullable(value => value.foo2), some(nested.foo2))
+    assert.deepEqual(nestedOption.mapNullable(value => value.foo2.bar2), none)
+    assert.deepEqual(none.mapNullable(identity), none)
   })
 
   it('ap', () => {


### PR DESCRIPTION
This PR adds a handy shortcut to `map(f).chain(fromNullable)` which is useful when working with deep optional structures.