### PR TITLE
deprecate Semigroup.getDictionarySemigroup, Monoid.getDictionaryMonoi…

### DIFF
--- a/src/Monoid.ts
+++ b/src/Monoid.ts
@@ -94,21 +94,15 @@ export const getArrayMonoid = <A = never>(): Monoid<Array<A>> => {
 const emptyObject = {}
 
 /**
- * Gets {@link Monoid} instance for dictionaries given {@link Semigroup} instance for their values
- *
- * @example
- * import { getDictionaryMonoid, fold } from 'fp-ts/lib/Monoid'
- * import { semigroupSum } from 'fp-ts/lib/Semigroup'
- *
- * const M = getDictionaryMonoid(semigroupSum)
- * assert.deepStrictEqual(fold(M)([{ foo: 123 }, { foo: 456 }]), { foo: 579 })
- *
+ * Use {@link Record}'s `getMonoid`
  * @since 1.4.0
+ * @deprecated
  */
 export function getDictionaryMonoid<K extends string, A>(S: Semigroup<A>): Monoid<Record<K, A>>
 export function getDictionaryMonoid<A>(S: Semigroup<A>): Monoid<{ [key: string]: A }>
 export function getDictionaryMonoid<A>(S: Semigroup<A>): Monoid<{ [key: string]: A }> {
   return {
+    // tslint:disable-next-line: deprecation
     ...getDictionarySemigroup(S),
     empty: emptyObject
   }

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -138,11 +138,21 @@ export function getSetoid<A>(S: Setoid<A>): Setoid<Record<string, A>> {
 }
 
 /**
+ * Returns a {@link Semigroup} instance for records given a {@link Semigroup} instance for their values
+ *
+ * @example
+ * import { semigroupSum } from 'fp-ts/lib/Semigroup'
+ * import { getMonoid } from 'fp-ts/lib/Record'
+ *
+ * const M = getMonoid(semigroupSum)
+ * assert.deepStrictEqual(M.concat({ foo: 123 }, { foo: 456 }), { foo: 579 })
+ *
  * @since 1.10.0
  */
 export function getMonoid<K extends string, A>(S: Semigroup<A>): Monoid<Record<K, A>>
 export function getMonoid<A>(S: Semigroup<A>): Monoid<Record<string, A>>
 export function getMonoid<A>(S: Semigroup<A>): Monoid<Record<string, A>> {
+  // tslint:disable-next-line: deprecation
   return getDictionaryMonoid(S)
 }
 

--- a/src/Semigroup.ts
+++ b/src/Semigroup.ts
@@ -121,16 +121,9 @@ export const getArraySemigroup = <A = never>(): Semigroup<Array<A>> => {
 }
 
 /**
- * Gets {@link Semigroup} instance for dictionaries given {@link Semigroup} instance for their values
- *
- * @example
- * import { getDictionarySemigroup, semigroupSum } from 'fp-ts/lib/Semigroup'
- *
- * const S = getDictionarySemigroup(semigroupSum)
- * assert.deepStrictEqual(S.concat({ foo: 123 }, { foo: 456 }), { foo: 579 })
- *
- *
+ * Use {@link Record}'s `getMonoid`
  * @since 1.4.0
+ * @deprecated
  */
 export function getDictionarySemigroup<K extends string, A>(S: Semigroup<A>): Semigroup<Record<K, A>>
 export function getDictionarySemigroup<A>(S: Semigroup<A>): Semigroup<{ [key: string]: A }>
@@ -149,17 +142,22 @@ export function getDictionarySemigroup<A>(S: Semigroup<A>): Semigroup<{ [key: st
   }
 }
 
+// tslint:disable-next-line: deprecation
 const semigroupAnyDictionary = getDictionarySemigroup(getLastSemigroup())
 
 /**
- * Gets {@link Semigroup} instance for objects of given type preserving their type
+ * Returns a {@link Semigroup} instance for objects preserving their type
  *
  * @example
  * import { getObjectSemigroup } from 'fp-ts/lib/Semigroup'
  *
- * const S = getObjectSemigroup<{ foo: number }>()
- * assert.deepStrictEqual(S.concat({ foo: 123 }, { foo: 456 }), { foo: 456 })
+ * interface Person {
+ *   name: string
+ *   age: number
+ * }
  *
+ * const S = getObjectSemigroup<Person>()
+ * assert.deepStrictEqual(S.concat({ name: 'name', age: 23 }, { name: 'name', age: 24 }), { name: 'name', age: 24 })
  *
  * @since 1.4.0
  */
@@ -168,7 +166,7 @@ export const getObjectSemigroup = <A extends object = never>(): Semigroup<A> => 
 }
 
 /**
- * Number Semigroup under addition
+ * Number `Semigroup` under addition
  * @since 1.0.0
  */
 export const semigroupSum: Semigroup<number> = {
@@ -176,7 +174,7 @@ export const semigroupSum: Semigroup<number> = {
 }
 
 /**
- * Number Semigroup under multiplication
+ * Number `Semigroup` under multiplication
  * @since 1.0.0
  */
 export const semigroupProduct: Semigroup<number> = {

--- a/src/StrMap.ts
+++ b/src/StrMap.ts
@@ -11,7 +11,7 @@ import { HKT, Type, Type2, Type3, URIS, URIS2, URIS3 } from './HKT'
 import { Monoid } from './Monoid'
 import { Option } from './Option'
 import * as R from './Record'
-import { getDictionarySemigroup, getLastSemigroup, Semigroup } from './Semigroup'
+import { getLastSemigroup, Semigroup } from './Semigroup'
 import { Setoid, fromEquals } from './Setoid'
 import { TraversableWithIndex1 } from './TraversableWithIndex'
 import { Unfoldable, Unfoldable1 } from './Unfoldable'
@@ -140,7 +140,7 @@ export class StrMap<A> {
 const empty: StrMap<never> = new StrMap(R.empty)
 
 const concat = <A>(S: Semigroup<A>): ((x: StrMap<A>, y: StrMap<A>) => StrMap<A>) => {
-  const concat = getDictionarySemigroup(S).concat
+  const concat = R.getMonoid(S).concat
   return (x, y) => new StrMap(concat(x.value, y.value))
 }
 

--- a/test/Monoid.ts
+++ b/test/Monoid.ts
@@ -73,6 +73,7 @@ describe('Monoid', () => {
       foo: 456,
       fff: 456
     }
+    // tslint:disable-next-line: deprecation
     const M1 = getDictionaryMonoid(semigroupSum)
     assert.deepStrictEqual(fold(M1)([foo, bar]), {
       bar: foo.bar,
@@ -80,6 +81,7 @@ describe('Monoid', () => {
       fff: bar.fff
     })
     type Keys = 'a' | 'b'
+    // tslint:disable-next-line: deprecation
     const M2 = getDictionaryMonoid<Keys, number>(semigroupSum)
     assert.deepStrictEqual(fold(M2)([{ a: 1, b: 2 }, { a: 3, b: 4 }]), {
       a: 4,

--- a/test/Semigroup.ts
+++ b/test/Semigroup.ts
@@ -59,6 +59,7 @@ describe('Semigroup', () => {
       foo: 456,
       fff: 456
     }
+    // tslint:disable-next-line: deprecation
     const S = getDictionarySemigroup(semigroupSum)
     const result = S.concat(foo, bar)
     const expected = {


### PR DESCRIPTION
…d in favour of Record.getMonoid
