### PR TITLE
Fix typo in Map's keys function comment: values -> keys

### DIFF
--- a/docs/Map.md
+++ b/docs/Map.md
@@ -155,7 +155,7 @@ Added in v1.14.0
 
 ## keys
 
-Get a sorted array of the values contained in a map
+Get a sorted array of the keys contained in a map
 
 **Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Map.ts#L80-L80)
 

--- a/docs/Monoid.md
+++ b/docs/Monoid.md
@@ -23,7 +23,7 @@ Added in v1.0.0
 
 Boolean monoid under conjunction
 
-**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L60-L63)
+**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L69-L72)
 
 ```ts
 export const monoidAll: Monoid<boolean> = ...
@@ -35,7 +35,7 @@ Added in v1.0.0
 
 Boolean monoid under disjunction
 
-**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L69-L72)
+**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L78-L81)
 
 ```ts
 export const monoidAny: Monoid<boolean> = ...
@@ -47,7 +47,7 @@ Added in v1.0.0
 
 Number monoid under multiplication
 
-**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L123-L126)
+**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L132-L135)
 
 ```ts
 export const monoidProduct: Monoid<number> = ...
@@ -57,7 +57,7 @@ Added in v1.0.0
 
 ## monoidString
 
-**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L131-L134)
+**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L140-L143)
 
 ```ts
 export const monoidString: Monoid<string> = ...
@@ -69,7 +69,7 @@ Added in v1.0.0
 
 Number monoid under addition
 
-**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L114-L117)
+**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L123-L126)
 
 ```ts
 export const monoidSum: Monoid<number> = ...
@@ -79,7 +79,7 @@ Added in v1.0.0
 
 ## monoidVoid
 
-**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L139-L142)
+**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L148-L151)
 
 ```ts
 export const monoidVoid: Monoid<void> = ...
@@ -89,7 +89,7 @@ Added in v1.0.0
 
 ## unsafeMonoidArray
 
-**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L79-L82)
+**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L88-L91)
 
 ```ts
 export const unsafeMonoidArray: Monoid<Array<any>> = ...
@@ -111,7 +111,7 @@ Added in v1.0.0
 
 `Monoid` under array concatenation
 
-**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L89-L91)
+**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L98-L100)
 
 ```ts
 export const getArrayMonoid = <A = never>(): Monoid<Array<A>> => { ... }
@@ -123,7 +123,7 @@ Added in v1.0.0
 
 Use [Record](./Record.md)'s `getMonoid`
 
-**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L102-L108)
+**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L111-L117)
 
 ```ts
 export function getDictionaryMonoid<A>(S: Semigroup<A>): Monoid< { ... }
@@ -133,7 +133,7 @@ Added in v1.4.0
 
 ## getDualMonoid
 
-**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L49-L54)
+**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L58-L63)
 
 ```ts
 export const getDualMonoid = <A>(M: Monoid<A>): Monoid<A> => { ... }
@@ -143,7 +143,7 @@ Added in v1.0.0
 
 ## getEndomorphismMonoid
 
-**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L157-L162)
+**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L166-L171)
 
 ```ts
 export const getEndomorphismMonoid = <A = never>(): Monoid<Endomorphism<A>> => { ... }
@@ -153,7 +153,7 @@ Added in v1.0.0
 
 ## getFunctionMonoid
 
-**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L147-L152)
+**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L156-L161)
 
 ```ts
 export const getFunctionMonoid = <M>(M: Monoid<M>) => <A = never>(): Monoid<(a: A) => M> => { ... }
@@ -163,7 +163,7 @@ Added in v1.0.0
 
 ## getJoinMonoid
 
-**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L194-L199)
+**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L213-L218)
 
 ```ts
 export const getJoinMonoid = <A>(B: Bounded<A>): Monoid<A> => { ... }
@@ -173,7 +173,7 @@ Added in v1.9.0
 
 ## getMeetMonoid
 
-**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L184-L189)
+**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L203-L208)
 
 ```ts
 export const getMeetMonoid = <A>(B: Bounded<A>): Monoid<A> => { ... }
