### PR TITLE
Fix taskify with immutable arguments.

### DIFF
--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -331,8 +331,9 @@ export function taskify<L, R>(f: Function): () => TaskEither<L, R> {
       new Task(
         () =>
           new Promise(resolve => {
-            args.push((e: L, r: R) => (e != null ? resolve(eitherLeft<L, R>(e)) : resolve(eitherRight<L, R>(r))))
-            f.apply(null, args)
+            const cbResolver = (e: L, r: R) =>
+              e != null ? resolve(eitherLeft<L, R>(e)) : resolve(eitherRight<L, R>(r))
+            f.apply(null, args.concat(cbResolver))
           })
       )
     )

--- a/test/TaskEither.ts
+++ b/test/TaskEither.ts
@@ -255,6 +255,18 @@ describe('TaskEither', () => {
     )
   })
 
+  it('composed taskify', () => {
+    const api = (callback: (err: Error | null | undefined, result?: string) => void): void => {
+      callback(null, 'ok')
+    }
+    const taskApi = taskify(api)()
+
+    return Promise.all([taskApi.run(), taskApi.run()]).then(([e1, e2]) => {
+      assert.deepEqual(e1, eitherRight('ok'))
+      assert.deepEqual(e2, eitherRight('ok'))
+    })
+  })
+
   it('alt', () => {
     const l1 = fromLeft<string, number>('foo')
     const l2 = fromLeft<string, number>('bar')


### PR DESCRIPTION
`taskify` mutates the `args` adding a callback every time the task runs, causing the wrapping promise not being resolved. This PR fixes this behaviour.
