### PR TITLE
Bug Fix: array.map should be safe when executed with a binary functio…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 **Note**: Gaps between patch versions are faulty/broken releases. **Note**: A feature tagged as Experimental is in a
 high state of flux, you're at risk of it changing without notice.
 
+# 1.12.1
+
+- **Bug Fix**
+  - `array.map` should be safe when executed with a binary function, fix #675 (@gcanti)
+
 # 1.12.0
 
 - **Deprecation**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fp-ts",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Functional programming in TypeScript",
   "files": [
     "lib"

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -115,7 +115,7 @@ export const getOrd = <A>(O: Ord<A>): Ord<Array<A>> => {
 }
 
 const map = <A, B>(fa: Array<A>, f: (a: A) => B): Array<B> => {
-  return fa.map(f)
+  return fa.map(a => f(a))
 }
 
 const mapWithIndex = <A, B>(fa: Array<A>, f: (index: number, a: A) => B): Array<B> => {

--- a/test/Array.ts
+++ b/test/Array.ts
@@ -717,4 +717,13 @@ describe('Array', () => {
     assert.deepEqual(difference(setoidNumber)([1, 2], [2, 3]), [1])
     assert.deepEqual(difference(setoidNumber)([1, 2], [1, 2]), [])
   })
+
+  it('should be safe when calling map with a binary function', () => {
+    interface Foo {
+      bar: () => number
+    }
+    const f = (a: number, x?: Foo) => (x !== undefined ? `${a}${x.bar()}` : `${a}`)
+    const res = array.map([1, 2], f)
+    assert.deepEqual(res, ['1', '2'])
+  })
 })


### PR DESCRIPTION
…n, fix #675
