### PR TITLE
`Array.last`: add support for `ReadonlyArray`

### DIFF
--- a/src/Array.ts
+++ b/src/Array.ts
@@ -361,7 +361,7 @@ export const head = <A>(as: Array<A>): Option<A> => {
  * @function
  * @since 1.0.0
  */
-export const last = <A>(as: Array<A>): Option<A> => {
+export const last = <A>(as: Array<A> | ReadonlyArray<A>): Option<A> => {
   return index(as.length - 1, as)
 }
 


### PR DESCRIPTION
Currently this function will error when trying to pass in an array of type `ReadonlyArray<T>`.

I suspect we'll want to make the same change for other functions which receive arrays… but it does seem like a PITA.