### PR TITLE
Add Align and Semialign type classes

### DIFF
--- a/dtslint/ts3.0/index.ts
+++ b/dtslint/ts3.0/index.ts
@@ -234,6 +234,15 @@ declare const fromFoldableF1: Fo.Foldable<'Test'>
 declare const fromFoldableInput1: H.HKT<'Test', ['a' | 'b', number]>
 const fromFoldable1 = R.fromFoldable(fromFoldableF1)(fromFoldableInput1, a => a) // $ExpectType Record<"a" | "b", number>
 
+declare const d2: Record<string, string>
+declare const r2: Record<'a', number>
+declare const r3: Record<'b', string>
+R.align(d1, d2) // $ExpectType Record<string, These<number, string>>
+R.align(r2, r3) // $ExpectType Record<"a" | "b", These<number, string>>
+
+R.alignWith(d1, d2, (x: Th.These<number, string>) => 'Test') // $ExpectType Record<string, string>
+R.alignWith(r2, r3, (x: Th.These<number, string>) => 'Test') // $ExpectType Record<"a" | "b", string>
+
 //
 // Semigroup
 //

--- a/src/Align.ts
+++ b/src/Align.ts
@@ -1,0 +1,156 @@
+/**
+ * @file The `Align` type class extends the `Semialign` type class with a value `nil`, which
+ * acts as a unit with regards to `align`.
+ *
+ * `Align` instances must satisfy the following laws in addition to the `Semialign` laws:
+ *
+ * 1. Right identity: `F.align(fa, nil) = F.map(fa, this_)`
+ * 2. Left identity: `F.align(nil, fa) = F.map(fa, that)`
+ *
+ * Adapted from http://hackage.haskell.org/package/these-0.8/docs/Data-Align.html
+ */
+import { Semialign, Semialign1, Semialign2, Semialign2C, Semialign3, Semialign3C } from './Semialign'
+import { HKT, Type, Type2, Type3, URIS, URIS2, URIS3 } from './HKT'
+import { Semigroup } from './Semigroup'
+import { Option, some, none } from './Option'
+import { identity, tuple } from './function'
+
+/**
+ * @since 1.15.0
+ */
+export interface Align<F> extends Semialign<F> {
+  readonly nil: <A>() => HKT<F, A>
+}
+
+export interface Align1<F extends URIS> extends Semialign1<F> {
+  readonly nil: <A>() => Type<F, A>
+}
+
+export interface Align2<F extends URIS2> extends Semialign2<F> {
+  readonly nil: <L, A>() => Type2<F, L, A>
+}
+
+export interface Align3<F extends URIS3> extends Semialign3<F> {
+  readonly nil: <U, L, A>() => Type3<F, U, L, A>
+}
+
+export interface Align2C<F extends URIS2, L> extends Semialign2C<F, L> {
+  readonly nil: <A>() => Type2<F, L, A>
+}
+
+export interface Align3C<F extends URIS3, U, L> extends Semialign3C<F, U, L> {
+  readonly nil: <A>() => Type3<F, U, L, A>
+}
+
+/**
+ * Align two structures, using a semigroup for combining values.
+ *
+ * @example
+ * import { salign } from 'fp-ts/lib/Align'
+ * import { array } from 'fp-ts/lib/Array'
+ * import { semigroupSum } from 'fp-ts/lib/Semigroup'
+ *
+ * assert.deepStrictEqual(salign(array, semigroupSum)([1, 2, 3], [4, 5]), [5, 7, 3])
+ *
+ * @since 1.15.0
+ */
+// export function salign<F extends URIS3, A, L>(
+//   F: Align3<F>,
+//   S: Semigroup<A>
+// ): <U, L>(fx: Type3<F, U, L, A>, fy: Type3<F, U, L, A>) => Type3<F, U, L, A>
+export function salign<F extends URIS3, A, U, L>(
+  F: Align3C<F, U, L>,
+  S: Semigroup<A>
+): (fx: Type3<F, U, L, A>, fy: Type3<F, U, L, A>) => Type3<F, U, L, A>
+// export function salign<F extends URIS2, A>(
+//   F: Align2<F>,
+//   S: Semigroup<A>
+// ): <L>(fx: Type2<F, L, A>, fy: Type2<F, L, A>) => Type2<F, L, A>
+export function salign<F extends URIS2, A, L>(
+  F: Align2C<F, L>,
+  S: Semigroup<A>
+): (fx: Type2<F, L, A>, fy: Type2<F, L, A>) => Type2<F, L, A>
+export function salign<F extends URIS, A>(F: Align1<F>, S: Semigroup<A>): (fx: Type<F, A>, fy: Type<F, A>) => Type<F, A>
+export function salign<F, A>(F: Align<F>, S: Semigroup<A>): (fx: HKT<F, A>, fy: HKT<F, A>) => HKT<F, A>
+export function salign<F, A>(F: Align<F>, S: Semigroup<A>): (fx: HKT<F, A>, fy: HKT<F, A>) => HKT<F, A> {
+  return (fx, fy) => F.alignWith(fx, fy, xy => xy.fold(identity, identity, S.concat))
+}
+
+/**
+ * Align two structures, using `none` to fill blanks.
+ *
+ * It is similar to `zip`, but it doesn't discard elements.
+ *
+ * @example
+ * import { padZip } from 'fp-ts/lib/Align'
+ * import { array } from 'fp-ts/lib/Array'
+ * import { some, none } from 'fp-ts/lib/Option'
+ *
+ * assert.deepStrictEqual(padZip(array)([1, 2, 3], [4, 5]), [[some(1), some(4)], [some(2), some(5)], [some(3), none]])
+ *
+ * @since 1.15.0
+ */
+// export function padZip<F extends URIS3, L>(
+//   F: Align3<F>
+// ): <U, L, A, B>(fa: Type3<F, U, L, A>, fb: Type3<F, U, L, B>) => Type3<F, U, L, [Option<A>, Option<B>]>
+export function padZip<F extends URIS3, U, L>(
+  F: Align3C<F, U, L>
+): <A, B>(fa: Type3<F, U, L, A>, fb: Type3<F, U, L, B>) => Type3<F, U, L, [Option<A>, Option<B>]>
+// export function padZip<F extends URIS2>(
+//   F: Align2<F>
+// ): <L, A, B>(fa: Type2<F, L, A>, fb: Type2<F, L, B>) => Type2<F, L, [Option<A>, Option<B>]>
+export function padZip<F extends URIS2, L>(
+  F: Align2C<F, L>
+): <A, B>(fa: Type2<F, L, A>, fb: Type2<F, L, B>) => Type2<F, L, [Option<A>, Option<B>]>
+export function padZip<F extends URIS>(
+  F: Align1<F>
+): <A, B>(fa: Type<F, A>, fb: Type<F, B>) => Type<F, [Option<A>, Option<B>]>
+export function padZip<F>(F: Align<F>): <A, B>(fa: HKT<F, A>, fb: HKT<F, B>) => HKT<F, [Option<A>, Option<B>]>
+export function padZip<F>(F: Align<F>): <A, B>(fa: HKT<F, A>, fb: HKT<F, B>) => HKT<F, [Option<A>, Option<B>]> {
+  return (fa, fb) => padZipWith(F)(fa, fb, (a, b) => tuple(a, b))
+}
+
+/**
+ * Align two structures by applying a function to each pair of aligned elements, using `none` to fill blanks.
+ *
+ * It is similar to `zipWith`, but it doesn't discard elements.
+ *
+ * @example
+ * import { padZipWith } from 'fp-ts/lib/Align'
+ * import { array } from 'fp-ts/lib/Array'
+ * import { Option } from 'fp-ts/lib/Option'
+ *
+ * const f = (ma: Option<number>, mb: Option<string>) => ma.fold('*', a => a.toString()) + mb.getOrElse('#')
+ * assert.deepStrictEqual(padZipWith(array)([1, 2], ['a'], f), ['1a', '2#'])
+ * assert.deepStrictEqual(padZipWith(array)([1], ['a', 'b'], f), ['1a', '*b'])
+ *
+ * @since 1.15.0
+ */
+// export function padZipWith<F extends URIS3, L>(
+//   F: Align3<F>
+// ): <U, L, A, B, C>(
+//   f: (a: Option<A>, b: Option<B>) => C,
+//   fa: Type3<F, U, L, A>,
+//   fb: Type3<F, U, L, B>
+// ) => Type3<F, U, L, C>
+export function padZipWith<F extends URIS3, U, L>(
+  F: Align3C<F, U, L>
+): <A, B, C>(fa: Type3<F, U, L, A>, fb: Type3<F, U, L, B>, f: (a: Option<A>, b: Option<B>) => C) => Type3<F, U, L, C>
+// export function padZipWith<F extends URIS2>(
+//   F: Align2<F>
+// ): <L, A, B, C>(f: (a: Option<A>, b: Option<B>) => C, fa: Type2<F, L, A>, fb: Type2<F, L, B>) => Type2<F, L, C>
+export function padZipWith<F extends URIS2, L>(
+  F: Align2C<F, L>
+): <A, B, C>(fa: Type2<F, L, A>, fb: Type2<F, L, B>, f: (a: Option<A>, b: Option<B>) => C) => Type2<F, L, C>
+export function padZipWith<F extends URIS>(
+  F: Align1<F>
+): <A, B, C>(fa: Type<F, A>, fb: Type<F, B>, f: (a: Option<A>, b: Option<B>) => C) => Type<F, C>
+export function padZipWith<F>(
+  F: Align<F>
+): <A, B, C>(fa: HKT<F, A>, fb: HKT<F, B>, f: (a: Option<A>, b: Option<B>) => C) => HKT<F, C>
+export function padZipWith<F>(
+  F: Align<F>
+): <A, B, C>(fa: HKT<F, A>, fb: HKT<F, B>, f: (a: Option<A>, b: Option<B>) => C) => HKT<F, C> {
+  return (fa, fb, f) =>
+    F.alignWith(fa, fb, ab => ab.bimap(some, some).fold(a => f(a, none), b => f(none, b), (a, b) => f(a, b)))
+}

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -1,6 +1,7 @@
 /**
  * @file Adapted from https://github.com/purescript/purescript-arrays
  */
