### PR TITLE
New Feature: add Option.getRefinement

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "jest-coverage": "jest --ci --coverage",
     "prettier": "prettier --list-different \"./{src,test,examples,exercises}/**/*.ts\"",
     "fix-prettier": "prettier --write \"./{src,test,examples,exercises}/**/*.ts\"",
-    "typings": "typings-checker --project ./typings-checker/tsconfig.json ./typings-checker/index.ts",
+    "typings": "typings-checker --allow-expect-error --project ./typings-checker/tsconfig.json ./typings-checker/index.ts",
     "test": "npm run lint && npm run prettier && npm run typings && npm run jest",
     "clean": "rimraf lib/*",
     "build": "npm run clean && tsc",

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -557,6 +557,26 @@ export const isNone = <A>(fa: Option<A>): fa is None<A> => {
 export const fromRefinement = <A, B extends A>(refinement: Refinement<A, B>) => (a: A): Option<B> => {
   return refinement(a) ? some(a) : none
 }
+
+/**
+ * Returns a refinement from a prism.
+ * This function ensures that a custom type guard definition is type-safe.
+ *
+ * @example
+ * type A = { type: 'A' }
+ * type B = { type: 'B' }
+ * type C = A | B
+ *
+ * const isA = (c: C): c is A => c.type === 'B' // <= typo but typescript doesn't complain
+ * const isA = getRefinement<C, A>(c => (c.type === 'B' ? some(c) : none)) // static error: Type '"B"' is not assignable to type '"A"'
+ *
+ * @function
+ * @since 1.7.0
+ */
+export const getRefinement = <A, B extends A>(getOption: (a: A) => Option<B>): Refinement<A, B> => {
+  return (a: A): a is B => getOption(a).isSome()
+}
+
 const compact = <A>(fa: Option<Option<A>>): Option<A> => fa.chain(identity)
 const separate = <RL, RR>(fa: Option<Either<RL, RR>>): Separated<Option<RL>, Option<RR>> => {
   if (fa.isNone()) {

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -17,7 +17,8 @@ import {
   none,
   option,
   some,
-  tryCatch
+  tryCatch,
+  getRefinement
 } from '../src/Option'
 import { ordString } from '../src/Ord'
 import { semigroupString } from '../src/Semigroup'
@@ -338,5 +339,18 @@ describe('Option', () => {
     assert.deepEqual(wiltIdentity(none, f), new Identity({ left: none, right: none }))
     assert.deepEqual(wiltIdentity(some(1), f), new Identity({ left: some(0), right: none }))
     assert.deepEqual(wiltIdentity(some(3), f), new Identity({ left: none, right: some(4) }))
+  })
+
+  it('getRefinement', () => {
+    const f = (s: string | number): Option<string> => (typeof s === 'string' ? some(s) : none)
+    const isString = getRefinement(f)
+    assert.strictEqual(isString('s'), true)
+    assert.strictEqual(isString(1), false)
+    type A = { type: 'A' }
+    type B = { type: 'B' }
+    type C = A | B
+    const isA = getRefinement<C, A>(c => (c.type === 'A' ? some(c) : none))
+    assert.strictEqual(isA({ type: 'A' }), true)
+    assert.strictEqual(isA({ type: 'B' }), false)
   })
 })

--- a/typings-checker/index.ts
+++ b/typings-checker/index.ts
@@ -6,7 +6,7 @@ import { Const, const_ } from '../src/Const'
 import { Either, either } from '../src/Either'
 import { Functor2C, Functor3C, lift } from '../src/Functor'
 import { getMonad as getIxIOMonad } from '../src/IxIO'
-import { Option, option } from '../src/Option'
+import { Option, option, getRefinement, some, none } from '../src/Option'
 import * as optionT from '../src/OptionT'
 import { Reader, reader } from '../src/Reader'
 import { getArraySemigroup, semigroupString } from '../src/Semigroup'
@@ -99,3 +99,11 @@ declare function apiForTaskify(path: string, callback: (err: Error | null | unde
 const apiTaskified = taskify(apiForTaskify)
 
 type S1 = AssertEquals<typeof apiTaskified, (a: string) => TaskEither<Error, string>, 'T'>
+
+// getRefinement
+
+type A = { type: 'A' }
+type B = { type: 'B' }
+type C = A | B
+// $ExpectError Type '"B"' is not assignable to type '"A"'
+const isA = getRefinement<C, A>(c => c.type === 'B' ? some(c) : none)


### PR DESCRIPTION
This function can be used to ensure that a custom type definition is type safe.

Example

```ts
type A = { type: 'A' }
type B = { type: 'B' }
type C = A | B

const isA = (c: C): c is A => c.type === 'B' // <= typo but typescript doesn't complain
const isA = getRefinement<C, A>(c => (c.type === 'B' ? some(c) : none)) // static error: Type '"B"' is not assignable to type '"A"'
```

The trick is to force typescript to check that the refinement is correct in `c.type === 'B' ? some(c) : none`