### PR TITLE
getObjectSemigroup signature fix in docs

### DIFF
--- a/docs/Semigroup.md
+++ b/docs/Semigroup.md
@@ -159,7 +159,7 @@ Added in v1.0.0 (function)
 ## getObjectSemigroup
 
 ```ts
-;<A extends object = never>(): Semigroup<A> => semigroupAnyDictionary as any
+<A extends object = never>(): Semigroup<A> => semigroupAnyDictionary as any
 ```
 
 Added in v1.4.0 (function)


### PR DESCRIPTION
I assume the trailing semicolon is a typo. This will remove it from the signature of `getObjectSemigroup`.