### PR TITLE
Feature/filterable instances

### DIFF
--- a/src/Array.ts
+++ b/src/Array.ts
@@ -14,8 +14,9 @@ import { Plus1 } from './Plus'
 import { Setoid, getArraySetoid } from './Setoid'
 import { Traversable1 } from './Traversable'
 import { Unfoldable1 } from './Unfoldable'
-import { Endomorphism, Predicate, Refinement, concat, identity, tuple } from './function'
-import { Compactable1, Separated } from './Compactable'
+import { Endomorphism, Predicate, Refinement, concat, tuple } from './function'
+import { Compactable1, compactDefaultFilterMap, separateDefaultPartitionMap } from './Compactable'
+import { Filterable1, filterDefaultFilterMap, partitionDefaultPartitionMap } from './Filterable'
 
 // Adapted from https://github.com/purescript/purescript-arrays
 
@@ -178,25 +179,6 @@ const unfoldr = <A, B>(b: B, f: (b: B) => Option<[A, B]>): Array<A> => {
 
 const extend = <A, B>(fa: Array<A>, f: (fa: Array<A>) => B): Array<B> => {
   return fa.map((_, i, as) => f(as.slice(i)))
-}
-
-/**
- * @function
- * @since 1.0.0
- */
-export const partitionMap = <A, L, R>(fa: Array<A>, f: (a: A) => Either<L, R>): { left: Array<L>; right: Array<R> } => {
-  const left: Array<L> = []
-  const right: Array<R> = []
-  const len = fa.length
-  for (let i = 0; i < len; i++) {
-    const v = f(fa[i])
-    if (v.isLeft()) {
-      left.push(v.value)
-    } else {
-      right.push(v.value)
-    }
-  }
-  return { left, right }
 }
 
 /**
@@ -522,23 +504,6 @@ export const findLast = <A>(as: Array<A>, predicate: Predicate<A>): Option<A> =>
 }
 
 /**
- * Filter an array, keeping the elements which satisfy a predicate function, creating a new array
- * @function
- * @since 1.0.0
- */
-export const filter = <A>(as: Array<A>, predicate: Predicate<A>): Array<A> => {
-  const l = as.length
-  const r = []
-  for (let i = 0; i < l; i++) {
-    const v = as[i]
-    if (predicate(v)) {
-      r.push(v)
-    }
-  }
-  return r
-}
-
-/**
  * @function
  * @since 1.0.0
  */
@@ -633,33 +598,6 @@ export const modifyAt = <A>(as: Array<A>, i: number, f: Endomorphism<A>): Option
  */
 export const reverse = <A>(as: Array<A>): Array<A> => {
   return copy(as).reverse()
-}
-
-/**
- * Apply a function to each element in an array, keeping only the results
- * which contain a value, creating a new array
- * @function
- * @since 1.0.0
- */
-export const mapOption = <A, B>(as: Array<A>, f: (a: A) => Option<B>): Array<B> => {
-  const r: Array<B> = []
-  const len = as.length
-  for (let i = 0; i < len; i++) {
-    const v = f(as[i])
-    if (v.isSome()) {
-      r.push(v.value)
-    }
-  }
-  return r
-}
-
-/**
- * Filter an array of optional values, keeping only the elements which contain a value, creating a new array
- * @function
- * @since 1.0.0
- */
-export const catOptions = <A>(as: Array<Option<A>>): Array<A> => {
-  return mapOption(as, identity)
 }
 
 /**
@@ -803,8 +741,72 @@ export const sortBy1 = <A>(head: Ord<A>, tail: Array<Ord<A>>): Endomorphism<Arra
   return sort(tail.reduce(getSemigroup<A>().concat, head))
 }
 
-const compact = catOptions
-const separate = <L, A>(fa: Either<L, A>[]): Separated<L[], A[]> => partitionMap(fa, identity)
+const filterMap = <A, B>(as: Array<A>, f: (a: A) => Option<B>): Array<B> => {
+  const r: Array<B> = []
+  const len = as.length
+  for (let i = 0; i < len; i++) {
+    const v = f(as[i])
+    if (v.isSome()) {
+      r.push(v.value)
+    }
+  }
+  return r
+}
+/**
+ * @function
+ * @since 1.0.0
+ */
+export const partitionMap = <A, L, R>(fa: Array<A>, f: (a: A) => Either<L, R>): { left: Array<L>; right: Array<R> } => {
+  const left: Array<L> = []
+  const right: Array<R> = []
+  const len = fa.length
+  for (let i = 0; i < len; i++) {
+    const v = f(fa[i])
+    if (v.isLeft()) {
+      left.push(v.value)
+    } else {
+      right.push(v.value)
+    }
+  }
+  return { left, right }
+}
+/**
+ * Filter an array, keeping the elements which satisfy a predicate function, creating a new array
+ * @function
+ * @since 1.0.0
+ */
+export const filter = filterDefaultFilterMap({
+  URI,
+  filterMap
+})
+const partition = partitionDefaultPartitionMap({
+  URI,
+  partitionMap
+})
+const compact = compactDefaultFilterMap({
+  URI,
+  filterMap
+})
+const separate = separateDefaultPartitionMap({
+  URI,
+  partitionMap
+})
+
+/**
+ * Filter an array of optional values, keeping only the elements which contain a value, creating a new array
+ * Alias for {@link Compactable.compact}
+ * @function
+ * @since 1.0.0
+ */
+export const catOptions = compact
+
+/**
+ * Apply a function to each element in an array, keeping only the results which contain a value, creating a new array
+ * Alias for {@link Filterable.filterMap}
+ * @function
+ * @since 1.0.0
+ */
+export const mapOption = filterMap
 
 export const array: Monad1<URI> &
   Foldable1<URI> &
@@ -813,11 +815,16 @@ export const array: Monad1<URI> &
   Alternative1<URI> &
   Plus1<URI> &
   Extend1<URI> &
-  Compactable1<URI> = {
+  Compactable1<URI> &
+  Filterable1<URI> = {
   URI,
   map,
   compact,
   separate,
+  filter,
+  filterMap,
+  partition,
+  partitionMap,
   of,
   ap,
   chain,

--- a/src/Compactable.ts
+++ b/src/Compactable.ts
@@ -56,6 +56,19 @@ export interface CompactableA<F, A, RL, RR> {
  * @see Compactable
  * @since 1.7.0
  */
+export interface CompactableA<F, A, RL, RR> {
+  readonly URI: F
+  readonly _A: A
+  readonly _RL: RL
+  readonly _RR: RR
+  readonly compact: (fa: HKT<F, Option<A>>) => HKT<F, A>
+  readonly separate: (fa: HKT<F, Either<RL, RR>>) => Separated<HKT<F, RL>, HKT<F, RR>>
+}
+
+/**
+ * @see Compactable
+ * @since 1.7.0
+ */
 export interface Compactable1<F extends URIS> {
   readonly URI: F
   readonly compact: <A>(fa: Type<F, Option<A>>) => Type<F, A>
@@ -78,6 +91,19 @@ export interface Compactable1A<F extends URIS, A, RL, RR> {
 
 /**
  * @typeclass
+ * @see Compactable
+ * @since 1.7.0
+ */
+export interface Compactable1A<F extends URIS, A, RL, RR> {
+  readonly URI: F
+  readonly _A: A
+  readonly _RL: RL
+  readonly _RR: RR
+  readonly compact: (fa: Type<F, Option<A>>) => Type<F, A>
+  readonly separate: (fa: Type<F, Either<RL, RR>>) => Separated<Type<F, RL>, Type<F, RR>>
+}
+
+/**
  * @see Compactable
  * @since 1.7.0
  */

--- a/src/Compactable.ts
+++ b/src/Compactable.ts
@@ -178,13 +178,13 @@ export function compactDefaultSeparate<F>(F: Functor<F> & Pick<Compactable<F>, '
  * @since 1.7.0
  */
 export function compactDefaultFilterMap<F extends URIS3, U, L>(
-  F: Pick<Filterable3C<F, U, L>, 'URI' | 'filterMap'>
+  F: Pick<Filterable3C<F, U, L>, 'URI' | '_U' | '_L' | 'filterMap'>
 ): Compactable3C<F, U, L>['compact']
 export function compactDefaultFilterMap<F extends URIS3>(
   F: Pick<Filterable3<F>, 'URI' | 'filterMap'>
 ): Compactable3<F>['compact']
 export function compactDefaultFilterMap<F extends URIS2, L>(
-  F: Pick<Filterable2C<F, L>, 'URI' | 'filterMap'>
+  F: Pick<Filterable2C<F, L>, 'URI' | '_L' | 'filterMap'>
 ): Compactable2C<F, L>['compact']
 export function compactDefaultFilterMap<F extends URIS2>(
   F: Pick<Filterable2<F>, 'URI' | 'filterMap'>
@@ -232,13 +232,13 @@ export function separateDefaultCompact<F>(F: Functor<F> & Pick<Compactable<F>, '
  * @since 1.7.0
  */
 export function separateDefaultPartitionMap<F extends URIS3, U, L>(
-  F: Pick<Filterable3C<F, U, L>, 'URI' | 'partitionMap'>
+  F: Pick<Filterable3C<F, U, L>, 'URI' | '_U' | '_L' | 'partitionMap'>
 ): Compactable3C<F, U, L>['separate']
 export function separateDefaultPartitionMap<F extends URIS3>(
   F: Pick<Filterable3<F>, 'URI' | 'partitionMap'>
 ): Compactable3<F>['separate']
 export function separateDefaultPartitionMap<F extends URIS2, L>(
-  F: Pick<Filterable2C<F, L>, 'URI' | 'partitionMap'>
+  F: Pick<Filterable2C<F, L>, 'URI' | '_L' | 'partitionMap'>
 ): Compactable2C<F, L>['separate']
 export function separateDefaultPartitionMap<F extends URIS2>(
   F: Pick<Filterable2<F>, 'URI' | 'partitionMap'>

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -13,6 +13,13 @@ import { Traversable2 } from './Traversable'
 import { Validation } from './Validation'
 import { Compactable2C, Separated } from './Compactable'
 import { Monoid } from './Monoid'
+import {
+  Filterable2C,
+  filterDefaultFilterMap,
+  filterMapDefaultCompact,
+  partitionDefaultPartitionMap,
+  partitionMapDefaultSeparate
+} from './Filterable'
 
 declare module './HKT' {
   interface URI2HKT2<L, A> {
@@ -462,6 +469,46 @@ export function getCompactable<L>(ML: Monoid<L>): Compactable2C<URI, L> {
     _L: phantom,
     compact,
     separate
+  }
+}
+
+/**
+ * Builds {@link Filterable} instance for {@link Either} gived {@link Monoid} for the left side
+ * @function
+ * @since 1.7.0
+ */
+export function getFilterable<L>(ML: Monoid<L>): Filterable2C<URI, L> {
+  const C = getCompactable(ML)
+  const { URI, _L, compact, separate } = C
+  const partitionMap = partitionMapDefaultSeparate({
+    URI,
+    _L,
+    map,
+    separate
+  })
+  const partition = partitionDefaultPartitionMap({
+    URI,
+    _L,
+    partitionMap
+  })
+  const filterMap = filterMapDefaultCompact({
+    URI,
+    _L,
+    map,
+    compact
+  })
+  const filter = filterDefaultFilterMap({
+    URI,
+    _L,
+    filterMap
+  })
+  return {
+    ...C,
+    map,
+    partitionMap,
+    filterMap,
+    partition,
+    filter
   }
 }
 

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -438,6 +438,13 @@ export const isRight = <L, A>(fa: Either<L, A>): fa is Right<L, A> => {
 }
 
 /**
+ * Upgrade a boolean-style predicate to an either-style predicate mapping.
+ * @function
+ * @since 1.7.0
+ */
+export const eitherBool = <A>(p: Predicate<A>) => (a: A): Either<A, A> => (p(a) ? right(a) : left(a))
+
+/**
  * Builds {@link Compactable} instance for {@link Either} given {@link Monoid} for the left side
  * @function
  * @since 1.7.0

--- a/src/Filterable.ts
+++ b/src/Filterable.ts
@@ -171,13 +171,13 @@ export function partitionMapDefaultSeparate<F>(
  * @since 1.7.0
  */
 export function partitionDefaultPartitionMap<F extends URIS3, U, L>(
-  F: Pick<Filterable3C<F, U, L>, 'URI' | 'partitionMap'>
+  F: Pick<Filterable3C<F, U, L>, 'URI' | '_U' | '_L' | 'partitionMap'>
 ): Filterable3C<F, U, L>['partition']
 export function partitionDefaultPartitionMap<F extends URIS3>(
   F: Pick<Filterable3<F>, 'URI' | 'partitionMap'>
 ): Filterable3<F>['partition']
 export function partitionDefaultPartitionMap<F extends URIS2, L>(
-  F: Pick<Filterable2C<F, L>, 'URI' | 'partitionMap'>
+  F: Pick<Filterable2C<F, L>, 'URI' | '_L' | 'partitionMap'>
 ): Filterable2C<F, L>['partition']
 export function partitionDefaultPartitionMap<F extends URIS2>(
   F: Pick<Filterable2<F>, 'URI' | 'partitionMap'>
@@ -200,13 +200,13 @@ export function partitionDefaultPartitionMap<F>(
  * @since 1.7.0
  */
 export function partitionDefaultFilter<F extends URIS3, U, L>(
-  F: Pick<Filterable3C<F, U, L>, 'URI' | 'filter'>
+  F: Pick<Filterable3C<F, U, L>, 'URI' | '_U' | '_L' | 'filter'>
 ): Filterable3C<F, U, L>['partition']
 export function partitionDefaultFilter<F extends URIS3>(
   F: Pick<Filterable3<F>, 'URI' | 'filter'>
 ): Filterable3<F>['partition']
 export function partitionDefaultFilter<F extends URIS2, L>(
-  F: Pick<Filterable2C<F, L>, 'URI' | 'filter'>
+  F: Pick<Filterable2C<F, L>, 'URI' | '_L' | 'filter'>
 ): Filterable2C<F, L>['partition']
 export function partitionDefaultFilter<F extends URIS2>(
   F: Pick<Filterable2<F>, 'URI' | 'filter'>
@@ -228,13 +228,13 @@ export function partitionDefaultFilter<F>(F: Pick<Filterable<F>, 'URI' | 'filter
  * @since 1.7.0
  */
 export function partitionDefaultFilterMap<F extends URIS3, U, L>(
-  F: Pick<Filterable3C<F, U, L>, 'URI' | 'filterMap'>
+  F: Pick<Filterable3C<F, U, L>, 'URI' | '_U' | '_L' | 'filterMap'>
 ): Filterable3C<F, U, L>['partition']
 export function partitionDefaultFilterMap<F extends URIS3>(
   F: Pick<Filterable3<F>, 'URI' | 'filterMap'>
 ): Filterable3<F>['partition']
 export function partitionDefaultFilterMap<F extends URIS2, L>(
-  F: Pick<Filterable2C<F, L>, 'URI' | 'filterMap'>
+  F: Pick<Filterable2C<F, L>, 'URI' | '_L' | 'filterMap'>
 ): Filterable2C<F, L>['partition']
 export function partitionDefaultFilterMap<F extends URIS2>(
   F: Pick<Filterable2<F>, 'URI' | 'filterMap'>
@@ -283,13 +283,13 @@ export function filterMapDefaultCompact<F>(
  * @since 1.7.0
  */
 export function filterDefaultFilterMap<F extends URIS3, U, L>(
-  F: Pick<Filterable3C<F, U, L>, 'URI' | 'filterMap'>
+  F: Pick<Filterable3C<F, U, L>, 'URI' | '_U' | '_L' | 'filterMap'>
 ): Filterable3C<F, U, L>['filter']
 export function filterDefaultFilterMap<F extends URIS3>(
   F: Pick<Filterable3<F>, 'URI' | 'filterMap'>
 ): Filterable3<F>['filter']
 export function filterDefaultFilterMap<F extends URIS2, L>(
-  F: Pick<Filterable2C<F, L>, 'URI' | 'filterMap'>
+  F: Pick<Filterable2C<F, L>, 'URI' | '_L' | 'filterMap'>
 ): Filterable2C<F, L>['filter']
 export function filterDefaultFilterMap<F extends URIS2>(
   F: Pick<Filterable2<F>, 'URI' | 'filterMap'>
@@ -308,13 +308,13 @@ export function filterDefaultFilterMap<F>(F: Pick<Filterable<F>, 'URI' | 'filter
  * @since 1.7.0
  */
 export function filterDefaultPartition<F extends URIS3, U, L>(
-  F: Functor3C<F, U, L> & Pick<Filterable3C<F, U, L>, 'URI' | 'partition'>
+  F: Functor3C<F, U, L> & Pick<Filterable3C<F, U, L>, 'URI' | '_U' | '_L' | 'partition'>
 ): Filterable3C<F, U, L>['filter']
 export function filterDefaultPartition<F extends URIS3>(
   F: Functor3<F> & Pick<Filterable3<F>, 'URI' | 'partition'>
 ): Filterable3<F>['filter']
 export function filterDefaultPartition<F extends URIS2, L>(
-  F: Functor2C<F, L> & Pick<Filterable2C<F, L>, 'URI' | 'partition'>
+  F: Functor2C<F, L> & Pick<Filterable2C<F, L>, 'URI' | '_L' | 'partition'>
 ): Filterable2C<F, L>['filter']
 export function filterDefaultPartition<F extends URIS2>(
   F: Functor2<F> & Pick<Filterable2<F>, 'URI' | 'partition'>
@@ -337,13 +337,13 @@ export function filterDefaultPartition<F>(
  * @since 1.7.0
  */
 export function filterDefaultPartitionMap<F extends URIS3, U, L>(
-  F: Pick<Filterable3C<F, U, L>, 'URI' | 'partitionMap'>
+  F: Pick<Filterable3C<F, U, L>, 'URI' | '_U' | '_L' | 'partitionMap'>
 ): Filterable3C<F, U, L>['filter']
 export function filterDefaultPartitionMap<F extends URIS3>(
   F: Pick<Filterable3<F>, 'URI' | 'partitionMap'>
 ): Filterable3<F>['filter']
 export function filterDefaultPartitionMap<F extends URIS2, L>(
-  F: Pick<Filterable2C<F, L>, 'URI' | 'partitionMap'>
+  F: Pick<Filterable2C<F, L>, 'URI' | '_L' | 'partitionMap'>
 ): Filterable2C<F, L>['filter']
 export function filterDefaultPartitionMap<F extends URIS2>(
   F: Pick<Filterable2<F>, 'URI' | 'partitionMap'>

--- a/src/Filterable.ts
+++ b/src/Filterable.ts
@@ -9,9 +9,9 @@ import {
   Separated
 } from './Compactable'
 import { HKT, Type, Type2, Type3, URIS, URIS2, URIS3 } from './HKT'
-import { Either, left, right } from './Either'
+import { Either, eitherBool } from './Either'
 import { not, Predicate } from './function'
-import { none, Option, some } from './Option'
+import { Option, optionBool } from './Option'
 
 /**
  * @typeclass
@@ -121,20 +121,6 @@ export interface Filterable3C<F extends URIS3, U, L> extends Functor3C<F, U, L>,
   readonly filterMap: <A, B>(fa: Type3<F, U, L, A>, f: (a: A) => Option<B>) => Type3<F, U, L, B>
   readonly filter: <A>(fa: Type3<F, U, L, A>, p: Predicate<A>) => Type3<F, U, L, A>
 }
-
-/**
- * Upgrade a boolean-style predicate to an either-style predicate mapping.
- * @function
- * @since 1.7.0
- */
-export const eitherBool = <A>(p: Predicate<A>) => (a: A): Either<A, A> => (p(a) ? right(a) : left(a))
-
-/**
- * Upgrade a boolean-style predicate to a maybe-style predicate mapping.
- * @function
- * @since 1.7.0
- */
-export const optionBool = <A>(p: Predicate<A>) => (a: A): Option<A> => (p(a) ? some(a) : none)
 
 /**
  * Gets default implementation of {@link Filterable.partitionMap} using {@link Compactable.separate}

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -556,6 +556,13 @@ export const fromRefinement = <A, B extends A>(refinement: Refinement<A, B>) => 
   return refinement(a) ? some(a) : none
 }
 
+/**
+ * Upgrade a boolean-style predicate to a maybe-style predicate mapping.
+ * @function
+ * @since 1.7.0
+ */
+export const optionBool = <A>(p: Predicate<A>) => (a: A): Option<A> => (p(a) ? some(a) : none)
+
 const compact = <A>(fa: Option<Option<A>>): Option<A> => fa.chain(identity)
 const separate = <RL, RR>(fa: Option<Either<RL, RR>>): Separated<Option<RL>, Option<RR>> =>
   fa.foldL(
@@ -575,7 +582,6 @@ const separate = <RL, RR>(fa: Option<Either<RL, RR>>): Separated<Option<RL>, Opt
         })
       )
   )
-
 /**
  * @instance
  * @since 1.0.0

--- a/src/Validation.ts
+++ b/src/Validation.ts
@@ -13,6 +13,13 @@ import { Predicate, phantom, toString } from './function'
 import { Bifunctor2 } from './Bifunctor'
 import { Compactable2C, Separated } from './Compactable'
 import { Option } from './Option'
+import {
+  Filterable2C,
+  filterDefaultFilterMap,
+  filterMapDefaultCompact,
+  partitionDefaultPartitionMap,
+  partitionMapDefaultSeparate
+} from './Filterable'
 
 // Adapted from https://github.com/purescript/purescript-validation
 
@@ -358,6 +365,46 @@ export function getCompactable<L>(ML: Monoid<L>): Compactable2C<URI, L> {
     _L: phantom,
     compact,
     separate
+  }
+}
+
+/**
+ * Builds {@link Filterable} instance for {@link Validation} gived {@link Monoid} for the left side
+ * @function
+ * @since 1.7.0
+ */
+export function getFilterable<L>(ML: Monoid<L>): Filterable2C<URI, L> {
+  const C = getCompactable(ML)
+  const { URI, _L, compact, separate } = C
+  const partitionMap = partitionMapDefaultSeparate({
+    URI,
+    _L,
+    map,
+    separate
+  })
+  const partition = partitionDefaultPartitionMap({
+    URI,
+    _L,
+    partitionMap
+  })
+  const filterMap = filterMapDefaultCompact({
+    URI,
+    _L,
+    map,
+    compact
+  })
+  const filter = filterDefaultFilterMap({
+    URI,
+    _L,
+    filterMap
+  })
+  return {
+    ...C,
+    map,
+    partitionMap,
+    filterMap,
+    partition,
+    filter
   }
 }
 

--- a/test/Array.ts
+++ b/test/Array.ts
@@ -225,18 +225,6 @@ describe('Array', () => {
     assert.deepEqual(modifyAt(as, 1, double), some([1, 4, 3]))
   })
 
-  it('mapOption', () => {
-    const f = (a: number) => (a % 2 === 0 ? none : some(a))
-    assert.deepEqual(mapOption([], f), [])
-    assert.deepEqual(mapOption(as, f), [1, 3])
-  })
-
-  it('catOptions', () => {
-    assert.deepEqual(catOptions([]), [])
-    assert.deepEqual(catOptions([some(1), some(2), some(3)]), [1, 2, 3])
-    assert.deepEqual(catOptions([some(1), none, some(3)]), [1, 3])
-  })
-
   it('sort', () => {
     assert.deepEqual(sort(ordNumber)([3, 2, 1]), [1, 2, 3])
   })
@@ -272,11 +260,6 @@ describe('Array', () => {
     assert.deepEqual(flatten([[1], [2], [3]]), [1, 2, 3])
   })
 
-  it('partitionMap', () => {
-    assert.deepEqual(partitionMap([], x => x), { left: [], right: [] })
-    assert.deepEqual(partitionMap([right(1), left('foo'), right(2)], x => x), { left: ['foo'], right: [1, 2] })
-  })
-
   it('rotate', () => {
     assert.deepEqual(rotate(1, []), [])
     assert.deepEqual(rotate(1, [1]), [1])
@@ -287,10 +270,6 @@ describe('Array', () => {
     assert.deepEqual(rotate(2, [1, 2, 3, 4, 5]), [4, 5, 1, 2, 3])
     assert.deepEqual(rotate(-1, [1, 2, 3, 4, 5]), [2, 3, 4, 5, 1])
     assert.deepEqual(rotate(-2, [1, 2, 3, 4, 5]), [3, 4, 5, 1, 2])
-  })
-
-  it('filter', () => {
-    assert.deepEqual(filter([1, 2, 3], n => n % 2 === 1), [1, 3])
   })
 
   it('map', () => {
@@ -436,14 +415,43 @@ describe('Array', () => {
     ])
   })
 
-  it('compact', () => {
+  it('compact/catOptions', () => {
     assert.deepEqual(array.compact([]), [])
     assert.deepEqual(array.compact([some(1), some(2), some(3)]), [1, 2, 3])
     assert.deepEqual(array.compact([some(1), none, some(3)]), [1, 3])
+    assert.deepEqual(catOptions([]), [])
+    assert.deepEqual(catOptions([some(1), some(2), some(3)]), [1, 2, 3])
+    assert.deepEqual(catOptions([some(1), none, some(3)]), [1, 3])
   })
 
   it('separate', () => {
     assert.deepEqual(array.separate([]), { left: [], right: [] })
     assert.deepEqual(array.separate([left(123), right('123')]), { left: [123], right: ['123'] })
+  })
+
+  it('filter', () => {
+    assert.deepEqual(filter([1, 2, 3], n => n % 2 === 1), [1, 3])
+    assert.deepEqual(array.filter([1, 2, 3], n => n % 2 === 1), [1, 3])
+  })
+
+  it('filterMap/mapOption', () => {
+    const f = (a: number) => (a % 2 === 0 ? none : some(a))
+    assert.deepEqual(mapOption([], f), [])
+    assert.deepEqual(mapOption(as, f), [1, 3])
+    assert.deepEqual(array.filterMap([], f), [])
+    assert.deepEqual(array.filterMap(as, f), [1, 3])
+  })
+
+  it('partitionMap', () => {
+    assert.deepEqual(partitionMap([], x => x), { left: [], right: [] })
+    assert.deepEqual(partitionMap([right(1), left('foo'), right(2)], x => x), { left: ['foo'], right: [1, 2] })
+    assert.deepEqual(array.partitionMap([], x => x), { left: [], right: [] })
+    assert.deepEqual(array.partitionMap([right(1), left('foo'), right(2)], x => x), { left: ['foo'], right: [1, 2] })
+  })
+
+  it('partition', () => {
+    const p = (n: number) => n > 2
+    assert.deepEqual(array.partition([], p), { left: [], right: [] })
+    assert.deepEqual(array.partition([1, 3], p), { left: [1], right: [3] })
   })
 })

--- a/test/Either.ts
+++ b/test/Either.ts
@@ -14,7 +14,8 @@ import {
   isLeft,
   isRight,
   fromRefinement,
-  getCompactable
+  getCompactable,
+  getFilterable
 } from '../src/Either'
 import { none, option, some } from '../src/Option'
 import { setoidNumber, setoidString } from '../src/Setoid'
@@ -285,6 +286,39 @@ describe('Either', () => {
       assert.deepEqual(C.separate(left('123')), { left: left('123'), right: left('123') })
       assert.deepEqual(C.separate(right(left('123'))), { left: right('123'), right: left(monoidString.empty) })
       assert.deepEqual(C.separate(right(right('123'))), { left: left(monoidString.empty), right: right('123') })
+    })
+  })
+
+  describe('getFilterable', () => {
+    const F = getFilterable(monoidString)
+    const p = (n: number) => n > 2
+    it('partition', () => {
+      assert.deepEqual(F.partition(left<string, number>('123'), p), {
+        left: left('123'),
+        right: left('123')
+      })
+      assert.deepEqual(F.partition(right<string, number>(1), p), { left: right(1), right: left(monoidString.empty) })
+      assert.deepEqual(F.partition(right<string, number>(3), p), { left: left(monoidString.empty), right: right(3) })
+    })
+    it('partitionMap', () => {
+      const f = (n: number) => (p(n) ? right(n + 1) : left(n - 1))
+      assert.deepEqual(F.partitionMap(left<string, number>('123'), f), {
+        left: left('123'),
+        right: left('123')
+      })
+      assert.deepEqual(F.partitionMap(right<string, number>(1), f), { left: right(0), right: left(monoidString.empty) })
+      assert.deepEqual(F.partitionMap(right<string, number>(3), f), { left: left(monoidString.empty), right: right(4) })
+    })
+    it('filter', () => {
+      assert.deepEqual(F.filter(left<string, number>('123'), p), left('123'))
+      assert.deepEqual(F.filter(right<string, number>(1), p), left(monoidString.empty))
+      assert.deepEqual(F.filter(right<string, number>(3), p), right(3))
+    })
+    it('filterMap', () => {
+      const f = (n: number) => (p(n) ? some(n + 1) : none)
+      assert.deepEqual(F.filterMap(left<string, number>('123'), f), left('123'))
+      assert.deepEqual(F.filterMap(right<string, number>(1), f), left(monoidString.empty))
+      assert.deepEqual(F.filterMap(right<string, number>(3), f), right(4))
     })
   })
 })

--- a/test/Either.ts
+++ b/test/Either.ts
@@ -15,13 +15,16 @@ import {
   isRight,
   fromRefinement,
   getCompactable,
-  getFilterable
+  getFilterable,
+  eitherBool
 } from '../src/Either'
 import { none, option, some } from '../src/Option'
 import { setoidNumber, setoidString } from '../src/Setoid'
 import { traverse } from '../src/Traversable'
 import { failure, success } from '../src/Validation'
 import { monoidString } from '../src/Monoid'
+
+const p = (n: number) => n > 2
 
 describe('Either', () => {
   it('fold', () => {
@@ -41,10 +44,9 @@ describe('Either', () => {
 
   it('bimap', () => {
     const f = (s: string): number => s.length
-    const g = (n: number): boolean => n > 2
-    assert.deepEqual(right<string, number>(1).bimap(f, g), right(false))
-    assert.deepEqual(left<string, number>('foo').bimap(f, g), left(3))
-    assert.deepEqual(either.bimap(right<string, number>(1), f, g), right(false))
+    assert.deepEqual(right<string, number>(1).bimap(f, p), right(false))
+    assert.deepEqual(left<string, number>('foo').bimap(f, p), left(3))
+    assert.deepEqual(either.bimap(right<string, number>(1), f, p), right(false))
   })
 
   it('ap', () => {
@@ -274,6 +276,12 @@ describe('Either', () => {
     assert.deepEqual(from('foo'), left('invalid color foo'))
   })
 
+  it('eitherBool', () => {
+    const eitherP = eitherBool(p)
+    assert.deepEqual(eitherP(1), left(1))
+    assert.deepEqual(eitherP(3), right(3))
+  })
+
   describe('getCompactable', () => {
     const C = getCompactable(monoidString)
     it('compact', () => {
@@ -291,7 +299,6 @@ describe('Either', () => {
 
   describe('getFilterable', () => {
     const F = getFilterable(monoidString)
-    const p = (n: number) => n > 2
     it('partition', () => {
       assert.deepEqual(F.partition(left<string, number>('123'), p), {
         left: left('123'),

--- a/test/Filterable.ts
+++ b/test/Filterable.ts
@@ -1,11 +1,9 @@
 import * as assert from 'assert'
 import {
-  eitherBool,
   filterDefaultFilterMap,
   filterDefaultPartition,
   filterDefaultPartitionMap,
   filterMapDefaultCompact,
-  optionBool,
   partitionDefaultFilter,
   partitionDefaultFilterMap,
   partitionDefaultPartitionMap,
@@ -17,19 +15,6 @@ import { none, some } from '../src/Option'
 
 describe('Filterable', () => {
   const p = (n: number) => n > 2
-
-  it('optionBool', () => {
-    const optionP = optionBool(p)
-    assert.deepEqual(optionP(1), none)
-    assert.deepEqual(optionP(3), some(3))
-  })
-
-  it('eitherBool', () => {
-    const p = (n: number) => n > 2
-    const eitherP = eitherBool(p)
-    assert.deepEqual(eitherP(1), left(1))
-    assert.deepEqual(eitherP(3), right(3))
-  })
 
   it('partitionMapDefaultSeparate', () => {
     const { URI, map, separate } = array

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -245,15 +245,6 @@ describe('Option', () => {
     assert.equal(some(2).exists(is2), true)
   })
 
-  it('filter', () => {
-    const x: Option<number> = none
-    const is2 = (a: number) => a === 2
-    assert.equal(x.filter(is2), x)
-    assert.equal(some(1).filter(is2), none)
-    const some2 = some(2)
-    assert.equal(some2.filter(is2), some2)
-  })
-
   it('refine', () => {
     const x: Option<number | string> = none
     const isString = (a: any): a is string => typeof a === 'string'
@@ -305,5 +296,37 @@ describe('Option', () => {
     const optionP = optionBool(p)
     assert.deepEqual(optionP(1), none)
     assert.deepEqual(optionP(3), some(3))
+  })
+
+  it('partition', () => {
+    assert.deepEqual(option.partition(none, p), { left: none, right: none })
+    assert.deepEqual(option.partition(some(1), p), { left: some(1), right: none })
+    assert.deepEqual(option.partition(some(3), p), { left: none, right: some(3) })
+  })
+
+  it('partitionMap', () => {
+    const f = (n: number) => (p(n) ? right(n + 1) : left(n - 1))
+    assert.deepEqual(option.partitionMap(none, f), { left: none, right: none })
+    assert.deepEqual(option.partitionMap(some(1), f), { left: some(0), right: none })
+    assert.deepEqual(option.partitionMap(some(3), f), { left: none, right: some(4) })
+  })
+
+  it('filter', () => {
+    const x: Option<number> = none
+    const is2 = (a: number) => a === 2
+    assert.equal(x.filter(is2), x)
+    assert.equal(option.filter(x, is2), x)
+    assert.equal(some(1).filter(is2), none)
+    assert.equal(option.filter(some(1), is2), none)
+    const some2 = some(2)
+    assert.equal(some2.filter(is2), some2)
+    assert.equal(option.filter(some2, is2), some2)
+  })
+
+  it('filterMap', () => {
+    const f = (n: number) => (p(n) ? some(n + 1) : none)
+    assert.deepEqual(option.filterMap(none, f), none)
+    assert.deepEqual(option.filterMap(some(1), f), none)
+    assert.deepEqual(option.filterMap(some(3), f), some(4))
   })
 })

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -17,7 +17,8 @@ import {
   none,
   option,
   some,
-  tryCatch
+  tryCatch,
+  optionBool
 } from '../src/Option'
 import { ordString } from '../src/Ord'
 import { semigroupString } from '../src/Semigroup'
@@ -298,5 +299,11 @@ describe('Option', () => {
     assert.deepEqual(option.separate(none), { left: none, right: none })
     assert.deepEqual(option.separate(some(left('123'))), { left: some('123'), right: none })
     assert.deepEqual(option.separate(some(right('123'))), { left: none, right: some('123') })
+  })
+
+  it('optionBool', () => {
+    const optionP = optionBool(p)
+    assert.deepEqual(optionP(1), none)
+    assert.deepEqual(optionP(3), some(3))
   })
 })

--- a/test/Set.ts
+++ b/test/Set.ts
@@ -27,7 +27,6 @@ import {
 } from '../src/Set'
 import { Setoid, setoidNumber, setoidString } from '../src/Setoid'
 import { none, option } from '../src/Option'
-import { separated } from '../src/Compactable'
 
 const gte2 = (n: number) => n >= 2
 
@@ -171,6 +170,9 @@ describe('Set', () => {
   })
 
   it('separate', () => {
-    assert.deepEqual(set.separate(new Set([left('123'), right(123)])), separated(new Set(['123']), new Set([123])))
+    assert.deepEqual(set.separate(new Set([left('123'), right(123)])), {
+      left: new Set(['123']),
+      right: new Set([123])
+    })
   })
 })

--- a/test/Set.ts
+++ b/test/Set.ts
@@ -18,6 +18,7 @@ import {
   partitionMap,
   reduce,
   remove,
+  set,
   singleton,
   some,
   subset,
@@ -25,6 +26,8 @@ import {
   union
 } from '../src/Set'
 import { Setoid, setoidNumber, setoidString } from '../src/Setoid'
+import { none, option } from '../src/Option'
+import { separated } from '../src/Compactable'
 
 const gte2 = (n: number) => n >= 2
 
@@ -161,5 +164,13 @@ describe('Set', () => {
     assert.deepEqual(fromArray(setoidNumber)([1, 2]), new Set([1, 2]))
 
     assert.deepEqual(fromArray(fooSetoid)(['a', 'a', 'b'].map(foo)), new Set(['a', 'b'].map(foo)))
+  })
+
+  it('compact', () => {
+    assert.deepEqual(set.compact(new Set([option.of(1), none])), new Set([1]))
+  })
+
+  it('separate', () => {
+    assert.deepEqual(set.separate(new Set([left('123'), right(123)])), separated(new Set(['123']), new Set([123])))
   })
 })

--- a/test/Set.ts
+++ b/test/Set.ts
@@ -7,7 +7,6 @@ import {
   every,
   filter,
   fromArray,
-  getCompactable,
   getIntersectionSemigroup,
   getSetoid,
   getUnionMonoid,
@@ -26,7 +25,6 @@ import {
   union
 } from '../src/Set'
 import { Setoid, setoidNumber, setoidString } from '../src/Setoid'
-import { none, option } from '../src/Option'
 
 const gte2 = (n: number) => n >= 2
 
@@ -163,19 +161,5 @@ describe('Set', () => {
     assert.deepEqual(fromArray(setoidNumber)([1, 2]), new Set([1, 2]))
 
     assert.deepEqual(fromArray(fooSetoid)(['a', 'a', 'b'].map(foo)), new Set(['a', 'b'].map(foo)))
-  })
-
-  describe('getCompactable', () => {
-    const C = getCompactable(setoidNumber, setoidString, setoidNumber)
-    it('compact', () => {
-      assert.deepEqual(C.compact(new Set([option.of(1), none])), new Set([1]))
-    })
-
-    it('separate', () => {
-      assert.deepEqual(C.separate(new Set([left('123'), right(123)])), {
-        left: new Set(['123']),
-        right: new Set([123])
-      })
-    })
   })
 })

--- a/test/Set.ts
+++ b/test/Set.ts
@@ -7,6 +7,7 @@ import {
   every,
   filter,
   fromArray,
+  getCompactable,
   getIntersectionSemigroup,
   getSetoid,
   getUnionMonoid,
@@ -18,7 +19,6 @@ import {
   partitionMap,
   reduce,
   remove,
-  set,
   singleton,
   some,
   subset,
@@ -165,14 +165,17 @@ describe('Set', () => {
     assert.deepEqual(fromArray(fooSetoid)(['a', 'a', 'b'].map(foo)), new Set(['a', 'b'].map(foo)))
   })
 
-  it('compact', () => {
-    assert.deepEqual(set.compact(new Set([option.of(1), none])), new Set([1]))
-  })
+  describe('getCompactable', () => {
+    const C = getCompactable(setoidNumber, setoidString, setoidNumber)
+    it('compact', () => {
+      assert.deepEqual(C.compact(new Set([option.of(1), none])), new Set([1]))
+    })
 
-  it('separate', () => {
-    assert.deepEqual(set.separate(new Set([left('123'), right(123)])), {
-      left: new Set(['123']),
-      right: new Set([123])
+    it('separate', () => {
+      assert.deepEqual(C.separate(new Set([left('123'), right(123)])), {
+        left: new Set(['123']),
+        right: new Set([123])
+      })
     })
   })
 })


### PR DESCRIPTION
Part of https://github.com/gcanti/fp-ts/pull/485
Wait for https://github.com/gcanti/fp-ts/pull/488 and https://github.com/gcanti/fp-ts/pull/489 to be merged first

Adds:
  - `Filterable` instance for `Array`
  - `Filterable` instance for `Either` (`getFilterable` using `Monoid`)
  - `Filterable` instance for `Option`
  - `Filterable` instance for `Validation` (`getFilterable` using `Monoid`)

Changes:
  - Compactable methods signature for `-2C` and `-3C` to require `_L` and `_U`