+import { Align1 } from './Align'
 import { Alternative1 } from './Alternative'
 import { Applicative, Applicative1, Applicative2, Applicative2C, Applicative3, Applicative3C } from './Applicative'
 import { Compactable1, Separated } from './Compactable'
@@ -19,6 +20,7 @@ import { getSemigroup, Ord, ordNumber, fromCompare } from './Ord'
 import { Plus1 } from './Plus'
 import { getArraySetoid, Setoid } from './Setoid'
 import { TraversableWithIndex1 } from './TraversableWithIndex'
+import { These, this_, that, both } from './These'
 import { Unfoldable1 } from './Unfoldable'
 import { Witherable1 } from './Witherable'
 
@@ -1543,6 +1545,32 @@ const filterWithIndex = <A>(fa: Array<A>, p: (i: number, a: A) => boolean): Arra
   return fa.filter((a, i) => p(i, a))
 }
 
+const align = <A, B>(fa: Array<A>, fb: Array<B>): Array<These<A, B>> => {
+  return alignWith<A, B, These<A, B>>(fa, fb, identity)
+}
+
+const alignWith = <A, B, C>(fa: Array<A>, fb: Array<B>, f: (x: These<A, B>) => C): Array<C> => {
+  const fc = []
+  const aLen = fa.length
+  const bLen = fb.length
+  const len = Math.min(aLen, bLen)
+  for (let i = 0; i < len; i++) {
+    fc[i] = f(both(fa[i], fb[i]))
+  }
+  if (aLen > bLen) {
+    for (let i = bLen; i < aLen; i++) {
+      fc[i] = f(this_<A, B>(fa[i]))
+    }
+  } else {
+    for (let i = aLen; i < bLen; i++) {
+      fc[i] = f(that<A, B>(fb[i]))
+    }
+  }
+  return fc
+}
+
+const nil = <A>(): Array<A> => empty
+
 /**
  * @since 1.0.0
  */