@@ -181,9 +181,11 @@ export const getMeetMonoid = <A>(B: Bounded<A>): Monoid<A> => { ... }
 
 Added in v1.9.0
 
-## getProductMonoid
+## ~~getProductMonoid~~ (deprecated)
 
-**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L39-L44)
+Use [getTupleMonoid](#gettuplemonoid) instead
+
+**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L51-L53)
 
 ```ts
 export const getProductMonoid = <A, B>(MA: Monoid<A>, MB: Monoid<B>): Monoid<[A, B]> => { ... }
@@ -191,14 +193,38 @@ export const getProductMonoid = <A, B>(MA: Monoid<A>, MB: Monoid<B>): Monoid<[A,
 
 Added in v1.0.0
 
-## getRecordMonoid
+## ~~getRecordMonoid~~ (deprecated)
 
-**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L167-L179)
+Use [getStructMonoid](#getstructmonoid) instead
+
+**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L194-L198)
 
 ```ts
 export const getRecordMonoid = <O extends { [key: string]: any }>(
   monoids: { [K in keyof O]: Monoid<O[K]> }
 ): Monoid<O> => { ... }
+```
+
+Added in v1.0.0
+
+## getStructMonoid
+
+**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L176-L187)
+
+```ts
+export const getStructMonoid = <O extends { [key: string]: any }>(
+  monoids: { [K in keyof O]: Monoid<O[K]> }
+): Monoid<O> => { ... }
+```
+
+Added in v1.14.0
+
+## getTupleMonoid
+
+**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Monoid.ts#L39-L44)
+
+```ts
+export const getTupleMonoid = <A, B>(MA: Monoid<A>, MB: Monoid<B>): Monoid<[A, B]> => { ... }
 ```
 
 Added in v1.0.0

--- a/docs/Semigroup.md
+++ b/docs/Semigroup.md
@@ -23,7 +23,7 @@ Added in v1.0.0
 
 Boolean semigroup under conjunction
 
-**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L100-L102)
+**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L119-L121)
 
 ```ts
 export const semigroupAll: Semigroup<boolean> = ...
@@ -35,7 +35,7 @@ Added in v1.0.0
 
 Boolean semigroup under disjunction
 
-**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L108-L110)
+**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L127-L129)
 
 ```ts
 export const semigroupAny: Semigroup<boolean> = ...
@@ -47,7 +47,7 @@ Added in v1.0.0
 
 Number `Semigroup` under multiplication
 
-**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L178-L180)
+**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L197-L199)
 
 ```ts
 export const semigroupProduct: Semigroup<number> = ...
@@ -57,7 +57,7 @@ Added in v1.0.0
 
 ## semigroupString
 
-**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L185-L187)
+**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L204-L206)
 
 ```ts
 export const semigroupString: Semigroup<string> = ...
@@ -69,7 +69,7 @@ Added in v1.0.0
 
 Number `Semigroup` under addition
 
-**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L170-L172)
+**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L189-L191)
 
 ```ts
 export const semigroupSum: Semigroup<number> = ...
@@ -79,7 +79,7 @@ Added in v1.0.0
 
 ## semigroupVoid
 
-**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L192-L194)
+**Signature** (constant) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L211-L213)
 
 ```ts
 export const semigroupVoid: Semigroup<void> = ...
@@ -101,7 +101,7 @@ Added in v1.0.0
 
 Use [Monoid](./Monoid.md)'s `getArrayMonoid` instead
 
-**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L117-L119)
+**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L136-L138)
 
 ```ts
 export const getArraySemigroup = <A = never>(): Semigroup<Array<A>> => { ... }
@@ -113,7 +113,7 @@ Added in v1.0.0
 
 Use [Record](./Record.md)'s `getMonoid`
 
