### PR TITLE
Add forEach to Option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fp-ts",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Functional programming in TypeScript",
   "files": [
     "lib"

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -230,6 +230,17 @@ export class None<A> {
   refine<B extends A>(refinement: Refinement<A, B>): Option<B> {
     return none
   }
+
+  /**
+   * Apply the given procedure f to the option's value, if it is nonempty.
+   * @example
+   * some('foo').forEach(console.log) // logs 'foo'
+   * none.forEach(console.log) // does nothing
+   * @since 1.8.0
+   */
+  forEach(f: (a: A) => void): void {
+    return
+  }
 }
 
 /**
@@ -311,6 +322,9 @@ export class Some<A> {
   }
   refine<B extends A>(refinement: Refinement<A, B>): Option<B> {
     return this.filter(refinement) as Option<B>
+  }
+  forEach(f: (a: A) => void): void {
+    f(this.value)
   }
 }
 
@@ -679,6 +693,17 @@ const wilt = <F>(F: Applicative<F>) => <RL, RR, A>(
       right: some(e.value)
     }
   })
+}
+
+/**
+ * Apply the given procedure f to the option's value, if it is nonempty.
+ * @example
+ * forEach(console.log, some('foo')) // logs 'foo'
+ * forEach(console.log, none) // does nothing
+ * @since 1.8.0
+ */
+export const forEach = <A>(f: (a: A) => void, fa: Option<A>): void => {
+  return fa.forEach(f)
 }
 
 /**

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -3,6 +3,7 @@ import { array } from '../src/Array'
 import { left, right } from '../src/Either'
 import {
   Option,
+  forEach,
   fromEither,
   fromNullable,
   fromPredicate,
@@ -370,5 +371,32 @@ describe('Option', () => {
     const isA = getRefinement<C, A>(c => (c.type === 'A' ? some(c) : none))
     assert.strictEqual(isA({ type: 'A' }), true)
     assert.strictEqual(isA({ type: 'B' }), false)
+  })
+
+  describe('forEach', () => {
+    const value: string = 'foo'
+    const noOp = jest.fn()
+    describe('method', () => {
+      afterEach(() => noOp.mockClear())
+      it('applies the procedure to a some’s value', () => {
+        some(value).forEach(noOp)
+        expect(noOp).toHaveBeenCalledWith(value)
+      })
+      it('does nothing to a none', () => {
+        none.forEach(noOp)
+        expect(noOp).not.toHaveBeenCalled()
+      })
+    })
+    describe('utility function', () => {
+      afterEach(() => noOp.mockClear())
+      it('applies the procedure to a some’s value', () => {
+        forEach(noOp, some(value))
+        expect(noOp).toHaveBeenCalledWith(value)
+      })
+      it('does nothing with a none', () => {
+        forEach(noOp, none)
+        expect(noOp).not.toHaveBeenCalled()
+      })
+    })
   })
 })


### PR DESCRIPTION
Scala's `Option` defines a `foreach` method:
https://www.scala-lang.org/api/current/scala/Option.html#foreach[U](f:A=%3EU):Unit

This PR adds and tests an analogous `forEach` method to both `Some` and `None` as well as provides a corresponding standalone `forEach` utility function.