### PR TITLE
Add scan left/right functions

### DIFF
--- a/docs/api/md/Array.md
+++ b/docs/api/md/Array.md
@@ -129,7 +129,7 @@ _function_
 ```ts
 <A, B>(f: ((b: B, a: A) => B), b: B, as: Array<A>): Array<B>
 ```
-Same as `fold` but it carries over the intermediate steps
+Same as `reduce` but it carries over the intermediate steps
 
 # getMonoid
 

--- a/docs/api/md/Array.md
+++ b/docs/api/md/Array.md
@@ -122,6 +122,15 @@ _function_
 
 Lazy version of `fold`
 
+# scan
+
+_function_
+
+```ts
+<A, B>(f: ((b: B, a: A) => B), b: B, as: Array<A>): Array<B>
+```
+Same as `fold` but it carries over the intermediate steps
+
 # getMonoid
 
 _function_

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -205,6 +205,16 @@ export const scanLeft = <A, B>(as: Array<A>, b: B, f: ((b: B, a: A) => B)): Arra
   return r
 }
 
+export const scanRight = <A, B>(as: Array<A>, b: B, f: ((a: A, b: B) => B)): Array<B> => {
+  const l = as.length
+  let r = new Array(l + 1)
+  r[l] = b
+  for (let i = l - 1; i >= 0; i--) {
+    r[i] = f(as[i], r[i + 1])
+  }
+  return r
+}
+
 /**
  * Test whether an array is empty
  * @function

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -192,11 +192,16 @@ export const foldL = <A, B>(as: Array<A>, nil: () => B, cons: (head: A, tail: Ar
 }
 
 /**
- * Same as `fold` but it carries over the intermediate steps
+ * Same as `reduce` but it carries over the intermediate steps
  * @function
  */
 export const scan = <A, B>(f: ((b: B, a: A) => B), b: B, as: Array<A>): Array<B> => {
-  return isEmpty(as) ? [b] : cons(b, scan(f, f(b, as[0]), as.slice(1)))
+  const l = as.length
+  let r = [b]
+  for (let i = 0; i < l; i++) {
+    r.push(f(r[i], as[i]))
+  }
+  return r
 }
 
 /**

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -195,11 +195,12 @@ export const foldL = <A, B>(as: Array<A>, nil: () => B, cons: (head: A, tail: Ar
  * Same as `reduce` but it carries over the intermediate steps
  * @function
  */
