### PR TITLE
Adjust the documentation colors

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-remote_theme: pmarsceill/just-the-docs
+remote_theme: fluffyemily/just-the-docs
 
 # Enable or disable the site search
 search_enabled: true

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -1,0 +1,5 @@
+$fp-ts-blue-000: #0088e6;
+$fp-ts-blue-100: #0075c5;
+
+$link-color: $fp-ts-blue-000;
+$btn-primary-color: $fp-ts-blue-100;


### PR DESCRIPTION
The default purple color used by the documentation theme bothers me a bit as fp-ts always had more of a blue feel to me.
The purple combined with the blue fp-ts logo bothered me enough to learn a bit about Jekyll and to create this PR.

I have adjusted the link and button colors using the fp-ts logo as a guide. To me this gives the documentation a vastly more coherent look.

There is one small problem though. The current version of the theme is broken with regards to customisation. This forced me into switching to a forked version of the theme. 

There exists a PR attempting to solve the issue pmarsceill/just-the-docs#97
So I'm thinking that this PR, if accepted, should probably not be merged until the above is fixed and we can use the official theme again.

Anyway I though I'll leave this PR here in hope that it might somehow be useful.

Ohh, and thank you for the awesome library. It makes TypeScript so much more bearable 👍 