### PR TITLE
Skip emitting sourcemaps when publishing to npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fp-ts",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "npm run lint && npm run prettier && npm run typings && npm run jest",
     "clean": "rimraf lib/*",
     "build": "npm run clean && tsc",
-    "prepublish": "npm run clean && tsc --sourceMap false",
+    "prepublish": "npm run build",
     "docs": "rimraf docs/*.md && ts-node docs-generator/main.ts"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "npm run lint && npm run prettier && npm run typings && npm run jest",
     "clean": "rimraf lib/*",
     "build": "npm run clean && tsc",
+    "prepublish": "npm run clean && tsc --sourceMap false",
     "docs": "rimraf docs/*.md && ts-node docs-generator/main.ts"
   },
   "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "outDir": "./lib",
-    "sourceMap": true,
     "declaration": true,
     "target": "es5",
     "module": "commonjs",


### PR DESCRIPTION
I considered two ways to do this:

1. Change the `files` array to: `["lib/**/*.js", "lib/**/*.d.ts"]`.
2. Do not emit the sourcemaps when publishing to npm.

I went with the second choice to avoid having to update the `files` array if there was every anything else in `lib/` that needed to be included in the future. This also seems to more directly target the issue: don't publish the sourcemaps.

Also updated the package version in the `package-lock.json` which was surprising that it was not in-sync with the `package.json` value. 🤷‍♂️ 

**Not addressed in this PR**: The module structure has not changed, so `fp-ts/lib/Foo` is still the way to import sub-modules.

<details>
<summary>The output of <code>npm pack --dry-run</code>:</summary>
<br>

