### PR TITLE
Fix/move semigroup methods

### DIFF
--- a/src/Monoid.ts
+++ b/src/Monoid.ts
@@ -3,7 +3,13 @@ import {
   getProductSemigroup,
   getDualSemigroup,
   fold as foldSemigroup,
-  getRecordSemigroup
+  getRecordSemigroup,
+  semigroupAll,
+  semigroupString,
+  semigroupProduct,
+  semigroupSum,
+  semigroupArray,
+  semigroupAny
 } from './Semigroup'
 import { constant, Endomorphism, identity, compose } from './function'
 
@@ -39,7 +45,7 @@ export const getDualMonoid = <A>(M: Monoid<A>): Monoid<A> => {
  * @instance
  */
 export const monoidAll: Monoid<boolean> = {
-  concat: x => y => x && y,
+  ...semigroupAll,
   empty: () => true
 }
 
@@ -48,7 +54,7 @@ export const monoidAll: Monoid<boolean> = {
  * @instance
  */
 export const monoidAny: Monoid<boolean> = {
-  concat: x => y => x || y,
+  ...semigroupAny,
   empty: () => false
 }
 
@@ -57,7 +63,7 @@ export const monoidAny: Monoid<boolean> = {
  * @instance
  */
 export const monoidArray: Monoid<Array<any>> = {
-  concat: x => y => x.concat(y),
+  ...semigroupArray,
   empty: () => []
 }
 
@@ -66,7 +72,7 @@ export const monoidArray: Monoid<Array<any>> = {
  * @instance
  */
 export const monoidSum: Monoid<number> = {
-  concat: x => y => x + y,
+  ...semigroupSum,
   empty: () => 0
 }
 
@@ -75,13 +81,13 @@ export const monoidSum: Monoid<number> = {
  * @instance
  */
 export const monoidProduct: Monoid<number> = {
-  concat: x => y => x * y,
+  ...semigroupProduct,
   empty: () => 1
 }
 
 /** @instance */
 export const monoidString: Monoid<string> = {
-  concat: x => y => x + y,
+  ...semigroupString,
   empty: () => ''
 }
 

--- a/src/Semigroup.ts
+++ b/src/Semigroup.ts
@@ -62,3 +62,48 @@ export const getJoinSemigroup = <A>(O: Ord<A>): Semigroup<A> => {
     concat: max(O)
   }
 }
+
+/**
+ * Boolean semigroup under conjunction
+ * @instance
+ */
+export const semigroupAll: Semigroup<boolean> = {
+  concat: x => y => x && y
+}
+
+/**
+ * Boolean semigroup under disjunction
+ * @instance
+ */
+export const semigroupAny: Semigroup<boolean> = {
+  concat: x => y => x || y
+}
+
+/**
+ * Semigroup under array concatenation (`Array<any>`)
+ * @instance
+ */
+export const semigroupArray: Semigroup<Array<any>> = {
+  concat: x => y => x.concat(y)
+}
+
+/**
+ * Number Semigroup under addition
+ * @instance
+ */
+export const semigroupSum: Semigroup<number> = {
+  concat: x => y => x + y
+}
+
+/**
+ * Number Semigroup under multiplication
+ * @instance
+ */
+export const semigroupProduct: Semigroup<number> = {
+  concat: x => y => x * y
+}
+
+/** @instance */
+export const semigroupString: Semigroup<string> = {
+  concat: x => y => x + y
+}


### PR DESCRIPTION
Hi,

This PR moves semigroup methods from Monoid to Semigroup module, like it's done in Ord and Setoid modules.