### PR TITLE
deprecate toOption in Either in favour of fromEither in Option

### DIFF
--- a/src/Either.ts
+++ b/src/Either.ts
@@ -117,7 +117,10 @@ export class Left<L, A>
   mapLeft<M>(f: (l: L) => M): Either<M, A> {
     return left(f(this.value))
   }
-  /** Returns a `Some` containing the `Right` value if it exists or a `None` if this is a `Left` */
+  /**
+   * Returns a `Some` containing the `Right` value if it exists or a `None` if this is a `Left`
+   * @deprecated
+   */
   toOption(): Option<A> {
     return none
   }
@@ -376,7 +379,10 @@ export const fromNullable = <L>(defaultValue: L) => <A>(a: A | null | undefined)
   return a == null ? left(defaultValue) : right(a)
 }
 
-/** @function */
+/**
+ * @function
+ * @deprecated
+ */
 export const toOption = <L, A>(fa: Either<L, A>): Option<A> => {
   return fa.toOption()
 }

--- a/src/Option.js.flow
+++ b/src/Option.js.flow
@@ -110,6 +110,8 @@ declare export var fromPredicate: <A>(predicate: (a: A) => boolean) => (a: A) =>
 
 declare export var tryCatch: <A>(f: Lazy<A>) => Option<A>
 
+declare export var fromEither: <L, A>(fa: Either<L, A>) => Option<A>
+
 export interface Instances
   extends Monad<URIT>, Foldable<URIT>, Plus<URIT>, Traversable<URIT>, Alternative<URIT>, Extend<URIT> {}
 

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -10,6 +10,7 @@ import { Setoid } from './Setoid'
 import { Traversable, FantasyTraversable } from './Traversable'
 import { Alternative, FantasyAlternative } from './Alternative'
 import { constant, Lazy, Predicate, toString } from './function'
+import { Either } from './Either'
 
 declare module './HKT' {
   interface URI2HKT<A> {
@@ -399,6 +400,11 @@ export const tryCatch = <A>(f: Lazy<A>): Option<A> => {
   } catch (e) {
     return none
   }
+}
+
+/** @function */
+export const fromEither = <L, A>(fa: Either<L, A>): Option<A> => {
+  return fa.fold(() => none, some)
 }
 
 /** @instance */

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -13,12 +13,14 @@ import {
   getFirstMonoid,
   getLastMonoid,
   tryCatch,
-  Option
+  Option,
+  fromEither
 } from '../src/Option'
 import * as array from '../src/Array'
 import { setoidNumber } from '../src/Setoid'
 import { eqOptions as eq } from './helpers'
 import { identity } from '../src/function'
+import { left, right } from '../src/Either'
 
 describe('Option', () => {
   it('fold', () => {
@@ -181,5 +183,10 @@ describe('Option', () => {
   it('tryCatch', () => {
     assert.deepEqual(tryCatch(() => JSON.parse('2')), some(2))
     assert.deepEqual(tryCatch(() => JSON.parse('(')), none)
+  })
+
+  it('fromEither', () => {
+    assert.deepEqual(fromEither(left('foo')), none)
+    assert.deepEqual(fromEither(right(1)), some(1))
   })
 })


### PR DESCRIPTION
This will remove an unnecessary runtime dependency in the next breaking change release