### PR TITLE
add constNull and constUndefined

### DIFF
--- a/src/function.ts
+++ b/src/function.ts
@@ -64,6 +64,12 @@ export const constTrue: Lazy<boolean> = constant(true)
 /** A thunk that returns always `false` */
 export const constFalse: Lazy<boolean> = constant(false)
 
+/** A thunk that returns always `null` */
+export const constNull: Lazy<null> = constant(null)
+
+/** A thunk that returns always `undefined` */
+export const constUndefined: Lazy<undefined> = constant(undefined)
+
 /** @function */
 export const identity = <A>(a: A): A => {
   return a


### PR DESCRIPTION
This PR adds two thunks to function.ts - constNull and constUndefined.
They are pretty useful when folding options in React TSX:
```typescript
type Props = {
  value: Option<number>
}

const Value: SFC<Props> = ({value}) => value.fold(constNull, value => (
  <div>Value: {value}</div>
))
```