@@ -1557,7 +1585,8 @@ export const array: Monad1<URI> &
   FilterableWithIndex1<URI, number> &
   Witherable1<URI> &
   FunctorWithIndex1<URI, number> &
-  FoldableWithIndex1<URI, number> = {
+  FoldableWithIndex1<URI, number> &
+  Align1<URI> = {
   URI,
   map,
   mapWithIndex,
@@ -1588,5 +1617,8 @@ export const array: Monad1<URI> &
   partitionMapWithIndex,
   partitionWithIndex,
   filterMapWithIndex,
-  filterWithIndex
+  filterWithIndex,
+  align,
+  alignWith,
+  nil
 }

--- a/src/NonEmptyArray.ts
+++ b/src/NonEmptyArray.ts
@@ -28,6 +28,8 @@ import { Setoid, getArraySetoid, fromEquals } from './Setoid'
 import { FunctorWithIndex1 } from './FunctorWithIndex'
 import { FoldableWithIndex1 } from './FoldableWithIndex'
 import { TraversableWithIndex1 } from './TraversableWithIndex'
+import { These, both } from './These'
+import { Semialign1 } from './Semialign'
 
 declare module './HKT' {
   interface URI2HKT<A> {
@@ -475,6 +477,20 @@ export class NonEmptyArray<A> {
   every(predicate: Predicate<A>): boolean {
     return predicate(this.head) && this.tail.every(a => predicate(a))
   }
+
+  /**
+   * @since 1.15.0
+   */
+  align<B>(fb: NonEmptyArray<B>): NonEmptyArray<These<A, B>> {
+    return new NonEmptyArray(both(this.head, fb.head), array.align(this.tail, fb.tail))
+  }
+
+  /**
+   * @since 1.15.0
+   */
+  alignWith<B, C>(fb: NonEmptyArray<B>, f: (x: These<A, B>) => C): NonEmptyArray<C> {
+    return new NonEmptyArray(f(both(this.head, fb.head)), array.alignWith(this.tail, fb.tail, f))
+  }
 }
 
 const unsafeFromArray = <A>(as: Array<A>): NonEmptyArray<A> => {
@@ -678,6 +694,14 @@ const traverseWithIndex = <F>(
   }
 }
 
+const align = <A, B>(fa: NonEmptyArray<A>, fb: NonEmptyArray<B>): NonEmptyArray<These<A, B>> => {
+  return fa.align(fb)
+}
+
+const alignWith = <A, B, C>(fa: NonEmptyArray<A>, fb: NonEmptyArray<B>, f: (x: These<A, B>) => C): NonEmptyArray<C> => {
+  return fa.alignWith(fb, f)
+}
+
 /**
  * @since 1.0.0
  */
@@ -686,7 +710,8 @@ export const nonEmptyArray: Monad1<URI> &
   Foldable2v1<URI> &
   TraversableWithIndex1<URI, number> &
   FunctorWithIndex1<URI, number> &
-  FoldableWithIndex1<URI, number> = {
+  FoldableWithIndex1<URI, number> &
+  Semialign1<URI> = {
   URI,
   extend,
   extract,
@@ -703,5 +728,7 @@ export const nonEmptyArray: Monad1<URI> &
   reduceWithIndex,
   foldMapWithIndex,
   foldrWithIndex,
-  traverseWithIndex
+  traverseWithIndex,
+  align,
+  alignWith
 }

--- a/src/Semialign.ts
+++ b/src/Semialign.ts
@@ -1,0 +1,61 @@
+/**
+ * @file The `Semialign` type class represents functors supporting a zip operation that takes the
+ * union of non-uniform shapes.
+ *
+ * `Semialign` instances are required to satisfy the following laws:
+ *
+ * TODO Do any of these laws have a name? And more importantly, have I converted them correctly?
+ * 1. `F.align(fa, fa) = F.map(fa, (a) => both(a, a))`
+ * 2. `F.align(F.map(fa, f), F.map(fb, g)) = F.map(F.align(fa, fb), (t) => These.bimap(t, f, g))`
+ * 3. `F.alignWith(fa, fb, f) = F.map(F.align(fa, fb), f)`
+ * 4. `F.align(fa, F.align(fb, fc)) = F.map(F.align(F.align(fa, fb), fc), These.assoc)`
+ *
+ * Where `These.assoc` implements the associativity law of `These` and has the following type signature:
+ * `function assoc<A, B, C>(fa: These<A, These<B, C>>): These<These<A, B>, C>`
+ *
+ * Adapted from http://hackage.haskell.org/package/these-0.8/docs/Data-Align.html
+ */
+import { Functor, Functor1, Functor2, Functor2C, Functor3, Functor3C } from './Functor'
+import { HKT, Type, Type2, Type3, URIS, URIS2, URIS3 } from './HKT'
+import { These } from './These'
+
+/**
+ * @since 1.15.0
+ */
+export interface Semialign<F> extends Functor<F> {
+  readonly align: <A, B>(fa: HKT<F, A>, fb: HKT<F, B>) => HKT<F, These<A, B>>
+  readonly alignWith: <A, B, C>(fa: HKT<F, A>, fb: HKT<F, B>, f: (x: These<A, B>) => C) => HKT<F, C>
+}
+
+export interface Semialign1<F extends URIS> extends Functor1<F> {
+  readonly align: <A, B>(fa: Type<F, A>, fb: Type<F, B>) => Type<F, These<A, B>>
+  readonly alignWith: <A, B, C>(fa: Type<F, A>, fb: Type<F, B>, f: (x: These<A, B>) => C) => Type<F, C>
+}
+
+export interface Semialign2<F extends URIS2> extends Functor2<F> {
+  readonly align: <L, A, B>(fa: Type2<F, L, A>, fb: Type2<F, L, B>) => Type2<F, L, These<A, B>>
+  readonly alignWith: <L, A, B, C>(fa: Type2<F, L, A>, fb: Type2<F, L, B>, f: (x: These<A, B>) => C) => Type2<F, L, C>
+}
+
+export interface Semialign3<F extends URIS3> extends Functor3<F> {
+  readonly align: <U, L, A, B>(fa: Type3<F, U, L, A>, fb: Type3<F, U, L, B>) => Type3<F, U, L, These<A, B>>
+  readonly alignWith: <U, L, A, B, C>(
+    fa: Type3<F, U, L, A>,
+    fb: Type3<F, U, L, B>,
+    f: (x: These<A, B>) => C
+  ) => Type3<F, U, L, C>
+}
+
+export interface Semialign2C<F extends URIS2, L> extends Functor2C<F, L> {
+  readonly align: <A, B>(fa: Type2<F, L, A>, fb: Type2<F, L, B>) => Type2<F, L, These<A, B>>
+  readonly alignWith: <A, B, C>(fa: Type2<F, L, A>, fb: Type2<F, L, B>, f: (x: These<A, B>) => C) => Type2<F, L, C>
+}
+
+export interface Semialign3C<F extends URIS3, U, L> extends Functor3C<F, U, L> {
+  readonly align: <A, B>(fa: Type3<F, U, L, A>, fb: Type3<F, U, L, B>) => Type3<F, U, L, These<A, B>>
+  readonly alignWith: <A, B, C>(
+    fa: Type3<F, U, L, A>,
+    fb: Type3<F, U, L, B>,
+    f: (x: These<A, B>) => C
+  ) => Type3<F, U, L, C>
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,6 +138,8 @@ import * as record from './Record'
 export { record }
 import * as ring from './Ring'
 export { ring }
+import * as semialign from './Semialign'
+export { semialign }
 import * as semigroup from './Semigroup'
 export { semigroup }
 import * as semigroupoid from './Semigroupoid'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import * as align from './Align'
+export { align }
 import * as alt from './Alt'
 export { alt }
 import * as alternative from './Alternative'

--- a/test/Align.ts
+++ b/test/Align.ts
@@ -1,0 +1,29 @@
+import * as assert from 'assert'
+import { array } from '../src/Array'
+import { salign, padZip, padZipWith } from '../src/Align'
+import { semigroupSum } from '../src/Semigroup'
+import { Option, some, none } from '../src/Option'
+
+describe('Align', () => {
+  it('salign', () => {
+    assert.deepStrictEqual(salign(array, semigroupSum)([1, 2], [4, 5]), [5, 7])
+    assert.deepStrictEqual(salign(array, semigroupSum)([1, 2], [4]), [5, 2])
+    assert.deepStrictEqual(salign(array, semigroupSum)([1], [4, 5]), [5, 5])
+    assert.deepStrictEqual(salign(array, semigroupSum)([], []), [])
+  })
+
+  it('padZip', () => {
+    assert.deepStrictEqual(padZip(array)([1, 2], ['a', 'b']), [[some(1), some('a')], [some(2), some('b')]])
+    assert.deepStrictEqual(padZip(array)([1, 2], ['a']), [[some(1), some('a')], [some(2), none]])
+    assert.deepStrictEqual(padZip(array)([1], ['a', 'b']), [[some(1), some('a')], [none, some('b')]])
+    assert.deepStrictEqual(padZip(array)([], []), [])
+  })
+
+  it('padZipWith', () => {
+    const f = (ma: Option<number>, mb: Option<string>) => mb.getOrElse('#') + ma.fold('*', a => a.toString())
+    assert.deepStrictEqual(padZipWith(array)([1, 2], ['a', 'b'], f), ['a1', 'b2'])
+    assert.deepStrictEqual(padZipWith(array)([1, 2], ['a'], f), ['a1', '#2'])
+    assert.deepStrictEqual(padZipWith(array)([1], ['a', 'b'], f), ['a1', 'b*'])
+    assert.deepStrictEqual(padZipWith(array)([], [], f), [])
+  })
+})

--- a/test/Array.ts
+++ b/test/Array.ts
@@ -70,6 +70,7 @@ import { option, Option, none, some, isSome } from '../src/Option'
 import { contramap as contramapOrd, ordNumber, ordString } from '../src/Ord'
 import { contramap, getArraySetoid, setoidBoolean, setoidNumber, setoidString, Setoid } from '../src/Setoid'
 import { identity, tuple, constTrue } from '../src/function'
+import { These, both, this_, that } from '../src/These'
 import * as I from '../src/Identity'
 import * as F from '../src/Foldable'
 import * as C from '../src/Const'
@@ -749,5 +750,24 @@ describe('Array', () => {
     const f = (a: number, x?: Foo) => (x !== undefined ? `${a}${x.bar()}` : `${a}`)
     const res = array.map([1, 2], f)
     assert.deepStrictEqual(res, ['1', '2'])
+  })
+
+  it('align', () => {
+    assert.deepStrictEqual(array.align([1, 2], ['a', 'b']), [both(1, 'a'), both(2, 'b')])
+    assert.deepStrictEqual(array.align([1, 2], ['a']), [both(1, 'a'), this_(2)])
+    assert.deepStrictEqual(array.align([1], ['a', 'b']), [both(1, 'a'), that('b')])
+    assert.deepStrictEqual(array.align([], []), [])
+    assert.deepStrictEqual(array.align([1], array.nil<string>()), [this_(1)])
+    assert.deepStrictEqual(array.align(array.nil<number>(), ['a']), [that('a')])
+  })
+
+  it('alignWith', () => {
+    const f = (x: These<number, string>) => x.fold(a => a.toString(), identity, (a, b) => b + a)
+    assert.deepStrictEqual(array.alignWith([1, 2], ['a', 'b'], f), ['a1', 'b2'])
+    assert.deepStrictEqual(array.alignWith([1, 2], ['a'], f), ['a1', '2'])
+    assert.deepStrictEqual(array.alignWith([1], ['a', 'b'], f), ['a1', 'b'])
+    assert.deepStrictEqual(array.alignWith([], [], f), [])
+    assert.deepStrictEqual(array.alignWith([1], array.nil<string>(), f), ['1'])
+    assert.deepStrictEqual(array.alignWith(array.nil<number>(), ['a'], f), ['a'])
   })
 })

--- a/test/Array.ts
+++ b/test/Array.ts
@@ -62,7 +62,11 @@ import {
   union,
   intersection,
   difference,
-  unsafeUpdateAt
+  unsafeUpdateAt,
+  lpadZip,
+  lpadZipWith,
+  rpadZip,
+  rpadZipWith
 } from '../src/Array'
 import { left, right } from '../src/Either'
 import { fold as foldMonoid, monoidSum, monoidString } from '../src/Monoid'
@@ -769,5 +773,35 @@ describe('Array', () => {
     assert.deepStrictEqual(array.alignWith([], [], f), [])
     assert.deepStrictEqual(array.alignWith([1], array.nil<string>(), f), ['1'])
     assert.deepStrictEqual(array.alignWith(array.nil<number>(), ['a'], f), ['a'])
+  })
+
+  it('lpadZip', () => {
+    assert.deepStrictEqual(lpadZip([1, 2], ['a', 'b']), [[some(1), 'a'], [some(2), 'b']])
+    assert.deepStrictEqual(lpadZip([1, 2], ['a']), [[some(1), 'a']])
+    assert.deepStrictEqual(lpadZip([1], ['a', 'b']), [[some(1), 'a'], [none, 'b']])
+    assert.deepStrictEqual(lpadZip([], []), [])
+  })
+
+  it('lpadZipWith', () => {
+    const f = (ma: Option<number>, b: string) => b + ma.fold('*', a => a.toString())
+    assert.deepStrictEqual(lpadZipWith([1, 2], ['a', 'b'], f), ['a1', 'b2'])
+    assert.deepStrictEqual(lpadZipWith([1, 2], ['a'], f), ['a1'])
+    assert.deepStrictEqual(lpadZipWith([1], ['a', 'b'], f), ['a1', 'b*'])
+    assert.deepStrictEqual(lpadZipWith([], [], f), [])
+  })
+
+  it('rpadZip', () => {
+    assert.deepStrictEqual(rpadZip([1, 2], ['a', 'b']), [[1, some('a')], [2, some('b')]])
+    assert.deepStrictEqual(rpadZip([1, 2], ['a']), [[1, some('a')], [2, none]])
+    assert.deepStrictEqual(rpadZip([1], ['a', 'b']), [[1, some('a')]])
+    assert.deepStrictEqual(rpadZip([], []), [])
+  })
+
+  it('rpadZipWith', () => {
+    const f = (a: number, mb: Option<string>) => mb.getOrElse('*') + a.toString()
+    assert.deepStrictEqual(rpadZipWith([1, 2], ['a', 'b'], f), ['a1', 'b2'])
+    assert.deepStrictEqual(rpadZipWith([1, 2], ['a'], f), ['a1', '*2'])
+    assert.deepStrictEqual(rpadZipWith([1], ['a', 'b'], f), ['a1'])
+    assert.deepStrictEqual(rpadZipWith([], [], f), [])
   })
 })

--- a/test/NonEmptyArray.ts
+++ b/test/NonEmptyArray.ts
@@ -18,6 +18,7 @@ import * as T from '../src/Traversable'
 import * as I from '../src/Identity'
 import * as C from '../src/Const'
 import { setoidNumber } from '../src/Setoid'
+import { These, both, this_, that } from '../src/These'
 
 describe('NonEmptyArray', () => {
   it('concat', () => {
@@ -394,5 +395,44 @@ describe('NonEmptyArray', () => {
     assert.deepStrictEqual(new NonEmptyArray('a', ['bb', 'ccc']).every(s => s.length >= 1), true)
     assert.deepStrictEqual(new NonEmptyArray('a', ['bb', 'ccc']).every(s => s.length >= 2), false)
     assert.deepStrictEqual(new NonEmptyArray('a', ['bb', 'ccc']).every(s => s.length >= 1 && s.length < 3), false)
+  })
+
+  it('align', () => {
+    assert.deepStrictEqual(
+      nonEmptyArray.align(new NonEmptyArray(1, [2, 3]), new NonEmptyArray('a', ['b', 'c'])),
+      new NonEmptyArray(both(1, 'a'), [both(2, 'b'), both(3, 'c')])
+    )
+    assert.deepStrictEqual(
+      nonEmptyArray.align(new NonEmptyArray(1, [2, 3]), new NonEmptyArray('a', ['b'])),
+      new NonEmptyArray(both(1, 'a'), [both(2, 'b'), this_(3)])
+    )
+    assert.deepStrictEqual(
+      nonEmptyArray.align(new NonEmptyArray(1, [2]), new NonEmptyArray('a', ['b', 'c'])),
+      new NonEmptyArray(both(1, 'a'), [both(2, 'b'), that('c')])
+    )
+    assert.deepStrictEqual(
+      nonEmptyArray.align(new NonEmptyArray(1, []), new NonEmptyArray('a', [])),
+      new NonEmptyArray(both(1, 'a'), [])
+    )
+  })
+
+  it('alignWith', () => {
+    const f = (x: These<number, string>) => x.fold(a => a.toString(), identity, (a, b) => b + a)
+    assert.deepStrictEqual(
+      nonEmptyArray.alignWith(new NonEmptyArray(1, [2, 3]), new NonEmptyArray('a', ['b', 'c']), f),
+      new NonEmptyArray('a1', ['b2', 'c3'])
+    )
+    assert.deepStrictEqual(
+      nonEmptyArray.alignWith(new NonEmptyArray(1, [2, 3]), new NonEmptyArray('a', ['b']), f),
+      new NonEmptyArray('a1', ['b2', '3'])
+    )
+    assert.deepStrictEqual(
+      nonEmptyArray.alignWith(new NonEmptyArray(1, [2]), new NonEmptyArray('a', ['b', 'c']), f),
+      new NonEmptyArray('a1', ['b2', 'c'])
+    )
+    assert.deepStrictEqual(
+      nonEmptyArray.alignWith(new NonEmptyArray(1, []), new NonEmptyArray('a', []), f),
+      new NonEmptyArray('a1', [])
+    )
   })
 })

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -28,6 +28,7 @@ import { setoidNumber } from '../src/Setoid'
 import { identity } from '../src/function'
 import { Identity, identity as I } from '../src/Identity'
 import { monoidSum, monoidString } from '../src/Monoid'
+import { These, both, this_, that } from '../src/These'
 import * as F from '../src/Foldable'
 
 const p = (n: number): boolean => n > 2
@@ -425,5 +426,20 @@ describe('Option', () => {
     const isA = getRefinement<C, A>(c => (c.type === 'A' ? some(c) : none))
     assert.strictEqual(isA({ type: 'A' }), true)
     assert.strictEqual(isA({ type: 'B' }), false)
+  })
+
+  it('align', () => {
+    assert.deepStrictEqual(option.align(some(1), some('a')), some(both(1, 'a')))
+    assert.deepStrictEqual(option.align(some(1), option.nil<string>()), some(this_(1)))
+    assert.deepStrictEqual(option.align(option.nil<number>(), some('a')), some(that('a')))
+    assert.deepStrictEqual(option.align(option.nil<number>(), option.nil<string>()), none)
+  })
+
+  it('alignWith', () => {
+    const f = (x: These<number, string>) => x.fold(a => a.toString(), identity, (a, b) => b + a)
+    assert.deepStrictEqual(option.alignWith(some(1), some('a'), f), some('a1'))
+    assert.deepStrictEqual(option.alignWith(some(1), option.nil<string>(), f), some('1'))
+    assert.deepStrictEqual(option.alignWith(option.nil<number>(), some('a'), f), some('a'))
+    assert.deepStrictEqual(option.alignWith(option.nil<number>(), option.nil<string>(), f), none)
   })
 })

--- a/test/Record.ts
+++ b/test/Record.ts
@@ -7,6 +7,7 @@ import { option, some, none, Option } from '../src/Option'
 import { setoidNumber } from '../src/Setoid'
 import { array } from '../src/Array'
 import { left, right } from '../src/Either'
+import { These, both, this_, that } from '../src/These'
 import * as I from '../src/Identity'
 
 const p = (n: number) => n > 2
@@ -273,5 +274,24 @@ describe('Record', () => {
     const expected = { a: 'a' }
     // tslint:disable-next-line: deprecation
     assert.deepStrictEqual(R.filterWithIndex(x, f), expected)
+  })
+
+  it('align', () => {
+    assert.deepStrictEqual(R.align({ a: 1, b: 2 }, { a: 'a', b: 'b' }), { a: both(1, 'a'), b: both(2, 'b') })
+    assert.deepStrictEqual(R.align({ a: 1, b: 2 }, { a: 'a' }), { a: both(1, 'a'), b: this_(2) })
+    assert.deepStrictEqual(R.align({ a: 1 }, { a: 'a', b: 'b' }), { a: both(1, 'a'), b: that('b') })
+    assert.deepStrictEqual(R.align({}, {}), {})
+    assert.deepStrictEqual(R.align({ a: 1 }, R.nil<string>()), { a: this_(1) })
+    assert.deepStrictEqual(R.align(R.nil<number>(), { a: 'a' }), { a: that('a') })
+  })
+
+  it('alignWith', () => {
+    const f = (x: These<number, string>) => x.fold(a => a.toString(), identity, (a, b) => b + a)
+    assert.deepStrictEqual(R.alignWith({ a: 1, b: 2 }, { a: 'a', b: 'b' }, f), { a: 'a1', b: 'b2' })
+    assert.deepStrictEqual(R.alignWith({ a: 1, b: 2 }, { a: 'a' }, f), { a: 'a1', b: '2' })
+    assert.deepStrictEqual(R.alignWith({ a: 1 }, { a: 'a', b: 'b' }, f), { a: 'a1', b: 'b' })
+    assert.deepStrictEqual(R.alignWith({}, {}, f), {})
+    assert.deepStrictEqual(R.alignWith({ a: 1 }, R.nil<string>(), f), { a: '1' })
+    assert.deepStrictEqual(R.alignWith(R.nil<number>(), { a: 'a' }, f), { a: 'a' })
   })
 })


### PR DESCRIPTION
I thought that we should get some more milage out of the These data type. So I decided to have a go at implementing the `Align` and `Semialign` type classes, that's part of the [_these_ Haskell package](http://hackage.haskell.org/package/these-0.8/docs/Data-Align.html).

I'm not sure if this is something that you want included in fp-ts.  
But if you do, I would appreciate some assistance regarding a couple of things that I'm a bit uncertain about:
1. The implementation of `Align`. It only defines the constant `nil` and I'm not sure how that should interact with the HKT emulation.
2. In the documentation, have I translated the laws correctly, and do they have names?

Also feel free to point out any other misstakes and inefficiencies. I'm partly doing this to learn, so that would be helpful.