### PR TITLE
Internal: fix upstream weird behaviour when type checking Type with w…

### DIFF
--- a/src/HKT.ts
+++ b/src/HKT.ts
@@ -25,9 +25,9 @@ export type URIS3 = (URI2HKT3<any, any, any> & { never: HKT<never, never> })[
   | keyof URI2HKT3<any, any, any>
   | 'never']['_URI']
 
-export type Type<URI extends URIS, A> = URI2HKT<A>[URI]
-export type Type2<URI extends URIS2, L, A> = URI2HKT2<L, A>[URI]
-export type Type3<URI extends URIS3, U, L, A> = URI2HKT3<U, L, A>[URI]
+export type Type<URI extends URIS, A> = {} & URI2HKT<A>[URI]
+export type Type2<URI extends URIS2, L, A> = {} & URI2HKT2<L, A>[URI]
+export type Type3<URI extends URIS3, U, L, A> = {} & URI2HKT3<U, L, A>[URI]
 
 // Type-level integrity check
 

--- a/typings-checker/index.ts
+++ b/typings-checker/index.ts
@@ -16,6 +16,7 @@ import { sequence } from '../src/Traversable'
 import { replicateA } from '../src/Unfoldable'
 import { Validation, getApplicative, validation } from '../src/Validation'
 import { taskify, TaskEither } from '../src/TaskEither'
+import { Type } from '../src/HKT'
 
 type Equals<A, B> = [A] extends [B] ? ([B] extends [A] ? 'T' : 'F') : 'F'
 
@@ -107,3 +108,8 @@ type B = { type: 'B' }
 type C = A | B
 // $ExpectError Type '"B"' is not assignable to type '"A"'
 const isA = getRefinement<C, A>(c => (c.type === 'B' ? some(c) : none))
+
+// HKT
+
+// $ExpectError Type '"a"' does not satisfy the constraint
+type HKT1 = Type<'a', string>


### PR DESCRIPTION
…rong URI

Without this fix the following type-checks even if the provided URI is invalid

```ts
import { Type } from 'fp-ts/lib/HKT'

type T1 = Type<'a', string>
```