### PR TITLE
Feature/orElse

### DIFF
--- a/src/Either.ts
+++ b/src/Either.ts
@@ -85,13 +85,13 @@ export class Left<L, A> {
   /**
    * Lazy version of {@link alt}
    * @since 1.6.0
-   * @param {Lazy<Either<L, A>>} fy - thunk
+   * @param {(l: L) => Either<L, A>} fy - thunk
    * @example
-   * assert.deepEqual(right(1).altL(() => right(2)), right(1))
+   * assert.deepEqual(right(1).orElse(() => right(2)), right(1))
    * @returns {Either<L, A>}
    */
-  altL(fy: Lazy<Either<L, A>>): Either<L, A> {
-    return fy()
+  orElse(fy: (l: L) => Either<L, A>): Either<L, A> {
+    return fy(this.value)
   }
   extend<B>(f: (ea: Either<L, A>) => B): Either<L, B> {
     return this as any
@@ -184,12 +184,12 @@ export class Right<L, A> {
   /**
    * Lazy version of {@link alt}
    * @since 1.6.0
-   * @param {Lazy<Either<L, A>>} fy - thunk
+   * @param {(l: L) => Either<L, A>} fy - thunk
    * @example
-   * assert.deepEqual(right(1).altL(() => right(2)), right(1))
+   * assert.deepEqual(right(1).orElse(() => right(2)), right(1))
    * @returns {Either<L, A>}
    */
-  altL(fy: Lazy<Either<L, A>>): Either<L, A> {
+  orElse(fy: (l: L) => Either<L, A>): Either<L, A> {
     return this
   }
   extend<B>(f: (ea: Either<L, A>) => B): Either<L, B> {

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -81,6 +81,18 @@ export class Left<L, A> {
   alt(fy: Either<L, A>): Either<L, A> {
     return fy
   }
+
+  /**
+   * Lazy version of {@link alt}
+   * @since 1.6.0
+   * @param {Lazy<Either<L, A>>} fy - thunk
+   * @example
+   * assert.deepEqual(right(1).altL(() => right(2)), right(1))
+   * @returns {Either<L, A>}
+   */
+  altL(fy: Lazy<Either<L, A>>): Either<L, A> {
+    return fy()
+  }
   extend<B>(f: (ea: Either<L, A>) => B): Either<L, B> {
     return this as any
   }
@@ -167,6 +179,17 @@ export class Right<L, A> {
     return new Right<V, B>(g(this.value))
   }
   alt(fy: Either<L, A>): Either<L, A> {
+    return this
+  }
+  /**
+   * Lazy version of {@link alt}
+   * @since 1.6.0
+   * @param {Lazy<Either<L, A>>} fy - thunk
+   * @example
+   * assert.deepEqual(right(1).altL(() => right(2)), right(1))
+   * @returns {Either<L, A>}
+   */
+  altL(fy: Lazy<Either<L, A>>): Either<L, A> {
     return this
   }
   extend<B>(f: (ea: Either<L, A>) => B): Either<L, B> {

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -181,14 +181,6 @@ export class Right<L, A> {
   alt(fy: Either<L, A>): Either<L, A> {
     return this
   }
-  /**
-   * Lazy version of {@link alt}
-   * @since 1.6.0
-   * @param {(l: L) => Either<M, A>} fy - thunk
-   * @example
-   * assert.deepEqual(right(1).orElse(() => right(2)), right(1))
-   * @returns {Either<M, A>}
-   */
   orElse<M>(fy: (l: L) => Either<M, A>): Either<M, A> {
     return this as any
   }

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -85,12 +85,12 @@ export class Left<L, A> {
   /**
    * Lazy version of {@link alt}
    * @since 1.6.0
-   * @param {(l: L) => Either<L, A>} fy - thunk
+   * @param {(l: L) => Either<M, A>} fy - thunk
    * @example
    * assert.deepEqual(right(1).orElse(() => right(2)), right(1))
-   * @returns {Either<L, A>}
+   * @returns {Either<M, A>}
    */
-  orElse(fy: (l: L) => Either<L, A>): Either<L, A> {
+  orElse<M>(fy: (l: L) => Either<M, A>): Either<M, A> {
     return fy(this.value)
   }
   extend<B>(f: (ea: Either<L, A>) => B): Either<L, B> {
@@ -184,13 +184,13 @@ export class Right<L, A> {
   /**
    * Lazy version of {@link alt}
    * @since 1.6.0
-   * @param {(l: L) => Either<L, A>} fy - thunk
+   * @param {(l: L) => Either<M, A>} fy - thunk
    * @example
    * assert.deepEqual(right(1).orElse(() => right(2)), right(1))
-   * @returns {Either<L, A>}
+   * @returns {Either<M, A>}
    */
-  orElse(fy: (l: L) => Either<L, A>): Either<L, A> {
-    return this
+  orElse<M>(fy: (l: L) => Either<M, A>): Either<M, A> {
+    return this as any
   }
   extend<B>(f: (ea: Either<L, A>) => B): Either<L, B> {
     return new Right(f(this))

--- a/src/Identity.ts
+++ b/src/Identity.ts
@@ -57,7 +57,7 @@ export class Identity<A> {
    * assert.deepEqual(a.altL(() => new Identity(2)), a)
    * @returns {Identity<A>}
    */
-  altL(fx: Lazy<Identity<A>>): Identity<A> {
+  orElse(fx: Lazy<Identity<A>>): Identity<A> {
     return this
   }
   extract(): A {

--- a/src/Identity.ts
+++ b/src/Identity.ts
@@ -8,7 +8,7 @@ import { HKT } from './HKT'
 import { Monad1 } from './Monad'
 import { Setoid } from './Setoid'
 import { Traversable1 } from './Traversable'
-import { toString } from './function'
+import { Lazy, toString } from './function'
 
 declare module './HKT' {
   interface URI2HKT<A> {
@@ -45,6 +45,19 @@ export class Identity<A> {
     return f(b, this.value)
   }
   alt(fx: Identity<A>): Identity<A> {
+    return this
+  }
+
+  /**
+   * Lazy version of {@link alt}
+   * @since 1.6.0
+   * @param {Lazy<Identity<A>>} fx - thunk
+   * @example
+   * const a = new Identity(1)
+   * assert.deepEqual(a.altL(() => new Identity(2)), a)
+   * @returns {Identity<A>}
+   */
+  altL(fx: Lazy<Identity<A>>): Identity<A> {
     return this
   }
   extract(): A {

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -150,7 +150,10 @@ export class None<A> {
 
   /**
    * Lazy version of {@link alt}
-   * @param {Lazy<Option<A>>} fa
+   * @since 1.6.0
+   * @param {Lazy<Option<A>>} fa - thunk
+   * @example
+   * assert.deepEqual(some(1).altL(() => some(2)), some(1))
    * @returns {Option<A>}
    */
   altL(fa: Lazy<Option<A>>): Option<A> {
@@ -277,7 +280,10 @@ export class Some<A> {
   }
   /**
    * Lazy version of {@link alt}
-   * @param {Lazy<Option<A>>} fa
+   * @since 1.6.0
+   * @param {Lazy<Option<A>>} fa - thunk
+   * @example
+   * assert.deepEqual(some(1).altL(() => some(2)), some(1))
    * @returns {Option<A>}
    */
   altL(fa: Lazy<Option<A>>): Option<A> {

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -286,7 +286,7 @@ export class Some<A> {
    * assert.deepEqual(some(1).orElse(() => some(2)), some(1))
    * @returns {Option<A>}
    */
-  orElse<B>(fa: Lazy<Option<A>>): Option<A> {
+  orElse(fa: Lazy<Option<A>>): Option<A> {
     return this
   }
   extend<B>(f: (ea: Option<A>) => B): Option<B> {

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -278,14 +278,6 @@ export class Some<A> {
   alt(fa: Option<A>): Option<A> {
     return this
   }
-  /**
-   * Lazy version of {@link alt}
-   * @since 1.6.0
-   * @param {Lazy<Option<A>>} fa - thunk
-   * @example
-   * assert.deepEqual(some(1).orElse(() => some(2)), some(1))
-   * @returns {Option<A>}
-   */
   orElse(fa: Lazy<Option<A>>): Option<A> {
     return this
   }

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -286,7 +286,7 @@ export class Some<A> {
    * assert.deepEqual(some(1).orElse(() => some(2)), some(1))
    * @returns {Option<A>}
    */
-  orElse(fa: Lazy<Option<A>>): Option<A> {
+  orElse<B>(fa: Lazy<Option<A>>): Option<A> {
     return this
   }
   extend<B>(f: (ea: Option<A>) => B): Option<B> {

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -147,6 +147,16 @@ export class None<A> {
   alt(fa: Option<A>): Option<A> {
     return fa
   }
+
+  /**
+   * Lazy version of {@link alt}
+   * @param {Lazy<Option<A>>} fa
+   * @returns {Option<A>}
+   */
+  altL(fa: Lazy<Option<A>>): Option<A> {
+    return fa()
+  }
+
   extend<B>(f: (ea: Option<A>) => B): Option<B> {
     return none
   }
@@ -263,6 +273,14 @@ export class Some<A> {
     return f(b, this.value)
   }
   alt(fa: Option<A>): Option<A> {
+    return this
+  }
+  /**
+   * Lazy version of {@link alt}
+   * @param {Lazy<Option<A>>} fa
+   * @returns {Option<A>}
+   */
+  altL(fa: Lazy<Option<A>>): Option<A> {
     return this
   }
   extend<B>(f: (ea: Option<A>) => B): Option<B> {

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -153,10 +153,10 @@ export class None<A> {
    * @since 1.6.0
    * @param {Lazy<Option<A>>} fa - thunk
    * @example
-   * assert.deepEqual(some(1).altL(() => some(2)), some(1))
+   * assert.deepEqual(some(1).orElse(() => some(2)), some(1))
    * @returns {Option<A>}
    */
-  altL(fa: Lazy<Option<A>>): Option<A> {
+  orElse(fa: Lazy<Option<A>>): Option<A> {
     return fa()
   }
 
@@ -283,10 +283,10 @@ export class Some<A> {
    * @since 1.6.0
    * @param {Lazy<Option<A>>} fa - thunk
    * @example
-   * assert.deepEqual(some(1).altL(() => some(2)), some(1))
+   * assert.deepEqual(some(1).orElse(() => some(2)), some(1))
    * @returns {Option<A>}
    */
-  altL(fa: Lazy<Option<A>>): Option<A> {
+  orElse(fa: Lazy<Option<A>>): Option<A> {
     return this
   }
   extend<B>(f: (ea: Option<A>) => B): Option<B> {

--- a/src/function.ts
+++ b/src/function.ts
@@ -15,6 +15,9 @@ export const identity = <A>(a: A): A => {
  */
 export const unsafeCoerce: <A, B>(a: A) => B = identity as any
 
+/**
+ * Thunk type
+ */
 export type Lazy<A> = () => A
 
 export type Function1<A, B> = (a: A) => B

--- a/test/Either.ts
+++ b/test/Either.ts
@@ -207,6 +207,13 @@ describe('Either', () => {
     assert.deepEqual(either.alt(right<string, number>(1), right<string, number>(2)), right<string, number>(1))
   })
 
+  it('altL', () => {
+    assert.deepEqual(right<string, number>(1).altL(() => right<string, number>(2)), right<string, number>(1))
+    assert.deepEqual(right<string, number>(1).altL(() => left<string, number>('foo')), right<string, number>(1))
+    assert.deepEqual(left<string, number>('foo').altL(() => right<string, number>(1)), right<string, number>(1))
+    assert.deepEqual(left<string, number>('foo').altL(() => left<string, number>('bar')), left<string, number>('bar'))
+  })
+
   it('extend', () => {
     assert.deepEqual(right(1).extend(() => 2), right(2))
     assert.deepEqual(left('foo').extend(() => 2), left('foo'))

--- a/test/Either.ts
+++ b/test/Either.ts
@@ -207,11 +207,11 @@ describe('Either', () => {
     assert.deepEqual(either.alt(right<string, number>(1), right<string, number>(2)), right<string, number>(1))
   })
 
-  it('altL', () => {
-    assert.deepEqual(right<string, number>(1).altL(() => right<string, number>(2)), right<string, number>(1))
-    assert.deepEqual(right<string, number>(1).altL(() => left<string, number>('foo')), right<string, number>(1))
-    assert.deepEqual(left<string, number>('foo').altL(() => right<string, number>(1)), right<string, number>(1))
-    assert.deepEqual(left<string, number>('foo').altL(() => left<string, number>('bar')), left<string, number>('bar'))
+  it('orElse', () => {
+    assert.deepEqual(right<string, number>(1).orElse(() => right<string, number>(2)), right<string, number>(1))
+    assert.deepEqual(right<string, number>(1).orElse(() => left<string, number>('foo')), right<string, number>(1))
+    assert.deepEqual(left<string, number>('foo').orElse(() => right<string, number>(1)), right<string, number>(1))
+    assert.deepEqual(left<string, number>('foo').orElse(() => left<string, number>('bar')), left<string, number>('bar'))
   })
 
   it('extend', () => {

--- a/test/Identity.ts
+++ b/test/Identity.ts
@@ -1,0 +1,8 @@
+import * as assert from 'assert'
+import { Identity } from '../src/Identity'
+
+describe('Identity', () => {
+  it('orElse', () => {
+    assert.deepEqual(new Identity(123).orElse(() => new Identity(456)), new Identity(123))
+  })
+})

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -159,11 +159,11 @@ describe('Option', () => {
     assert.deepEqual(none.alt(none), none)
   })
 
-  it('altL', () => {
-    assert.deepEqual(some(1).altL(() => some(2)), some(1))
-    assert.deepEqual(some(2).altL(() => none), some(2))
-    assert.deepEqual((none as Option<number>).altL(() => some(1)), some(1))
-    assert.deepEqual(none.altL(() => none), none)
+  it('orElse', () => {
+    assert.deepEqual(some(1).orElse(() => some(2)), some(1))
+    assert.deepEqual(some(2).orElse(() => none), some(2))
+    assert.deepEqual((none as Option<number>).orElse(() => some(1)), some(1))
+    assert.deepEqual(none.orElse(() => none), none)
   })
 
   it('extend', () => {

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -159,6 +159,13 @@ describe('Option', () => {
     assert.deepEqual(none.alt(none), none)
   })
 
+  it('altL', () => {
+    assert.deepEqual(some(1).altL(() => some(2)), some(1))
+    assert.deepEqual(some(2).altL(() => none), some(2))
+    assert.deepEqual((none as Option<number>).altL(() => some(1)), some(1))
+    assert.deepEqual(none.altL(() => none), none)
+  })
+
   it('extend', () => {
     const f = (fa: Option<number>) => fa.getOrElse(0)
     assert.deepEqual(some(2).extend(f), some(2))


### PR DESCRIPTION
Adds lazy alt (orElse) to Option, Either, Identity.
It's often useful to pass some heavy computation as alternative to missing value. `orElse` allows to pass a thunk which will be executed on failure