### PR TITLE
failing test for sequence(option, io)

### DIFF
--- a/test/Traversable.ts
+++ b/test/Traversable.ts
@@ -2,7 +2,8 @@ import * as assert from 'assert'
 import { Applicative } from '../src/Applicative'
 import { array } from '../src/Array'
 import { none, option, some } from '../src/Option'
-import { getTraversableComposition } from '../src/Traversable'
+import { getTraversableComposition, sequence } from '../src/Traversable'
+import { io } from '../src/IO'
 
 export const ArrayOptionURI = 'ArrayOption'
 
@@ -20,5 +21,9 @@ describe('Traversable', () => {
       arrayOptionTraversable.traverse(o)([some(1), some(3)], (n: number) => (n <= 2 ? some(n * 2) : none)),
       none
     )
+  })
+
+  it('sequence(option, io)', () => {
+    assert.deepEqual(sequence(option, io)(io.of(some(1))), some(io.of(1)))
   })
 })


### PR DESCRIPTION
I have an `IO<Option<A>>` and I want an `Option<IO<A>>`, and I _think_ I should be able to do that by invoking `sequence(option, io)`. However the compiler is shouting at me that:

```
Argument of type 'Monad1<"Option"> & Foldable1<"Option"> & Plus1<"Option"> & Traversable1<"Option"> & Alternative1<...' is not assignable to parameter of type 'Applicative<"Option">'.
  Types of property 'ap' are incompatible.
    Type '<A, B>(fab: Option<(a: A) => B>, fa: Option<A>) => Option<B>' is not assignable to type '<A, B>(fab: HKT<"Option", (a: A) => B>, fa: HKT<"Option", A>) => HKT<"Option", B>'.
      Types of parameters 'fab' and 'fab' are incompatible.
        Type 'HKT<"Option", (a: A) => B>' is not assignable to type 'Option<(a: A) => B>'.
          Type 'HKT<"Option", (a: A) => B>' is not assignable to type 'Some<(a: A) => B>'.
            Property '_tag' is missing in type 'HKT<"Option", (a: A) => B>'.
```

I've added a test to `Traversable.ts` to show it. I have also noticed that the `getTraversableComposition` does:

```ts
    const o: Applicative<'Option'> = option as any // TODO
```

so I suppose that test is using that to work around the same issue. Is there a route forward here or do I need to use some `as any` incantation too?