### PR TITLE
Handle unwanted behaviour when an IO throws an error.

### DIFF
--- a/src/Task.ts
+++ b/src/Task.ts
@@ -145,7 +145,7 @@ export const tryCatch = <L, A>(f: Lazy<Promise<A>>, onrejected: (reason: unknown
  * @since 1.0.0
  */
 export const fromIO = <A>(io: IO<A>): Task<A> => {
-  return new Task(() => Promise.resolve(io.run()))
+  return new Task(() => Promise.resolve().then(() => io.run()))
 }
 
 /**

--- a/test/Task.ts
+++ b/test/Task.ts
@@ -97,11 +97,30 @@ describe('Task', () => {
     })
   })
 
-  it('fromIO', () => {
-    const io = new IO(() => 1)
-    const task = fromIO(io)
-    return task.run().then(a => {
-      assert.strictEqual(a, 1)
+  describe('fromIO', () => {
+    it('should work', () => {
+      const io = new IO(() => 1)
+      const task = fromIO(io)
+      return task.run().then(a => {
+        assert.strictEqual(a, 1)
+      })
+    })
+    it('does not throw, but rejects instead', () => {
+      const ioThrowError = new IO(() => {
+        throw new Error('ouch!')
+      })
+      const task = fromIO(ioThrowError)
+      const noop = () => undefined
+      assert.doesNotThrow(() => task.run().catch(noop))
+      return task.run().then(
+        () => {
+          assert.fail('Unexpected condition')
+        },
+        e => {
+          assert(e instanceof Error)
+          assert.strictEqual(e.message, 'ouch!')
+        }
+      )
     })
   })
 


### PR DESCRIPTION
This will prevent a `Task` created with `fromIO` to throw instead of return a Promise with a rejection.