-export const scan = <A, B>(f: ((b: B, a: A) => B), b: B, as: Array<A>): Array<B> => {
+export const scan = <A, B>(as: Array<A>, b: B, f: ((b: B, a: A) => B)): Array<B> => {
   const l = as.length
-  let r = new Array(l)
+  let r = new Array(l + 1)
+  r[0] = b
   for (let i = 0; i < l; i++) {
-    r.push(f(r[i], as[i]))
+    r[i + 1] = f(r[i], as[i])
   }
   return r
 }

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -193,6 +193,7 @@ export const foldL = <A, B>(as: Array<A>, nil: () => B, cons: (head: A, tail: Ar
 
 /**
  * Same as `fold` but it carries over the intermediate steps
+ * @function
  */
 export const scan = <A, B>(f: ((b: B, a: A) => B), b: B, as: Array<A>): Array<B> => {
   return isEmpty(as) ? [b] : cons(b, scan(f, f(b, as[0]), as.slice(1)))

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -192,6 +192,13 @@ export const foldL = <A, B>(as: Array<A>, nil: () => B, cons: (head: A, tail: Ar
 }
 
 /**
+ * Same as `fold` but it carries over the intermediate steps
+ */
+export const scan = <A, B>(f: ((b: B, a: A) => B), b: B, as: Array<A>): Array<B> => {
+  return isEmpty(as) ? [b] : cons(b, scan(f, f(b, as[0]), as.slice(1)))
+}
+
+/**
  * Test whether an array is empty
  * @function
  */

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -197,7 +197,7 @@ export const foldL = <A, B>(as: Array<A>, nil: () => B, cons: (head: A, tail: Ar
  */
 export const scan = <A, B>(f: ((b: B, a: A) => B), b: B, as: Array<A>): Array<B> => {
   const l = as.length
-  let r = [b]
+  let r = new Array(l)
   for (let i = 0; i < l; i++) {
     r.push(f(r[i], as[i]))
   }

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -195,7 +195,7 @@ export const foldL = <A, B>(as: Array<A>, nil: () => B, cons: (head: A, tail: Ar
  * Same as `reduce` but it carries over the intermediate steps
  * @function
  */
-export const scan = <A, B>(as: Array<A>, b: B, f: ((b: B, a: A) => B)): Array<B> => {
+export const scanLeft = <A, B>(as: Array<A>, b: B, f: ((b: B, a: A) => B)): Array<B> => {
   const l = as.length
   let r = new Array(l + 1)
   r[0] = b

--- a/test/Array.ts
+++ b/test/Array.ts
@@ -281,6 +281,9 @@ describe('Array', () => {
   })
 
   it('scan', () => {
-    assert.deepEqual(scan((b, a) => b - a, 10, [1, 2, 3]), [10, 9, 7, 4])
+    const f = (b: number, a: number) => b - a
+    assert.deepEqual(scan(f, 10, [1, 2, 3]), [10, 9, 7, 4])
+    assert.deepEqual(scan(f, 10, [0]), [10, 10])
+    assert.deepEqual(scan(f, 10, []), [10])
   })
 })

--- a/test/Array.ts
+++ b/test/Array.ts
@@ -37,7 +37,8 @@ import {
   flatten,
   fold,
   foldL,
-  scanLeft
+  scanLeft,
+  scanRight
 } from '../src/Array'
 import * as option from '../src/Option'
 import { traverse } from '../src/Traversable'
@@ -280,10 +281,17 @@ describe('Array', () => {
     assert.strictEqual(len([1, 2, 3]), 3)
   })
 
-  it('scan', () => {
+  it('scanLeft', () => {
     const f = (b: number, a: number) => b - a
     assert.deepEqual(scanLeft([1, 2, 3], 10, f), [10, 9, 7, 4])
     assert.deepEqual(scanLeft([0], 10, f), [10, 10])
     assert.deepEqual(scanLeft([], 10, f), [10])
+  })
+
+  it('scanRight', () => {
+    const f = (b: number, a: number) => b - a
+    assert.deepEqual(scanRight([1, 2, 3], 10, f), [-8, 9, -7, 10])
+    assert.deepEqual(scanRight([0], 10, f), [-10, 10])
+    assert.deepEqual(scanRight([], 10, f), [10])
   })
 })

--- a/test/Array.ts
+++ b/test/Array.ts
@@ -37,7 +37,7 @@ import {
   flatten,
   fold,
   foldL,
-  scan
+  scanLeft
 } from '../src/Array'
 import * as option from '../src/Option'
 import { traverse } from '../src/Traversable'
@@ -282,8 +282,8 @@ describe('Array', () => {
 
   it('scan', () => {
     const f = (b: number, a: number) => b - a
-    assert.deepEqual(scan([1, 2, 3], 10, f), [10, 9, 7, 4])
-    assert.deepEqual(scan([0], 10, f), [10, 10])
-    assert.deepEqual(scan([], 10, f), [10])
+    assert.deepEqual(scanLeft([1, 2, 3], 10, f), [10, 9, 7, 4])
+    assert.deepEqual(scanLeft([0], 10, f), [10, 10])
+    assert.deepEqual(scanLeft([], 10, f), [10])
   })
 })

--- a/test/Array.ts
+++ b/test/Array.ts
@@ -36,7 +36,8 @@ import {
   drop,
   flatten,
   fold,
-  foldL
+  foldL,
+  scan
 } from '../src/Array'
 import * as option from '../src/Option'
 import { traverse } from '../src/Traversable'
@@ -277,5 +278,9 @@ describe('Array', () => {
   it('foldL', () => {
     const len = <A>(as: Array<A>): number => foldL(as, () => 0, (_, tail) => 1 + len(tail))
     assert.strictEqual(len([1, 2, 3]), 3)
+  })
+
+  it('scan', () => {
+    assert.deepEqual(scan((b, a) => b - a, 10, [1, 2, 3]), [10, 9, 7, 4])
   })
 })

--- a/test/Array.ts
+++ b/test/Array.ts
@@ -282,8 +282,8 @@ describe('Array', () => {
 
   it('scan', () => {
     const f = (b: number, a: number) => b - a
-    assert.deepEqual(scan(f, 10, [1, 2, 3]), [10, 9, 7, 4])
-    assert.deepEqual(scan(f, 10, [0]), [10, 10])
-    assert.deepEqual(scan(f, 10, []), [10])
+    assert.deepEqual(scan([1, 2, 3], 10, f), [10, 9, 7, 4])
+    assert.deepEqual(scan([0], 10, f), [10, 10])
+    assert.deepEqual(scan([], 10, f), [10])
   })
 })


### PR DESCRIPTION
Hi, 

I've observed that in haskell/scala they have a scan function which allows to do a fold carrying intermediate steps and I've translated the haskell implementation to TS.

http://hackage.haskell.org/package/base-4.10.1.0/docs/src/GHC.List.html#scanl
https://github.com/scala/collection-strawman/blob/57340b9fa6732a0bae37845f16dfb272fbb2173a/collections/src/main/scala/strawman/collection/immutable/LazyList.scala#L271