-**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L128-L141)
+**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L147-L160)
 
 ```ts
 export function getDictionarySemigroup<A>(S: Semigroup<A>): Semigroup< { ... }
@@ -123,7 +123,7 @@ Added in v1.4.0
 
 ## getDualSemigroup
 
-**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L45-L49)
+**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L54-L58)
 
 ```ts
 export const getDualSemigroup = <A>(S: Semigroup<A>): Semigroup<A> => { ... }
@@ -143,7 +143,7 @@ Added in v1.0.0
 
 ## getFunctionSemigroup
 
-**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L54-L58)
+**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L63-L67)
 
 ```ts
 export const getFunctionSemigroup = <S>(S: Semigroup<S>) => <A = never>(): Semigroup<(a: A) => S> => { ... }
@@ -153,7 +153,7 @@ Added in v1.0.0
 
 ## getJoinSemigroup
 
-**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L90-L94)
+**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L109-L113)
 
 ```ts
 export const getJoinSemigroup = <A>(O: Ord<A>): Semigroup<A> => { ... }
@@ -173,7 +173,7 @@ Added in v1.0.0
 
 ## getMeetSemigroup
 
-**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L81-L85)
+**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L100-L104)
 
 ```ts
 export const getMeetSemigroup = <A>(O: Ord<A>): Semigroup<A> => { ... }
@@ -185,7 +185,7 @@ Added in v1.0.0
 
 Returns a [Semigroup](./Semigroup.md) instance for objects preserving their type
 
-**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L162-L164)
+**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L181-L183)
 
 ```ts
 export const getObjectSemigroup = <A extends object = never>(): Semigroup<A> => { ... }
@@ -207,9 +207,11 @@ assert.deepStrictEqual(S.concat({ name: 'name', age: 23 }, { name: 'name', age: 
 
 Added in v1.4.0
 
-## getProductSemigroup
+## ~~getProductSemigroup~~ (deprecated)
 
-**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L36-L40)
+Use [getTupleSemigroup](#gettuplesemigroup) instead
+
+**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L47-L49)
 
 ```ts
 export const getProductSemigroup = <A, B>(SA: Semigroup<A>, SB: Semigroup<B>): Semigroup<[A, B]> => { ... }
@@ -217,9 +219,11 @@ export const getProductSemigroup = <A, B>(SA: Semigroup<A>, SB: Semigroup<B>): S
 
 Added in v1.0.0
 
-## getRecordSemigroup
+## ~~getRecordSemigroup~~ (deprecated)
 
-**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L63-L76)
+Use [getStructSemigroup](#getstructsemigroup) instead
+
+**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L91-L95)
 
 ```ts
 export const getRecordSemigroup = <O extends { [key: string]: any }>(
@@ -228,3 +232,25 @@ export const getRecordSemigroup = <O extends { [key: string]: any }>(
 ```
 
 Added in v1.0.0
+
+## getStructSemigroup
+
+**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L72-L84)
+
+```ts
+export const getStructSemigroup = <O extends { [key: string]: any }>(
+  semigroups: { [K in keyof O]: Semigroup<O[K]> }
+): Semigroup<O> => { ... }
+```
+
+Added in v1.14.0
+
+## getTupleSemigroup
+
+**Signature** (function) [Source](https://github.com/gcanti/fp-ts/blob/master/src/Semigroup.ts#L36-L40)
+
+```ts
+export const getTupleSemigroup = <A, B>(SA: Semigroup<A>, SB: Semigroup<B>): Semigroup<[A, B]> => { ... }
+```
+
+Added in v1.14.0

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -73,7 +73,7 @@ export const elem = <A>(S: Setoid<A>): (<K>(a: A, m: Map<K, A>) => boolean) => {
 }
 
 /**
- * Get a sorted array of the values contained in a map
+ * Get a sorted array of the keys contained in a map
  *
  * @since 1.14.0
  */


### PR DESCRIPTION
I accidentally let a typo in before. Fixing the comment for `keys`.