### PR TITLE
Add shx and update npm scripts to allow building on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -274,6 +274,12 @@
         "is-arrayish": "0.2.1"
       }
     },
+    "es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
+      "dev": true
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -394,6 +400,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "interpret": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
     "invert-kv": {
@@ -804,6 +816,15 @@
         "read-pkg": "1.1.0"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "1.6.0"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -851,6 +872,36 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "dev": true,
+      "requires": {
+        "glob": "7.0.5",
+        "interpret": "1.1.0",
+        "rechoir": "0.6.2"
+      }
+    },
+    "shx": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.2.2.tgz",
+      "integrity": "sha1-CjBNAgsO3xMGrYFXDoDwNG31ijk=",
+      "dev": true,
+      "requires": {
+        "es6-object-assign": "1.1.0",
+        "minimist": "1.2.0",
+        "shelljs": "0.7.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
     },
     "source-map": {
       "version": "0.5.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -274,12 +274,6 @@
         "is-arrayish": "0.2.1"
       }
     },
-    "es6-object-assign": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
-      "dev": true
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -400,12 +394,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
-    },
-    "interpret": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
     "invert-kv": {
@@ -816,15 +804,6 @@
         "read-pkg": "1.1.0"
       }
     },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
-      "requires": {
-        "resolve": "1.6.0"
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -844,6 +823,15 @@
       "dev": true,
       "requires": {
         "path-parse": "1.0.5"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.0.5"
       }
     },
     "semver": {
@@ -872,36 +860,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
-    },
-    "shelljs": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-      "dev": true,
-      "requires": {
-        "glob": "7.0.5",
-        "interpret": "1.1.0",
-        "rechoir": "0.6.2"
-      }
-    },
-    "shx": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/shx/-/shx-0.2.2.tgz",
-      "integrity": "sha1-CjBNAgsO3xMGrYFXDoDwNG31ijk=",
-      "dev": true,
-      "requires": {
-        "es6-object-assign": "1.1.0",
-        "minimist": "1.2.0",
-        "shelljs": "0.7.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
     },
     "source-map": {
       "version": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "fix-prettier": "prettier --no-semi --single-quote --print-width 120 --parser typescript --write \"{src,test,examples,exercises}/**/*.ts\"",
     "typings": "typings-checker --project ./typings-checker/tsconfig.json ./typings-checker/index.ts",
     "test": "npm run lint && npm run prettier && npm run typings && npm run mocha",
-    "clean": "rm -rf lib/*",
+    "clean": "shx rm -rf lib/*",
     "build": "npm run clean && tsc",
-    "docs": "rm -rf docs/api/md/* && ts-node docs/api/main.ts"
+    "docs": "shx rm -rf docs/api/md/* && ts-node docs/api/main.ts"
   },
   "repository": {
     "type": "git",
@@ -40,6 +40,7 @@
     "doctrine": "2.0.0",
     "mocha": "3.2.0",
     "prettier": "1.11.1",
+    "shx": "^0.2.2",
     "ts-node": "3.1.0",
     "ts-simple-ast": "0.74.0",
     "tslint": "5.9.1",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "fix-prettier": "prettier --no-semi --single-quote --print-width 120 --parser typescript --write \"{src,test,examples,exercises}/**/*.ts\"",
     "typings": "typings-checker --project ./typings-checker/tsconfig.json ./typings-checker/index.ts",
     "test": "npm run lint && npm run prettier && npm run typings && npm run mocha",
-    "clean": "shx rm -rf lib/*",
+    "clean": "rimraf lib/*",
     "build": "npm run clean && tsc",
-    "docs": "shx rm -rf docs/api/md/* && ts-node docs/api/main.ts"
+    "docs": "rimraf docs/api/md/* && ts-node docs/api/main.ts"
   },
   "repository": {
     "type": "git",
@@ -40,7 +40,7 @@
     "doctrine": "2.0.0",
     "mocha": "3.2.0",
     "prettier": "1.11.1",
-    "shx": "^0.2.2",
+    "rimraf": "^2.6.2",
     "ts-node": "3.1.0",
     "ts-simple-ast": "0.74.0",
     "tslint": "5.9.1",


### PR DESCRIPTION
`rm -rf` doesn't work on windows, so this PR adds [shx](https://www.npmjs.com/package/shx) as a dev dependency and uses it in the `clean` and `docs` npm scripts.