### PR TITLE
Update generated docs, diff in update

### DIFF
--- a/docs/Foldable2v.md
+++ b/docs/Foldable2v.md
@@ -253,7 +253,7 @@ import { sequence_ } from 'fp-ts/lib/Foldable2v'
 import { io, IO } from 'fp-ts/lib/IO'
 
 let log = ''
-const append = (s: String) => new IO(() => (log += s))
+const append = (s: string) => new IO(() => (log += s))
 sequence_(io, array)([append('a'), append('b'), append('c')]).run()
 assert.strictEqual(log, 'abc')
 ```
@@ -321,7 +321,7 @@ import { traverse_ } from 'fp-ts/lib/Foldable2v'
 import { io, IO } from 'fp-ts/lib/IO'
 
 let log = ''
-const append = (s: String) => new IO(() => (log += s))
+const append = (s: string) => new IO(() => (log += s))
 traverse_(io, array)(['a', 'b', 'c'], append).run()
 assert.strictEqual(log, 'abc')
 ```


### PR DESCRIPTION
Checking out `master` and executing the `docs` script, I get a diff in the output. `string` is used over `String`, which looks like it would make sense.

Creating this commit mostly to raise awareness, as the diff shouldn't be the case in an ideal world ;)