### PR TITLE
feature: add NonEmptyArray.prototype.last

### DIFF
--- a/src/NonEmptyArray.ts
+++ b/src/NonEmptyArray.ts
@@ -1,5 +1,5 @@
 import { Applicative } from './Applicative'
-import { array } from './Array'
+import { array, last } from './Array'
 import { Comonad1 } from './Comonad'
 import { Foldable1 } from './Foldable'
 import { HKT } from './HKT'
@@ -88,6 +88,18 @@ export class NonEmptyArray<A> {
    */
   max(ord: Ord<A>): A {
     return fold(getJoinSemigroup(ord))(this.head)(this.tail)
+  }
+
+  /**
+   * Gets last element of this {@link NonEmptyArray}
+   * @since 1.6.0
+   * @example
+   * const last = new NonEmptyArray(1, [2, 3]).last(); // 3
+   * const last = new NonEmptyArray(1, []).last(); // 1
+   * @returns {A}
+   */
+  last(): A {
+    return last(this.tail).getOrElse(this.head)
   }
 }
 

--- a/test/NonEmptyArray.ts
+++ b/test/NonEmptyArray.ts
@@ -93,4 +93,9 @@ describe('NonEmptyArray', () => {
     assert.deepEqual(S.concat(new NonEmptyArray(1, []), new NonEmptyArray(2, [])), new NonEmptyArray(1, [2]))
     assert.deepEqual(S.concat(new NonEmptyArray(1, [2]), new NonEmptyArray(3, [4])), new NonEmptyArray(1, [2, 3, 4]))
   })
+
+  it('last', () => {
+    assert.deepEqual(new NonEmptyArray(1, [2, 3]).last(), 3)
+    assert.deepEqual(new NonEmptyArray(1, []).last(), 1)
+  })
 })


### PR DESCRIPTION
adds `last` shortcut method to NonEmptyArray

PS. Seems odd to increase minor version in `@since` jsdoc tag each time a small helper is added. What can we do with this?