### PR TITLE
Make example/exercise runnable

### DIFF
--- a/examples/ArrayOption.ts
+++ b/examples/ArrayOption.ts
@@ -1,9 +1,9 @@
-import * as optionT from 'fp-ts/lib/OptionT'
-import { array } from 'fp-ts/lib/Array'
-import { Option } from 'fp-ts/lib/Option'
-import { Monad1 } from 'fp-ts/lib/Monad'
+import * as optionT from '../src/OptionT'
+import { array } from '../src/Array'
+import { Option } from '../src/Option'
+import { Monad1 } from '../src/Monad'
 
-declare module 'fp-ts/lib/HKT' {
+declare module '../src/HKT' {
   interface URI2HKT<A> {
     ArrayOption: ArrayOption<A>
   }

--- a/examples/EitherOption.ts
+++ b/examples/EitherOption.ts
@@ -1,9 +1,9 @@
-import * as optionT from 'fp-ts/lib/OptionT'
-import * as either from 'fp-ts/lib/Either'
-import { Option } from 'fp-ts/lib/Option'
-import { Monad2 } from 'fp-ts/lib/Monad'
+import * as optionT from '../src/OptionT'
+import * as either from '../src/Either'
+import { Option } from '../src/Option'
+import { Monad2 } from '../src/Monad'
 
-declare module 'fp-ts/lib/HKT' {
+declare module '../src/HKT' {
   interface URI2HKT2<L, A> {
     EitherOption: EitherOption<L, A>
   }

--- a/examples/ReaderIO.ts
+++ b/examples/ReaderIO.ts
@@ -1,11 +1,11 @@
-import * as readerT from 'fp-ts/lib/ReaderT'
-import { IO, io } from 'fp-ts/lib/IO'
-import { Monad2 } from 'fp-ts/lib/Monad'
-import { Reader } from 'fp-ts/lib/Reader'
+import * as readerT from '../src/ReaderT'
+import { IO, io } from '../src/IO'
+import { Monad2 } from '../src/Monad'
+import { Reader } from '../src/Reader'
 
 const readerTIO = readerT.getReaderT(io)
 
-declare module 'fp-ts/lib/HKT' {
+declare module '../src/HKT' {
   interface URI2HKT2<L, A> {
     ReaderIO: ReaderIO<L, A>
   }

--- a/examples/StateIO.ts
+++ b/examples/StateIO.ts
@@ -1,11 +1,11 @@
-import * as stateT from 'fp-ts/lib/StateT'
-import { io, IO } from 'fp-ts/lib/IO'
-import { Monad2 } from 'fp-ts/lib/Monad'
-import { Endomorphism } from 'fp-ts/lib/function'
-import * as array from 'fp-ts/lib/Array'
-import { State } from 'fp-ts/lib/State'
+import * as stateT from '../src/StateT'
+import { io, IO } from '../src/IO'
+import { Monad2 } from '../src/Monad'
+import { Endomorphism } from '../src/function'
+import * as array from '../src/Array'
+import { State } from '../src/State'
 
-declare module 'fp-ts/lib/HKT' {
+declare module '../src/HKT' {
   interface URI2HKT2<L, A> {
     StateIO: StateIO<L, A>
   }
@@ -105,7 +105,7 @@ export const stateIO: Monad2<URI> = {
 
 // Example 1
 
-import { log } from 'fp-ts/lib/Console'
+import { log } from '../src/Console'
 
 /** pop the next unique off the stack */
 const pop: StateIO<Array<number>, number> = get<Array<number>>().chain(ns =>
@@ -124,8 +124,8 @@ program1.run([1, 2, 3])
 
 // Example 2: a guessing game
 
-import { ordNumber } from 'fp-ts/lib/Ord'
-import { randomInt } from 'fp-ts/lib/Random'
+import { ordNumber } from '../src/Ord'
+import { randomInt } from '../src/Random'
 
 function readLine(s: string): IO<string> {
   return new IO(() => require('readline-sync').question(s))

--- a/examples/StateTaskEither.ts
+++ b/examples/StateTaskEither.ts
@@ -1,11 +1,11 @@
-import * as stateT from 'fp-ts/lib/StateT'
-import { TaskEither, taskEither } from 'fp-ts/lib/TaskEither'
-import { Monad3 } from 'fp-ts/lib/Monad'
-import { Endomorphism } from 'fp-ts/lib/function'
-import { Either } from 'fp-ts/lib/Either'
-import { State } from 'fp-ts/lib/State'
+import * as stateT from '../src/StateT'
+import { TaskEither, taskEither } from '../src/TaskEither'
+import { Monad3 } from '../src/Monad'
+import { Endomorphism } from '../src/function'
+import { Either } from '../src/Either'
+import { State } from '../src/State'
 
-declare module 'fp-ts/lib/HKT' {
+declare module '../src/HKT' {
   interface URI2HKT3<U, L, A> {
     StateTaskEither: StateTaskEither<U, L, A>
   }

--- a/examples/TaskOption.ts
+++ b/examples/TaskOption.ts
@@ -1,10 +1,10 @@
-import { Task, task, tryCatch as tryCatchTask } from 'fp-ts/lib/Task'
-import { Option, fromEither } from 'fp-ts/lib/Option'
-import { Monad1 } from 'fp-ts/lib/Monad'
-import * as optionT from 'fp-ts/lib/OptionT'
-import { Lazy } from 'fp-ts/lib/function'
+import { Task, task, tryCatch as tryCatchTask } from '../src/Task'
+import { Option, fromEither } from '../src/Option'
+import { Monad1 } from '../src/Monad'
+import * as optionT from '../src/OptionT'
+import { Lazy } from '../src/function'
 
-declare module 'fp-ts/lib/HKT' {
+declare module '../src/HKT' {
   interface URI2HKT<A> {
     TaskOption: TaskOption<A>
   }

--- a/examples/debugging-with-Trace.ts
+++ b/examples/debugging-with-Trace.ts
@@ -1,7 +1,7 @@
-import { left } from 'fp-ts/lib/Either'
-import { head } from 'fp-ts/lib/Array'
-import { Option, option, some } from 'fp-ts/lib/Option'
-import { spy, trace, traceA, traceM } from 'fp-ts/lib/Trace'
+import { left } from '../src/Either'
+import { head } from '../src/Array'
+import { Option, option, some } from '../src/Option'
+import { spy, trace, traceA, traceM } from '../src/Trace'
 
 //
 // spy

--- a/examples/ixIO.ts
+++ b/examples/ixIO.ts
@@ -1,5 +1,5 @@
-import { IxIO } from 'fp-ts/lib/IxIO'
-import * as io from 'fp-ts/lib/IO'
+import { IxIO } from '../src/IxIO'
+import * as io from '../src/IO'
 
 /*
 

--- a/examples/mtl.ts
+++ b/examples/mtl.ts
@@ -1,7 +1,7 @@
-import { Monad, Monad1 } from 'fp-ts/lib/Monad'
-import { HKT, URIS, Type } from 'fp-ts/lib/HKT'
-import { liftA2 } from 'fp-ts/lib/Apply'
-import { flatten } from 'fp-ts/lib/Chain'
+import { Monad, Monad1 } from '../src/Monad'
+import { HKT, URIS, Type } from '../src/HKT'
+import { liftA2 } from '../src/Apply'
+import { flatten } from '../src/Chain'
 
 // Adapted from https://tech.iheart.com/why-fp-its-the-composition-f585d17b01d3
 
@@ -33,7 +33,7 @@ function likePost<M>(M: Monad<M>, U: MonadUser<M>, F: MonadFB<M>): (token: strin
 // IO
 //
 
-import { URI as IOURI, io, IO } from 'fp-ts/lib/IO'
+import { URI as IOURI, io, IO } from '../src/IO'
 
 const monadUserIO: MonadUser<IOURI> = {
   validateUser: token => io.of(`string(${token})`),
@@ -58,7 +58,7 @@ console.log(likePost(io, monadUserIO, monadFBIO)('session123')('https://me.com/1
 // Task
 //
 
-import { URI as TaskURI, task, Task } from 'fp-ts/lib/Task'
+import { URI as TaskURI, task, Task } from '../src/Task'
 
 const now = Date.now()
 const delay = <A>(a: A) => (n: number): Task<A> =>

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "noEmit": true,
+    "outDir": "./dist",
     "declaration": true,
     "module": "commonjs",
     "strict": true,
@@ -17,15 +17,7 @@
       "es6",
       "dom"
     ],
-    "baseUrl": ".",
-    "paths": {
-      "fp-ts/lib/*": [
-        "../src/*"
-      ],
-      "fp-ts": [
-        "../src/index"
-      ]
-    }
+    "baseUrl": "."
   },
   "include": [
     "../src/**/*",

--- a/exercises/answer1.ts
+++ b/exercises/answer1.ts
@@ -1,5 +1,5 @@
-import { Ord } from 'fp-ts/lib/Ord'
-import { ordNumber, ordString } from 'fp-ts/lib/Ord'
+import { Ord } from '../src/Ord'
+import { ordNumber, ordString } from '../src/Ord'
 
 export function binarySearch<A>(xs: Array<A>, x: A, ord: Ord<A>): number {
   function go(low: number, mid: number, high: number): number {

--- a/exercises/answer2.ts
+++ b/exercises/answer2.ts
@@ -1,5 +1,5 @@
-import { Ord } from 'fp-ts/lib/Ord'
-import { greaterThan, ordNumber } from 'fp-ts/lib/Ord'
+import { Ord } from '../src/Ord'
+import { greaterThan, ordNumber } from '../src/Ord'
 
 export function isSorted<A>(xs: Array<A>, ord: Ord<A>): boolean {
   const len = xs.length

--- a/exercises/answer3.ts
+++ b/exercises/answer3.ts
@@ -1,6 +1,6 @@
-import { Functor1 } from 'fp-ts/lib/Functor'
+import { Functor1 } from '../src/Functor'
 
-declare module 'fp-ts/lib/HKT' {
+declare module '../src/HKT' {
   interface URI2HKT<A> {
     List: List<A>
   }

--- a/exercises/answer4.ts
+++ b/exercises/answer4.ts
@@ -1,4 +1,4 @@
-import { Option, none, option } from 'fp-ts/lib/Option'
+import { Option, none, option } from '../src/Option'
 
 export function head<A>(xs: Array<A>): Option<A> {
   if (xs.length) {
@@ -10,8 +10,8 @@ export function head<A>(xs: Array<A>): Option<A> {
 console.log(head([1, 2, 3])) // => some(1)
 console.log(head([])) // => none
 
-import { Either } from 'fp-ts/lib/Either'
-import * as either from 'fp-ts/lib/Either'
+import { Either } from '../src/Either'
+import * as either from '../src/Either'
 
 export function elementAt<A>(xs: Array<A>, i: number): Either<string, A> {
   if (i < 0) {

--- a/exercises/answer5.ts
+++ b/exercises/answer5.ts
@@ -1,6 +1,6 @@
-import { Option, some, none, option } from 'fp-ts/lib/Option'
-import { array } from 'fp-ts/lib/Array'
-import { sequence } from 'fp-ts/lib/Traversable'
+import { Option, some, none, option } from '../src/Option'
+import { array } from '../src/Array'
+import { sequence } from '../src/Traversable'
 
 export function getAllSomesOrNone<A>(xs: Array<Option<A>>): Option<Array<A>> {
   return sequence(option, array)(xs)

--- a/exercises/answer6.ts
+++ b/exercises/answer6.ts
@@ -1,6 +1,6 @@
-import { array } from 'fp-ts/lib/Array'
-import { some, none } from 'fp-ts/lib/Option'
-import { tuple } from 'fp-ts/lib/function'
+import { array } from '../src/Array'
+import { some, none } from '../src/Option'
+import { tuple } from '../src/function'
 
 export function evens(count: number): Array<number> {
   let i = count

--- a/exercises/exercise2.ts
+++ b/exercises/exercise2.ts
@@ -6,6 +6,6 @@
 
 */
 
-import { Ord } from 'fp-ts/lib/Ord'
+import { Ord } from '../src/Ord'
 
 declare function isSorted<A>(xs: Array<A>, ord: Ord<A>): boolean

--- a/exercises/exercise4.ts
+++ b/exercises/exercise4.ts
@@ -5,7 +5,7 @@
   Write a type safe head function.
 
 */
-import { Option } from 'fp-ts/lib/Option'
+import { Option } from '../src/Option'
 
 declare function head<A>(xs: Array<A>): Option<A>
 
@@ -14,6 +14,6 @@ declare function head<A>(xs: Array<A>): Option<A>
   Write a type safe elementAt function
 
 */
-import { Either } from 'fp-ts/lib/Either'
+import { Either } from '../src/Either'
 
 declare function elementAt<A>(xs: Array<A>, i: number): Either<string, A>

--- a/exercises/exercise5.ts
+++ b/exercises/exercise5.ts
@@ -8,6 +8,6 @@
   Some with a list of all the values
 
 */
-import { Option } from 'fp-ts/lib/Option'
+import { Option } from '../src/Option'
 
 declare function getAllSomesOrNone<A>(xs: Array<Option<A>>): Option<Array<A>>

--- a/exercises/tsconfig.json
+++ b/exercises/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "outDir": "./dist",
     "noStrictGenericChecks": true,
     "declaration": true,
     "module": "commonjs",
@@ -16,10 +17,6 @@
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,
     "lib": ["es6", "dom"],
-    "baseUrl": ".",
-    "paths": {
-      "fp-ts/lib/*": ["../src/*"],
-      "fp-ts": ["../src/index"]
-    }
+    "baseUrl": "."
   }
 }


### PR DESCRIPTION
Currently we cannot run example/exercise code(by `noEmit`) :sob: 
Even though I modified configuration to emit `*.js`, transpiled code causes errors because module resolution goes wrong.

```
$ pwd
/home/e_ntyo/github/gcanti/fp-ts/examples

$ tsc && node ixIO.js
module.js:557
    throw err;
    ^

Error: Cannot find module 'fp-ts/lib/IxIO'
    at Function.Module._resolveFilename (module.js:555:15)
    at Function.Module._load (module.js:482:25)
    at Module.require (module.js:604:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/home/e_ntyo/github/gcanti/fp-ts/examples/ixIO.js:13:14)
    at Module._compile (module.js:660:30)
    at Object.Module._extensions..js (module.js:671:10)
    at Module.load (module.js:573:32)
    at tryModuleLoad (module.js:513:12)
    at Function.Module._load (module.js:505:3)
```
So I changed `import` statement in each files, to resolve modules correctly. Now we can run built code like this:

```
$ pwd
/home/e_ntyo/github/gcanti/fp-ts/examples

$ tsc && node dist/examples/ixIO.js
Opening the door
Closing the door
Ringing the bell
```