### PR TITLE
Pass read value to 'onrejected' handler for ReaderTaskEither's tryCatch

### DIFF
--- a/src/ReaderTaskEither.ts
+++ b/src/ReaderTaskEither.ts
@@ -238,9 +238,9 @@ export const fromPredicate = <E, L, A>(
  */
 export const tryCatch = <E, L, A>(
   f: (e: E) => Promise<A>,
-  onrejected: (reason: unknown) => L
+  onrejected: (reason: unknown, e: E) => L
 ): ReaderTaskEither<E, L, A> => {
-  return new ReaderTaskEither(e => taskEither.tryCatch(() => f(e), onrejected))
+  return new ReaderTaskEither(e => taskEither.tryCatch(() => f(e), (reason: unknown) => onrejected(reason, e)))
 }
 
 const fromTask = right


### PR DESCRIPTION
Now `tryCatch` from `ReaderTaskEither` pass the reader's value as the second argument to `onrejected` function.