```
npm notice 
npm notice 📦  fp-ts@1.8.1
npm notice === Tarball Contents === 
npm notice 2.3kB  package.json                       
npm notice 20.1kB CHANGELOG.md                       
npm notice 1.1kB  LICENSE                            
npm notice 3.7kB  README.md                          
npm notice 1.5kB  lib/Alt.d.ts                       
npm notice 108B   lib/Alt.js                         
npm notice 1.2kB  lib/Alternative.d.ts               
npm notice 116B   lib/Alternative.js                 
npm notice 7.9kB  lib/Applicative.d.ts               
npm notice 2.1kB  lib/Applicative.js                 
npm notice 12.8kB lib/Apply.d.ts                     
npm notice 2.8kB  lib/Apply.js                       
npm notice 12.6kB lib/Array.d.ts                     
npm notice 19.4kB lib/Array.js                       
npm notice 818B   lib/Bifunctor.d.ts                 
npm notice 114B   lib/Bifunctor.js                   
npm notice 1.2kB  lib/BooleanAlgebra.d.ts            
npm notice 1.7kB  lib/BooleanAlgebra.js              
npm notice 470B   lib/Bounded.d.ts                   
npm notice 655B   lib/Bounded.js                     
npm notice 532B   lib/BoundedDistributiveLattice.d.ts
npm notice 814B   lib/BoundedDistributiveLattice.js  
npm notice 314B   lib/BoundedJoinSemilattice.d.ts    
npm notice 127B   lib/BoundedJoinSemilattice.js      
npm notice 508B   lib/BoundedLattice.d.ts            
npm notice 119B   lib/BoundedLattice.js              
npm notice 312B   lib/BoundedMeetSemilattice.d.ts    
npm notice 127B   lib/BoundedMeetSemilattice.js      
npm notice 649B   lib/Category.d.ts                  
npm notice 113B   lib/Category.js                    
npm notice 2.4kB  lib/Chain.d.ts                     
npm notice 288B   lib/Chain.js                       
npm notice 1.3kB  lib/ChainRec.d.ts                  
npm notice 282B   lib/ChainRec.js                    
npm notice 908B   lib/Comonad.d.ts                   
npm notice 112B   lib/Comonad.js                     
npm notice 2.9kB  lib/Compactable.d.ts               
npm notice 116B   lib/Compactable.js                 
npm notice 371B   lib/Console.d.ts                   
npm notice 881B   lib/Console.js                     
npm notice 1.3kB  lib/Const.d.ts                     
npm notice 2.1kB  lib/Const.js                       
npm notice 2.0kB  lib/Contravariant.d.ts             
npm notice 303B   lib/Contravariant.js               
npm notice 541B   lib/DistributiveLattice.d.ts       
npm notice 323B   lib/DistributiveLattice.js         
npm notice 11.1kB lib/Either.d.ts                    
npm notice 16.0kB lib/Either.js                      
npm notice 3.8kB  lib/EitherT.d.ts                   
npm notice 2.1kB  lib/EitherT.js                     
npm notice 1.1kB  lib/Exception.d.ts                 
npm notice 1.8kB  lib/Exception.js                   
npm notice 1.9kB  lib/Extend.d.ts                    
npm notice 317B   lib/Extend.js                      
npm notice 677B   lib/Field.d.ts                     
npm notice 1.0kB  lib/Field.js                       
npm notice 4.2kB  lib/Filterable.d.ts                
npm notice 115B   lib/Filterable.js                  
npm notice 17.2kB lib/Foldable.d.ts                  
npm notice 5.6kB  lib/Foldable.js                    
npm notice 4.5kB  lib/Free.d.ts                      
npm notice 3.5kB  lib/Free.js                        
npm notice 8.2kB  lib/function.d.ts                  
npm notice 4.7kB  lib/function.js                    
npm notice 7.1kB  lib/Functor.d.ts                   
npm notice 1.4kB  lib/Functor.js                     
npm notice 1.2kB  lib/HeytingAlgebra.d.ts            
npm notice 119B   lib/HeytingAlgebra.js              
npm notice 966B   lib/HKT.d.ts                       
npm notice 197B   lib/HKT.js                         
npm notice 1.7kB  lib/Identity.d.ts                  
npm notice 2.8kB  lib/Identity.js                    
npm notice 4.9kB  lib/index.d.ts                     
npm notice 5.5kB  lib/index.js                       
npm notice 1.2kB  lib/Invariant.d.ts                 
npm notice 114B   lib/Invariant.js                   
npm notice 1.3kB  lib/IO.d.ts                        
npm notice 2.7kB  lib/IO.js                          
npm notice 2.6kB  lib/IOEither.d.ts                  
npm notice 4.1kB  lib/IOEither.js                    
npm notice 642B   lib/IORef.d.ts                     
npm notice 1.2kB  lib/IORef.js                       
npm notice 1.0kB  lib/IxIO.d.ts                      
npm notice 1.7kB  lib/IxIO.js                        
npm notice 1.1kB  lib/IxMonad.d.ts                   
npm notice 599B   lib/IxMonad.js                     
npm notice 462B   lib/JoinSemilattice.d.ts           
npm notice 120B   lib/JoinSemilattice.js             
npm notice 438B   lib/Lattice.d.ts                   
npm notice 112B   lib/Lattice.js                     
npm notice 465B   lib/MeetSemilattice.d.ts           
npm notice 120B   lib/MeetSemilattice.js             
npm notice 1.3kB  lib/Monad.d.ts                     
npm notice 110B   lib/Monad.js                       
npm notice 2.3kB  lib/Monoid.d.ts                    
npm notice 3.4kB  lib/Monoid.js                      
npm notice 2.5kB  lib/Monoidal.d.ts                  
npm notice 934B   lib/Monoidal.js                    
npm notice 7.8kB  lib/NonEmptyArray.d.ts             
npm notice 10.5kB lib/NonEmptyArray.js               
npm notice 17.1kB lib/Option.d.ts                    
npm notice 18.7kB lib/Option.js                      
npm notice 5.9kB  lib/OptionT.d.ts                   
npm notice 2.0kB  lib/OptionT.js                     
npm notice 3.1kB  lib/Ord.d.ts                       
npm notice 4.3kB  lib/Ord.js                         
npm notice 491B   lib/Ordering.d.ts                  
npm notice 680B   lib/Ordering.js                    
npm notice 1.8kB  lib/Pair.d.ts                      
npm notice 3.3kB  lib/Pair.js                        
npm notice 1.3kB  lib/Plus.d.ts                      
npm notice 109B   lib/Plus.js                        
npm notice 1.6kB  lib/Profunctor.d.ts                
npm notice 483B   lib/Profunctor.js                  
npm notice 1.1kB  lib/Random.d.ts                    
npm notice 1.4kB  lib/Random.js                      
npm notice 1.3kB  lib/Reader.d.ts                    
npm notice 2.0kB  lib/Reader.js                      
npm notice 6.2kB  lib/ReaderT.d.ts                   
npm notice 1.4kB  lib/ReaderT.js                     
npm notice 4.4kB  lib/ReaderTaskEither.d.ts          
npm notice 5.9kB  lib/ReaderTaskEither.js            
npm notice 804B   lib/Ring.d.ts                      
npm notice 1.7kB  lib/Ring.js                        
npm notice 2.9kB  lib/Semigroup.d.ts                 
npm notice 4.6kB  lib/Semigroup.js                   
npm notice 779B   lib/Semigroupoid.d.ts              
npm notice 117B   lib/Semigroupoid.js                
npm notice 1.3kB  lib/Semiring.d.ts                  
npm notice 577B   lib/Semiring.js                    
npm notice 3.2kB  lib/Set.d.ts                       
npm notice 6.1kB  lib/Set.js                         
npm notice 1.5kB  lib/Setoid.d.ts                    
npm notice 1.7kB  lib/Setoid.js                      
npm notice 1.6kB  lib/State.d.ts                     
npm notice 2.7kB  lib/State.js                       
npm notice 8.0kB  lib/StateT.d.ts                    
npm notice 2.3kB  lib/StateT.js                      
npm notice 2.0kB  lib/Store.d.ts                     
npm notice 2.3kB  lib/Store.js                       
npm notice 4.9kB  lib/StrMap.d.ts                    
npm notice 9.3kB  lib/StrMap.js                      
npm notice 1.9kB  lib/Task.d.ts                      
npm notice 4.6kB  lib/Task.js                        
npm notice 4.4kB  lib/TaskEither.d.ts                
npm notice 6.7kB  lib/TaskEither.js                  
npm notice 4.3kB  lib/These.d.ts                     
npm notice 7.6kB  lib/These.js                       
npm notice 1.9kB  lib/Trace.d.ts                     
npm notice 1.2kB  lib/Trace.js                       
npm notice 11.6kB lib/Traversable.d.ts               
npm notice 1.4kB  lib/Traversable.js                 
npm notice 4.6kB  lib/Tree.d.ts                      
npm notice 6.0kB  lib/Tree.js                        
npm notice 2.7kB  lib/Tuple.d.ts                     
npm notice 4.9kB  lib/Tuple.js                       
npm notice 4.3kB  lib/Unfoldable.d.ts                
npm notice 2.1kB  lib/Unfoldable.js                  
npm notice 7.9kB  lib/Validation.d.ts                
npm notice 11.7kB lib/Validation.js                  
npm notice 15.2kB lib/Witherable.d.ts                
npm notice 115B   lib/Witherable.js                  
npm notice 1.6kB  lib/Writer.d.ts                    
npm notice 3.0kB  lib/Writer.js                      
npm notice === Tarball Details === 
npm notice name:          fp-ts                                   
npm notice version:       1.8.1                                   
npm notice filename:      fp-ts-1.8.1.tgz                         
npm notice package size:  89.9 kB                                 
npm notice unpacked size: 527.6 kB                                
npm notice shasum:        13f4ccb3b83ae875e9cf150d1eff9cec1c904c72
npm notice integrity:     sha512-TI8l8AMgImtpX[...]s62z58z5Xtyew==
npm notice total files:   164                                     
npm notice 
fp-ts-1.8.1.tgz
~/projects/fp-ts:master* λ npm run clean

> fp-ts@1.8.1 clean /Users/scotttrinh/projects/fp-ts
> rimraf lib/*

~/projects/fp-ts:master*? λ npx tsc --sourceMap false
~/projects/fp-ts:master*? λ npm run clean && npx tsc --sourceMap false

> fp-ts@1.8.1 clean /Users/scotttrinh/projects/fp-ts
> rimraf lib/*

~/projects/fp-ts:master* λ npm pack --dry-run
npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.

> fp-ts@1.8.1 prepublish /Users/scotttrinh/projects/fp-ts
> npm run clean && tsc --sourceMap false


> fp-ts@1.8.1 clean /Users/scotttrinh/projects/fp-ts
> rimraf lib/*

npm notice 
npm notice 📦  fp-ts@1.8.1
npm notice === Tarball Contents === 
npm notice 2.4kB  package.json                       
npm notice 20.1kB CHANGELOG.md                       
npm notice 1.1kB  LICENSE                            
npm notice 3.7kB  README.md                          
npm notice 1.5kB  lib/Alt.d.ts                       
npm notice 77B    lib/Alt.js                         
npm notice 1.2kB  lib/Alternative.d.ts               
npm notice 77B    lib/Alternative.js                 
npm notice 7.9kB  lib/Applicative.d.ts               
npm notice 2.0kB  lib/Applicative.js                 
npm notice 12.8kB lib/Apply.d.ts                     
npm notice 2.8kB  lib/Apply.js                       
npm notice 12.6kB lib/Array.d.ts                     
npm notice 19.4kB lib/Array.js                       
npm notice 818B   lib/Bifunctor.d.ts                 
npm notice 77B    lib/Bifunctor.js                   
npm notice 1.2kB  lib/BooleanAlgebra.d.ts            
npm notice 1.7kB  lib/BooleanAlgebra.js              
npm notice 470B   lib/Bounded.d.ts                   
npm notice 620B   lib/Bounded.js                     
npm notice 532B   lib/BoundedDistributiveLattice.d.ts
npm notice 760B   lib/BoundedDistributiveLattice.js  
npm notice 314B   lib/BoundedJoinSemilattice.d.ts    
npm notice 77B    lib/BoundedJoinSemilattice.js      
npm notice 508B   lib/BoundedLattice.d.ts            
npm notice 77B    lib/BoundedLattice.js              
npm notice 312B   lib/BoundedMeetSemilattice.d.ts    
npm notice 77B    lib/BoundedMeetSemilattice.js      
npm notice 649B   lib/Category.d.ts                  
npm notice 77B    lib/Category.js                    
npm notice 2.4kB  lib/Chain.d.ts                     
npm notice 255B   lib/Chain.js                       
npm notice 1.3kB  lib/ChainRec.d.ts                  
npm notice 246B   lib/ChainRec.js                    
npm notice 908B   lib/Comonad.d.ts                   
npm notice 77B    lib/Comonad.js                     
npm notice 2.9kB  lib/Compactable.d.ts               
npm notice 77B    lib/Compactable.js                 
npm notice 371B   lib/Console.d.ts                   
npm notice 846B   lib/Console.js                     
npm notice 1.3kB  lib/Const.d.ts                     
npm notice 2.1kB  lib/Const.js                       
npm notice 2.0kB  lib/Contravariant.d.ts             
npm notice 262B   lib/Contravariant.js               
npm notice 541B   lib/DistributiveLattice.d.ts       
npm notice 276B   lib/DistributiveLattice.js         
npm notice 11.1kB lib/Either.d.ts                    
npm notice 16.0kB lib/Either.js                      
npm notice 3.8kB  lib/EitherT.d.ts                   
npm notice 2.1kB  lib/EitherT.js                     
npm notice 1.1kB  lib/Exception.d.ts                 
npm notice 1.7kB  lib/Exception.js                   
npm notice 1.9kB  lib/Extend.d.ts                    
npm notice 283B   lib/Extend.js                      
npm notice 677B   lib/Field.d.ts                     
npm notice 975B   lib/Field.js                       
npm notice 4.2kB  lib/Filterable.d.ts                
npm notice 77B    lib/Filterable.js                  
npm notice 17.2kB lib/Foldable.d.ts                  
npm notice 5.5kB  lib/Foldable.js                    
npm notice 4.5kB  lib/Free.d.ts                      
npm notice 3.5kB  lib/Free.js                        
npm notice 8.2kB  lib/function.d.ts                  
npm notice 4.7kB  lib/function.js                    
npm notice 7.1kB  lib/Functor.d.ts                   
npm notice 1.4kB  lib/Functor.js                     
npm notice 1.2kB  lib/HeytingAlgebra.d.ts            
npm notice 77B    lib/HeytingAlgebra.js              
npm notice 966B   lib/HKT.d.ts                       
npm notice 166B   lib/HKT.js                         
npm notice 1.7kB  lib/Identity.d.ts                  
npm notice 2.8kB  lib/Identity.js                    
npm notice 4.9kB  lib/index.d.ts                     
npm notice 5.5kB  lib/index.js                       
npm notice 1.2kB  lib/Invariant.d.ts                 
npm notice 77B    lib/Invariant.js                   
npm notice 1.3kB  lib/IO.d.ts                        
npm notice 2.7kB  lib/IO.js                          
npm notice 2.6kB  lib/IOEither.d.ts                  
npm notice 4.1kB  lib/IOEither.js                    
npm notice 642B   lib/IORef.d.ts                     
npm notice 1.2kB  lib/IORef.js                       
npm notice 1.0kB  lib/IxIO.d.ts                      
npm notice 1.6kB  lib/IxIO.js                        
npm notice 1.1kB  lib/IxMonad.d.ts                   
npm notice 564B   lib/IxMonad.js                     
npm notice 462B   lib/JoinSemilattice.d.ts           
npm notice 77B    lib/JoinSemilattice.js             
npm notice 438B   lib/Lattice.d.ts                   
npm notice 77B    lib/Lattice.js                     
npm notice 465B   lib/MeetSemilattice.d.ts           
npm notice 77B    lib/MeetSemilattice.js             
npm notice 1.3kB  lib/Monad.d.ts                     
npm notice 77B    lib/Monad.js                       
npm notice 2.3kB  lib/Monoid.d.ts                    
npm notice 3.4kB  lib/Monoid.js                      
npm notice 2.5kB  lib/Monoidal.d.ts                  
npm notice 898B   lib/Monoidal.js                    
npm notice 7.8kB  lib/NonEmptyArray.d.ts             
npm notice 10.4kB lib/NonEmptyArray.js               
npm notice 17.1kB lib/Option.d.ts                    
npm notice 18.6kB lib/Option.js                      
npm notice 5.9kB  lib/OptionT.d.ts                   
npm notice 2.0kB  lib/OptionT.js                     
npm notice 3.1kB  lib/Ord.d.ts                       
npm notice 4.3kB  lib/Ord.js                         
npm notice 491B   lib/Ordering.d.ts                  
npm notice 644B   lib/Ordering.js                    
npm notice 1.8kB  lib/Pair.d.ts                      
npm notice 3.3kB  lib/Pair.js                        
npm notice 1.3kB  lib/Plus.d.ts                      
npm notice 77B    lib/Plus.js                        
npm notice 1.6kB  lib/Profunctor.d.ts                
npm notice 445B   lib/Profunctor.js                  
npm notice 1.1kB  lib/Random.d.ts                    
npm notice 1.4kB  lib/Random.js                      
npm notice 1.3kB  lib/Reader.d.ts                    
npm notice 1.9kB  lib/Reader.js                      
npm notice 6.2kB  lib/ReaderT.d.ts                   
npm notice 1.4kB  lib/ReaderT.js                     
npm notice 4.4kB  lib/ReaderTaskEither.d.ts          
npm notice 5.9kB  lib/ReaderTaskEither.js            
npm notice 804B   lib/Ring.d.ts                      
npm notice 1.6kB  lib/Ring.js                        
npm notice 2.9kB  lib/Semigroup.d.ts                 
npm notice 4.5kB  lib/Semigroup.js                   
npm notice 779B   lib/Semigroupoid.d.ts              
npm notice 77B    lib/Semigroupoid.js                
npm notice 1.3kB  lib/Semiring.d.ts                  
npm notice 541B   lib/Semiring.js                    
npm notice 3.2kB  lib/Set.d.ts                       
npm notice 6.1kB  lib/Set.js                         
npm notice 1.5kB  lib/Setoid.d.ts                    
npm notice 1.7kB  lib/Setoid.js                      
npm notice 1.6kB  lib/State.d.ts                     
npm notice 2.7kB  lib/State.js                       
npm notice 8.0kB  lib/StateT.d.ts                    
npm notice 2.3kB  lib/StateT.js                      
npm notice 2.0kB  lib/Store.d.ts                     
npm notice 2.2kB  lib/Store.js                       
npm notice 4.9kB  lib/StrMap.d.ts                    
npm notice 9.2kB  lib/StrMap.js                      
npm notice 1.9kB  lib/Task.d.ts                      
npm notice 4.6kB  lib/Task.js                        
npm notice 4.4kB  lib/TaskEither.d.ts                
npm notice 6.6kB  lib/TaskEither.js                  
npm notice 4.3kB  lib/These.d.ts                     
npm notice 7.6kB  lib/These.js                       
npm notice 1.9kB  lib/Trace.d.ts                     
npm notice 1.2kB  lib/Trace.js                       
npm notice 11.6kB lib/Traversable.d.ts               
npm notice 1.3kB  lib/Traversable.js                 
npm notice 4.6kB  lib/Tree.d.ts                      
npm notice 6.0kB  lib/Tree.js                        
npm notice 2.7kB  lib/Tuple.d.ts                     
npm notice 4.9kB  lib/Tuple.js                       
npm notice 4.3kB  lib/Unfoldable.d.ts                
npm notice 2.1kB  lib/Unfoldable.js                  
npm notice 7.9kB  lib/Validation.d.ts                
npm notice 11.7kB lib/Validation.js                  
npm notice 15.2kB lib/Witherable.d.ts                
npm notice 77B    lib/Witherable.js                  
npm notice 1.6kB  lib/Writer.d.ts                    
npm notice 3.0kB  lib/Writer.js                      
npm notice === Tarball Details === 
npm notice name:          fp-ts                                   
npm notice version:       1.8.1                                   
npm notice filename:      fp-ts-1.8.1.tgz                         
npm notice package size:  89.4 kB                                 
npm notice unpacked size: 524.7 kB                                
npm notice shasum:        d18f99d98dc7effb3931399d1efb90ef4864466a
npm notice integrity:     sha512-Z1US3QhLpYyos[...]spgr14KQd24bg==
npm notice total files:   164                                     
npm notice 
fp-ts-1.8.1.tgz
```
</details>