### PR TITLE
Add example to docs for Array.member function

### DIFF
--- a/docs/Array.md
+++ b/docs/Array.md
@@ -477,10 +477,17 @@ _Signature_
 ```ts
 <A>(S: Setoid<A>) => (as: Array<A>, a: A): boolean
 ```
+_Example_
+
+```ts
+member(stetoid.stetoidString)(['thing one', 'thing two', 'cat in the hat'], 'thing two') // true 
+```
 
 _Description_
 
-Test if a value is a member of an array
+Test if a value is a member of an array. Takes a `Stetoid<A>` as a single
+argument which returns the function to use to search for a value of type `A` in
+an array of types `<A>`.
 
 ### modifyAt
 

--- a/docs/Array.md
+++ b/docs/Array.md
@@ -477,17 +477,10 @@ _Signature_
 ```ts
 <A>(S: Setoid<A>) => (as: Array<A>, a: A): boolean
 ```
-_Example_
-
-```ts
-member(stetoid.stetoidString)(['thing one', 'thing two', 'cat in the hat'], 'thing two') // true 
-```
 
 _Description_
 
-Test if a value is a member of an array. Takes a `Stetoid<A>` as a single
-argument which returns the function to use to search for a value of type `A` in
-an array of types `<A>`.
+Test if a value is a member of an array
 
 ### modifyAt
 

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -705,7 +705,13 @@ export const rotate = <A>(n: number, xs: Array<A>): Array<A> => {
 }
 
 /**
- * Test if a value is a member of an array
+ * Test if a value is a member of an array. Takes a `Stetoid<A>` as a single
+ * argument which returns the function to use to search for a value of type `A` in
+ * an array of type `Array<A>`.
+ *
+ * @example
+ * member(stetoid.stetoidString)(['thing one', 'thing two', 'cat in the hat'], 'thing two') // true
+ *
  * @function
  * @since 1.3.0
  */

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -705,12 +705,14 @@ export const rotate = <A>(n: number, xs: Array<A>): Array<A> => {
 }
 
 /**
- * Test if a value is a member of an array. Takes a `Stetoid<A>` as a single
+ * Test if a value is a member of an array. Takes a `Setoid<A>` as a single
  * argument which returns the function to use to search for a value of type `A` in
  * an array of type `Array<A>`.
  *
  * @example
- * member(stetoid.stetoidString)(['thing one', 'thing two', 'cat in the hat'], 'thing two') // true
+ * import { setoidString } from 'fp-ts/lib/Setoid'
+ *
+ * member(setoidString)(['thing one', 'thing two', 'cat in the hat'], 'thing two') // true
  *
  * @function
  * @since 1.3.0


### PR DESCRIPTION
Hey there!

My team just started using this lib and I saw in #265 that you're taking PRs to help
improve the docs. I personally would love some examples for functions like `member` so
I thought I'd add one.

I'll be sure to throw up more PRs of examples as I go.

Great library!