### PR TITLE
FunctorWithIndex comment typo fix: `map` -> `mapWithIndex`

### DIFF
--- a/src/FunctorWithIndex.ts
+++ b/src/FunctorWithIndex.ts
@@ -20,7 +20,7 @@ import {
 } from './Functor'
 
 /**
- * A `FunctorWithIndex` is a type constructor which supports a mapping operation `map`.
+ * A `FunctorWithIndex` is a type constructor which supports a mapping operation `mapWithIndex`.
  *
  * `mapWithIndex` can be used to turn functions `i -> a -> b` into functions `f a -> f b` whose argument and return types use the type
  * constructor `f` to represent some computational context.


### PR DESCRIPTION
I think this was a mistake. Just correcting what appeared to be a typo.