### PR TITLE
add fold to ReaderTaskEither

### DIFF
--- a/src/ReaderTaskEither.ts
+++ b/src/ReaderTaskEither.ts
@@ -79,6 +79,12 @@ export class ReaderTaskEither<E, L, A> {
   /**
    * @since 1.6.0
    */
+  fold<R>(left: (l: L) => R, right: (a: A) => R): Reader<E, Task<R>> {
+    return new Reader(e => this.value(e).fold(left, right))
+  }
+  /**
+   * @since 1.6.0
+   */
   mapLeft<M>(f: (l: L) => M): ReaderTaskEither<E, M, A> {
     return new ReaderTaskEither(e => this.value(e).mapLeft(f))
   }

--- a/test/ReaderTaskEither.ts
+++ b/test/ReaderTaskEither.ts
@@ -73,6 +73,17 @@ describe('ReaderTaskEither', () => {
     })
   })
 
+  it('fold', () => {
+    const f = (s: string): boolean => s.length > 2
+    const g = (n: number): boolean => n > 2
+    const rte1 = readerTaskEither.of<{}, string, number>(1).fold(f, g)
+    const rte2 = fromLeft<{}, string, number>('foo').fold(f, g)
+    return Promise.all([rte1.run({}).run(), rte2.run({}).run()]).then(([b1, b2]) => {
+      assert.strictEqual(b1, false)
+      assert.strictEqual(b2, true)
+    })
+  })
+
   it('of', () => {
     return readerTaskEither
       .of(1)


### PR DESCRIPTION
My spider sense is tingling about having to do `.run({}).run()` in the tests, but I can't see a better return type than `Reader<E, Task<R>>` so....