### PR TITLE
Handle undefined errors in callback of TaskEither taskify

### DIFF
--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -219,7 +219,7 @@ export function taskify<L, R>(f: Function): () => TaskEither<L, R> {
       new Task(
         () =>
           new Promise(resolve => {
-            args.push((e: L, r: R) => (e !== null ? resolve(eitherLeft<L, R>(e)) : resolve(eitherRight<L, R>(r))))
+            args.push((e: L, r: R) => (e != null ? resolve(eitherLeft<L, R>(e)) : resolve(eitherRight<L, R>(r))))
             f.apply(null, args)
           })
       )

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -175,8 +175,12 @@ export const tryCatch = <L, A>(f: Lazy<Promise<A>>, onrejected: (reason: {}) => 
 
 /** Convert a node style callback function to one returning a `TaskEither` */
 export function taskify<L, R>(f: (cb: (e: L | null | undefined, r: R) => void) => void): () => TaskEither<L, R>
-export function taskify<A, L, R>(f: (a: A, cb: (e: L | null | undefined, r: R) => void) => void): (a: A) => TaskEither<L, R>
-export function taskify<A, B, L, R>(f: (a: A, b: B, cb: (e: L | null | undefined, r: R) => void) => void): (a: A, b: B) => TaskEither<L, R>
+export function taskify<A, L, R>(
+  f: (a: A, cb: (e: L | null | undefined, r: R) => void) => void
+): (a: A) => TaskEither<L, R>
+export function taskify<A, B, L, R>(
+  f: (a: A, b: B, cb: (e: L | null | undefined, r: R) => void) => void
+): (a: A, b: B) => TaskEither<L, R>
 export function taskify<A, B, C, L, R>(
   f: (a: A, b: B, c: C, cb: (e: L | null | undefined, r: R) => void) => void
 ): (a: A, b: B, c: C) => TaskEither<L, R>

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -174,17 +174,17 @@ export const tryCatch = <L, A>(f: Lazy<Promise<A>>, onrejected: (reason: {}) => 
 }
 
 /** Convert a node style callback function to one returning a `TaskEither` */
-export function taskify<L, R>(f: (cb: (e: L, r: R) => void) => void): () => TaskEither<L, R>
-export function taskify<A, L, R>(f: (a: A, cb: (e: L, r: R) => void) => void): (a: A) => TaskEither<L, R>
-export function taskify<A, B, L, R>(f: (a: A, b: B, cb: (e: L, r: R) => void) => void): (a: A, b: B) => TaskEither<L, R>
+export function taskify<L, R>(f: (cb: (e: L | null | undefined, r: R) => void) => void): () => TaskEither<L, R>
+export function taskify<A, L, R>(f: (a: A, cb: (e: L | null | undefined, r: R) => void) => void): (a: A) => TaskEither<L, R>
+export function taskify<A, B, L, R>(f: (a: A, b: B, cb: (e: L | null | undefined, r: R) => void) => void): (a: A, b: B) => TaskEither<L, R>
 export function taskify<A, B, C, L, R>(
-  f: (a: A, b: B, c: C, cb: (e: L, r: R) => void) => void
+  f: (a: A, b: B, c: C, cb: (e: L | null | undefined, r: R) => void) => void
 ): (a: A, b: B, c: C) => TaskEither<L, R>
 export function taskify<A, B, C, D, L, R>(
-  f: (a: A, b: B, c: C, d: D, cb: (e: L, r: R) => void) => void
+  f: (a: A, b: B, c: C, d: D, cb: (e: L | null | undefined, r: R) => void) => void
 ): (a: A, b: B, c: C, d: D) => TaskEither<L, R>
 export function taskify<A, B, C, D, E, L, R>(
-  f: (a: A, b: B, c: C, d: D, e: E, cb: (e: L, r: R) => void) => void
+  f: (a: A, b: B, c: C, d: D, e: E, cb: (e: L | null | undefined, r: R) => void) => void
 ): (a: A, b: B, c: C, d: D, e: E) => TaskEither<L, R>
 /**
  * Convert a node style callback function to one returning a `TaskEither`

--- a/test/TaskEither.ts
+++ b/test/TaskEither.ts
@@ -140,16 +140,22 @@ describe('TaskEither', () => {
   })
 
   it('taskify', () => {
-    const api1 = (path: string, callback: (err: Error | null, result?: string) => void): void => {
+    const api1 = (path: string, callback: (err: Error | null | undefined, result?: string) => void): void => {
       callback(null, 'ok')
     }
-    const api2 = (path: string, callback: (err: Error | null, result?: string) => void): void => {
+    const api2 = (path: string, callback: (err: Error | null | undefined, result?: string) => void): void => {
+      callback(undefined, 'ok')
+    }
+    const api3 = (path: string, callback: (err: Error | null | undefined, result?: string) => void): void => {
       callback(new Error('ko'))
     }
-    return Promise.all([taskify(api1)('foo').run(), taskify(api2)('foo').run()]).then(([e1, e2]) => {
-      assert.deepEqual(e1, eitherRight('ok'))
-      assert.deepEqual(e2, eitherLeft(new Error('ko')))
-    })
+    return Promise.all([taskify(api1)('foo').run(), taskify(api2)('foo').run(), taskify(api3)('foo').run()]).then(
+      ([e1, e2, e3]) => {
+        assert.deepEqual(e1, eitherRight('ok'))
+        assert.deepEqual(e2, eitherRight('ok'))
+        assert.deepEqual(e3, eitherLeft(new Error('ko')))
+      }
+    )
   })
 
   it('alt', () => {


### PR DESCRIPTION
When wrapping a function from elasticsearch client the callback is called with `undefined` as first argument preventing taskify to return a right and instead returns left