### PR TITLE
Deprecated inspect() replaced with symbol keyed function.

### DIFF
--- a/src/Const.ts
+++ b/src/Const.ts
@@ -36,7 +36,7 @@ export class Const<L, A> {
   fold<B>(f: (l: L) => B): B {
     return f(this.value)
   }
-  inspect(): string {
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
     return this.toString()
   }
   toString(): string {

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -128,7 +128,7 @@ export class Left<L, A> {
   mapLeft<M>(f: (l: L) => M): Either<M, A> {
     return new Left(f(this.value))
   }
-  inspect(): string {
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
     return this.toString()
   }
   toString(): string {
@@ -241,7 +241,7 @@ export class Right<L, A> {
   mapLeft<M>(f: (l: L) => M): Either<M, A> {
     return new Right(this.value)
   }
-  inspect(): string {
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
     return this.toString()
   }
   toString(): string {

--- a/src/Free.ts
+++ b/src/Free.ts
@@ -44,7 +44,7 @@ export class Pure<F, A> {
   chain<B>(f: (a: A) => Free<F, B>): Free<F, B> {
     return f(this.value)
   }
-  inspect(): string {
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
     return this.toString()
   }
   toString(): string {
@@ -76,7 +76,7 @@ export class Impure<F, A, X> {
   chain<B>(f: (a: A) => Free<F, B>): Free<F, B> {
     return new Impure(this.fx, x => this.f(x).chain(f))
   }
-  inspect(): string {
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
     return this.toString()
   }
   toString(): string {

--- a/src/IO.ts
+++ b/src/IO.ts
@@ -54,7 +54,7 @@ export class IO<A> {
   chain<B>(f: (a: A) => IO<B>): IO<B> {
     return new IO(() => f(this.run()).run())
   }
-  inspect(): string {
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
     return this.toString()
   }
   toString(): string {

--- a/src/Identity.ts
+++ b/src/Identity.ts
@@ -75,7 +75,7 @@ export class Identity<A> {
   fold<B>(f: (a: A) => B): B {
     return f(this.value)
   }
-  inspect(): string {
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
     return this.toString()
   }
   toString(): string {

--- a/src/NonEmptyArray.ts
+++ b/src/NonEmptyArray.ts
@@ -193,7 +193,7 @@ export class NonEmptyArray<A> {
   /**
    * Same as {@link toString}
    */
-  inspect(): string {
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
     return this.toString()
   }
 

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -279,7 +279,7 @@ export class None<A> {
   toUndefined(): A | undefined {
     return undefined
   }
-  inspect(): string {
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
     return this.toString()
   }
   toString(): string {
@@ -381,7 +381,7 @@ export class Some<A> {
   toUndefined(): A | undefined {
     return this.value
   }
-  inspect(): string {
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
     return this.toString()
   }
   toString(): string {

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -36,7 +36,7 @@ export class Store<S, A> {
   extend<B>(f: (sa: Store<S, A>) => B): Store<S, B> {
     return new Store(s => f(this.seek(s)), this.pos)
   }
-  inspect(): string {
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
     return this.toString()
   }
   toString(): string {

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -57,7 +57,7 @@ export class Task<A> {
   chain<B>(f: (a: A) => Task<B>): Task<B> {
     return new Task(() => this.run().then(a => f(a).run()))
   }
-  inspect(): string {
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
     return this.toString()
   }
   toString(): string {

--- a/src/These.ts
+++ b/src/These.ts
@@ -68,7 +68,7 @@ export class This<L, A> {
   fold<B>(this_: (l: L) => B, that: (a: A) => B, both: (l: L, a: A) => B): B {
     return this_(this.value)
   }
-  inspect(): string {
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
     return this.toString()
   }
   toString(): string {
@@ -106,7 +106,7 @@ export class That<L, A> {
   fold<B>(this_: (l: L) => B, that: (a: A) => B, both: (l: L, a: A) => B): B {
     return that(this.value)
   }
-  inspect(): string {
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
     return this.toString()
   }
   toString(): string {
@@ -141,7 +141,7 @@ export class Both<L, A> {
   fold<B>(this_: (l: L) => B, that: (a: A) => B, both: (l: L, a: A) => B): B {
     return both(this.l, this.a)
   }
-  inspect(): string {
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
     return this.toString()
   }
   toString(): string {

--- a/src/Tree.ts
+++ b/src/Tree.ts
@@ -67,7 +67,7 @@ export class Tree<A> {
     }
     return r
   }
-  inspect(): string {
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
     return this.toString()
   }
   toString(): string {

--- a/src/Tuple.ts
+++ b/src/Tuple.ts
@@ -60,7 +60,7 @@ export class Tuple<L, A> {
   swap(): Tuple<A, L> {
     return new Tuple(this.snd, this.fst)
   }
-  inspect(): string {
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
     return this.toString()
   }
   toString(): string {

--- a/src/Validation.ts
+++ b/src/Validation.ts
@@ -108,7 +108,7 @@ export class Failure<L, A> {
   swap(): Validation<A, L> {
     return new Success(this.value)
   }
-  inspect(): string {
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
     return this.toString()
   }
   toString(): string {
@@ -154,7 +154,7 @@ export class Success<L, A> {
   swap(): Validation<A, L> {
     return new Failure(this.value)
   }
-  inspect(): string {
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
     return this.toString()
   }
   toString(): string {

--- a/src/Zipper.ts
+++ b/src/Zipper.ts
@@ -170,7 +170,7 @@ export class Zipper<A> {
   reduce<B>(b: B, f: (b: B, a: A) => B): B {
     return this.rights.reduce(f, f(this.lefts.reduce(f, b), this.focus))
   }
-  inspect(): string {
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
     return this.toString()
   }
   toString(): string {


### PR DESCRIPTION
One possible solution to #408 is to replace the inspect member functions with functions keyed on the appropriate symbol (as this pull request does). It also uses the `Symbol.for` approach, as this shouldn't error if the symbol doesn't exist, simply create a new symbol in the global symbol registry (in a browser, this would probably be the case).

I'm not personally sure of the status of support for custom inspection across browsers (or the mechanism). I can't see any sign of support, in which case this might well be effectively "no change" for browsers, but a fix for Node as the runtime.