### PR TITLE
Removed duplicate fold definition from Either

### DIFF
--- a/src/Either.js.flow
+++ b/src/Either.js.flow
@@ -19,7 +19,6 @@ declare export class Left<L, A> {
   +_tag: 'Left';
   +value: L;
   constructor(value: L): Left<L>;
-  fold<R>(left: (l: L) => R, right: (a: A) => R): R;
   map<B>(f: (a: A) => B): Either<L, B>;
   ap<B>(fab: Either<L, (a: A) => B>): Either<L, B>;
   chain<B>(f: (a: A) => Either<L, B>): Either<L, B>;
@@ -44,7 +43,6 @@ declare export class Right<L, A> {
   +_tag: 'Right';
   +value: A;
   constructor(value: A): Right<A>;
-  fold<R>(left: (l: L) => R, right: (a: A) => R): R;
   map<B>(f: (a: A) => B): Either<L, B>;
   ap<B>(fab: Either<L, (a: A) => B>): Either<L, B>;
   chain<B>(f: (a: A) => Either<L, B>): Either<L, B>;


### PR DESCRIPTION
Found a duplicate definition for the fold signature of Either (Flow). This microfix just removes it.