### PR TITLE
357

### DIFF
--- a/src/Array.ts
+++ b/src/Array.ts
@@ -142,7 +142,12 @@ export const partitionMap = <A, L, R>(fa: Array<A>, f: (a: A) => Either<L, R>): 
   const right: Array<R> = []
   const len = fa.length
   for (let i = 0; i < len; i++) {
-    f(fa[i]).fold(l => left.push(l), r => right.push(r))
+    const v = f(fa[i])
+    if (v.isLeft()) {
+      left.push(v.value)
+    } else {
+      right.push(v.value)
+    }
   }
   return { left, right }
 }
@@ -530,7 +535,15 @@ export const reverse = <A>(as: Array<A>): Array<A> => {
  * @function
  */
 export const mapOption = <A, B>(as: Array<A>, f: (a: A) => Option<B>): Array<B> => {
-  return chain(as, a => f(a).fold([], of))
+  const r: Array<B> = []
+  const len = as.length
+  for (let i = 0; i < len; i++) {
+    const v = f(as[i])
+    if (v.isSome()) {
+      r.push(v.value)
+    }
+  }
+  return r
 }
 
 /**
@@ -547,7 +560,15 @@ export const catOptions = <A>(as: Array<Option<A>>): Array<A> => {
  * @function
  */
 export const rights = <L, A>(as: Array<Either<L, A>>): Array<A> => {
-  return chain(as, a => a.fold(() => [], of))
+  const r: Array<A> = []
+  const len = as.length
+  for (let i = 0; i < len; i++) {
+    const a = as[i]
+    if (a.isRight()) {
+      r.push(a.value)
+    }
+  }
+  return r
 }
 
 /**
@@ -555,7 +576,15 @@ export const rights = <L, A>(as: Array<Either<L, A>>): Array<A> => {
  * @function
  */
 export const lefts = <L, A>(as: Array<Either<L, A>>): Array<L> => {
-  return chain(as, a => a.fold(of, () => []))
+  const r: Array<L> = []
+  const len = as.length
+  for (let i = 0; i < len; i++) {
+    const a = as[i]
+    if (a.isLeft()) {
+      r.push(a.value)
+    }
+  }
+  return r
 }
 
 /**

--- a/src/Const.ts
+++ b/src/Const.ts
@@ -48,7 +48,7 @@ export class Const<L, A> {
 
 /** @function */
 export const getSetoid = <L, A>(S: Setoid<L>): Setoid<Const<L, A>> => ({
-  equals: (x, y) => x.fold(ax => y.fold(ay => S.equals(ax, ay)))
+  equals: (x, y) => S.equals(x.value, y.value)
 })
 
 const map = <L, A, B>(fa: Const<L, A>, f: (a: A) => B): Const<L, B> => {
@@ -60,7 +60,7 @@ const contramap = <L, A, B>(fa: Const<L, A>, f: (b: B) => A): Const<L, B> => {
 }
 
 const ap = <L>(S: Semigroup<L>) => <A, B>(fab: Const<L, (a: A) => B>, fa: Const<L, A>): Const<L, B> => {
-  return new Const(S.concat(fab.fold(identity), fa.fold(identity)))
+  return new Const(S.concat(fab.value, fa.value))
 }
 
 /** @function */

--- a/src/Const.ts
+++ b/src/Const.ts
@@ -5,7 +5,7 @@ import { Applicative2C } from './Applicative'
 import { Apply2C } from './Apply'
 import { Semigroup } from './Semigroup'
 import { Setoid } from './Setoid'
-import { identity, toString, phantom } from './function'
+import { toString, phantom } from './function'
 
 declare module './HKT' {
   interface URI2HKT2<L, A> {

--- a/src/EitherT.ts
+++ b/src/EitherT.ts
@@ -29,7 +29,7 @@ export function chain<F extends URIS2>(F: Monad2<F>): EitherT2<F>['chain']
 export function chain<F extends URIS>(F: Monad1<F>): EitherT1<F>['chain']
 export function chain<F>(F: Monad<F>): EitherT<F>['chain']
 export function chain<F>(F: Monad<F>): EitherT<F>['chain'] {
-  return (f, fa) => F.chain(fa, e => e.fold(l => F.of(either.left(l)), a => f(a)))
+  return (f, fa) => F.chain(fa, e => (e.isLeft() ? F.of(either.left(e.value)) : f(e.value)))
 }
 
 export function right<F extends URIS2>(F: Functor2<F>): <L, M, A>(fa: Type2<F, M, A>) => Type2<F, M, Either<L, A>>
@@ -67,7 +67,7 @@ export function fold<F>(
 export function fold<F>(
   F: Functor<F>
 ): <R, L, A>(left: (l: L) => R, right: (a: A) => R, fa: HKT<F, Either<L, A>>) => HKT<F, R> {
-  return (left, right, fa) => F.map(fa, e => e.fold(left, right))
+  return (left, right, fa) => F.map(fa, e => (e.isLeft() ? left(e.value) : right(e.value)))
 }
 
 export function mapLeft<F extends URIS2>(

--- a/src/Foldable.ts
+++ b/src/Foldable.ts
@@ -430,7 +430,7 @@ export function minimum<F, A>(F: Foldable<F>, O: Ord<A>): (fa: HKT<F, A>) => Opt
  */
 export function minimum<F, A>(F: Foldable<F>, O: Ord<A>): (fa: HKT<F, A>) => Option<A> {
   const minO = min(O)
-  return fa => F.reduce(fa, none, (b: Option<A>, a) => b.fold(some(a), b => some(minO(b, a))))
+  return fa => F.reduce(fa, none, (b: Option<A>, a) => (b.isNone() ? some(a) : some(minO(b.value, a))))
 }
 
 /**
@@ -451,7 +451,7 @@ export function maximum<F, A>(F: Foldable<F>, O: Ord<A>): (fa: HKT<F, A>) => Opt
  */
 export function maximum<F, A>(F: Foldable<F>, O: Ord<A>): (fa: HKT<F, A>) => Option<A> {
   const maxO = max(O)
-  return fa => F.reduce(fa, none, (b: Option<A>, a) => b.fold(some(a), b => some(maxO(b, a))))
+  return fa => F.reduce(fa, none, (b: Option<A>, a) => (b.isNone() ? some(a) : some(maxO(b.value, a))))
 }
 
 export function toArray<F extends URIS3>(F: Foldable3<F>): <U, L, A>(fa: Type3<F, U, L, A>) => Array<A>

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -178,7 +178,7 @@ export class Some<A> {
     return fromNullable(f(this.value))
   }
   ap<B>(fab: Option<(a: A) => B>): Option<B> {
-    return fab.map(f => f(this.value))
+    return fab.isNone() ? none : some(fab.value(this.value))
   }
   ap_<B, C>(this: Option<(b: B) => C>, fb: Option<B>): Option<C> {
     return fb.ap(this)

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -187,7 +187,7 @@ export class Some<A> {
     return f(this.value)
   }
   reduce<B>(b: B, f: (b: B, a: A) => B): B {
-    return this.fold(b, a => f(b, a))
+    return f(b, this.value)
   }
   alt(fa: Option<A>): Option<A> {
     return this
@@ -239,7 +239,7 @@ export class Some<A> {
 /** @function */
 export const getSetoid = <A>(S: Setoid<A>): Setoid<Option<A>> => {
   return {
-    equals: (x, y) => x.fold(y.isNone(), ax => y.fold(false, ay => S.equals(ax, ay)))
+    equals: (x, y) => (x.isNone() ? y.isNone() : y.isNone() ? false : S.equals(x.value, y.value))
   }
 }
 
@@ -297,7 +297,7 @@ export const getLastMonoid = <A = never>(): Monoid<Option<A>> => {
 /** @function */
 export const getMonoid = <A>(S: Semigroup<A>): Monoid<Option<A>> => {
   return {
-    concat: (x, y) => x.fold(y, ax => y.fold(x, ay => some(S.concat(ax, ay)))),
+    concat: (x, y) => (x.isNone() ? y : y.isNone() ? x : some(S.concat(x.value, y.value))),
     empty: none
   }
 }
@@ -323,7 +323,7 @@ export const fromPredicate = <A>(predicate: Predicate<A>) => (a: A): Option<A> =
 }
 
 function traverse<F>(F: Applicative<F>): <A, B>(ta: Option<A>, f: (a: A) => HKT<F, B>) => HKT<F, Option<B>> {
-  return (ta, f) => ta.foldL(() => F.of(none), a => F.map(f(a), some))
+  return (ta, f) => (ta.isNone() ? F.of(none) : F.map(f(ta.value), some))
 }
 
 /** @function */
@@ -337,7 +337,7 @@ export const tryCatch = <A>(f: Lazy<A>): Option<A> => {
 
 /** @function */
 export const fromEither = <L, A>(fa: Either<L, A>): Option<A> => {
-  return fa.fold(() => none, some)
+  return fa.isLeft() ? none : some(fa.value)
 }
 
 /**

--- a/src/OptionT.ts
+++ b/src/OptionT.ts
@@ -30,7 +30,7 @@ export function chain<F extends URIS>(F: Monad1<F>): OptionT1<F>['chain']
 export function chain<F>(F: Monad<F>): OptionT<F>['chain']
 /** @function */
 export function chain<F>(F: Monad<F>): OptionT<F>['chain'] {
-  return (f, fa) => F.chain(fa, o => o.fold(F.of(option.none), a => f(a)))
+  return (f, fa) => F.chain(fa, o => (o.isNone() ? F.of(option.none) : f(o.value)))
 }
 
 export function some<F extends URIS2>(F: Applicative2<F>): <L, A>(a: A) => Type2<F, L, Option<A>>
@@ -74,7 +74,7 @@ export function fold<F extends URIS>(
 export function fold<F>(F: Functor<F>): <R, A>(r: R, some: (a: A) => R, fa: HKT<F, Option<A>>) => HKT<F, R>
 /** @function */
 export function fold<F>(F: Functor<F>): <R, A>(r: R, some: (a: A) => R, fa: HKT<F, Option<A>>) => HKT<F, R> {
-  return (r, some, fa) => F.map(fa, o => o.fold(r, some))
+  return (r, some, fa) => F.map(fa, o => (o.isNone() ? r : some(o.value)))
 }
 
 export function getOrElse<F extends URIS2>(

--- a/src/ReaderT.ts
+++ b/src/ReaderT.ts
@@ -82,7 +82,7 @@ export function ask<F extends URIS>(F: Applicative1<F>): <E>() => (e: E) => Type
 export function ask<F>(F: Applicative<F>): <E>() => (e: E) => HKT<F, E>
 /** @function */
 export function ask<F>(F: Applicative<F>): <E>() => (e: E) => HKT<F, E> {
-  return () => e => F.of(e)
+  return () => F.of
 }
 
 export function asks<F extends URIS2>(F: Applicative2<F>): <L, E, A>(f: (e: E) => A) => (e: E) => Type2<F, L, A>

--- a/src/StrMap.ts
+++ b/src/StrMap.ts
@@ -237,7 +237,8 @@ export const remove = <A>(k: string, d: StrMap<A>): StrMap<A> => {
  * @function
  */
 export const pop = <A>(k: string, d: StrMap<A>): Option<[A, StrMap<A>]> => {
-  return lookup(k, d).fold(none, a => some(tuple(a, remove(k, d))))
+  const a = lookup(k, d)
+  return a.isNone() ? none : some(tuple(a.value, remove(k, d)))
 }
 
 /** @instance */

--- a/test/Validation.ts
+++ b/test/Validation.ts
@@ -1,5 +1,14 @@
 import * as assert from 'assert'
-import { failure, success, getMonad, getApplicative, fromEither, getSetoid, getAlt, getSemigroup } from '../src/Validation'
+import {
+  failure,
+  success,
+  getMonad,
+  getApplicative,
+  fromEither,
+  getSetoid,
+  getAlt,
+  getSemigroup
+} from '../src/Validation'
 import * as either from '../src/Either'
 import { monoidString } from '../src/Monoid'
 import { sequence } from '../src/Traversable'

--- a/test/Validation.ts
+++ b/test/Validation.ts
@@ -1,11 +1,12 @@
 import * as assert from 'assert'
-import { array } from '../src/Array'
-import { failure, success, getMonad, getApplicative, fromEither, getSetoid, getSemigroup } from '../src/Validation'
+import { failure, success, getMonad, getApplicative, fromEither, getSetoid, getAlt, getSemigroup } from '../src/Validation'
 import * as either from '../src/Either'
 import { monoidString } from '../src/Monoid'
 import { sequence } from '../src/Traversable'
 import { setoidNumber, setoidString } from '../src/Setoid'
 import { semigroupString } from '../src/Semigroup'
+import { getArraySemigroup } from '../src/Semigroup'
+import { array } from '../src/Array'
 
 describe('Validation', () => {
   it('chain', () => {
@@ -84,5 +85,12 @@ describe('Validation', () => {
   it('mapFailure', () => {
     assert.deepEqual(success<string, number>(12).mapFailure(s => s.length), success(12))
     assert.deepEqual(failure<string, number>('foo').mapFailure(s => s.length), failure(3))
+  })
+
+  it('getAlt', () => {
+    const alt = getAlt(getArraySemigroup<number>())
+    assert.deepEqual(alt.alt(failure([1]), success('a')), success('a'))
+    assert.deepEqual(alt.alt(success('a'), failure([1])), success('a'))
+    assert.deepEqual(alt.alt(failure([1]), failure([2])), failure([1, 2]))
   })
 })


### PR DESCRIPTION
Flatten all (flattenable) folds (Used mainly ternary operators).
Fix getAlt in Validation (added tests)
Changed the declaration of `traverse` (Validation, These and Either) from function to values (const) in order to correctly type one of the param and avoid creating another unnecessary closure doing so (`of` function).
Further optimisation (also chain flattening) for mapOption, rights and lefts of Array.

(Fixes #357)