### PR TITLE
Add Promise.all like interface for Task

### DIFF
--- a/docs/modules/Task.ts.md
+++ b/docs/modules/Task.ts.md
@@ -26,6 +26,7 @@ If you want to represent an asynchronous computation that may fail, please see `
 - [URI (constant)](#uri-constant)
 - [task (constant)](#task-constant)
 - [taskSeq (constant)](#taskseq-constant)
+- [all (function)](#all-function)
 - [delay (function)](#delay-function)
 - [fromIO (function)](#fromio-function)
 - [getMonoid (function)](#getmonoid-function)
@@ -159,6 +160,14 @@ export const taskSeq: typeof task = ...
 ```
 
 Added in v1.10.0
+
+# all (function)
+
+**Signature**
+
+```ts
+export const all = <A>(ts: Array<Task<A>>): Task<Array<A>> => ...
+```
 
 # delay (function)
 

--- a/docs/modules/TaskEither.ts.md
+++ b/docs/modules/TaskEither.ts.md
@@ -37,6 +37,7 @@ error of type `L`. If you want to represent an asynchronous computation that nev
 - [URI (constant)](#uri-constant)
 - [taskEither (constant)](#taskeither-constant)
 - [taskEitherSeq (constant)](#taskeitherseq-constant)
+- [all (function)](#all-function)
 - [bracket (function)](#bracket-function)
 - [fromEither (function)](#fromeither-function)
 - [fromIO (function)](#fromio-function)
@@ -299,6 +300,14 @@ export const taskEitherSeq: typeof taskEither = ...
 ```
 
 Added in v1.10.0
+
+# all (function)
+
+**Signature**
+
+```ts
+export const all = <L, A>(ts: Array<TaskEither<L,A>>): TaskEither<L,Array<A>> => ...
+```
 
 # bracket (function)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fp-ts",
-  "version": "1.14.4",
+  "version": "1.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2560,7 +2560,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2581,12 +2582,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2601,17 +2604,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2728,7 +2734,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2740,6 +2747,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2754,6 +2762,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2761,12 +2770,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2785,6 +2796,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2865,7 +2877,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2877,6 +2890,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2962,7 +2976,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2998,6 +3013,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3017,6 +3033,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3060,12 +3077,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -164,6 +164,14 @@ export const delay = <A>(millis: number, a: A): Task<A> => {
 
 const fromTask = identity
 
+export const all = <A>(ts: Array<Task<A>>): Task<Array<A>> => {
+  return ts.reduce((prevTask, curTask) => {
+    return prevTask.chain(prev => {
+      return curTask.map(cur => prev.concat([cur]))
+    })
+  }, new Task(async () => new Array<A>()))
+}
+
 /**
  * @since 1.0.0
  */

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -380,6 +380,14 @@ export const bracket = <L, A, B>(
   )
 }
 
+export const all = <L, A>(ts: Array<TaskEither<L,A>>): TaskEither<L,Array<A>> => {
+  return ts.reduce((prevTask, curTask) => {
+    return prevTask.chain(prev => {
+      return curTask.map(cur => prev.concat([cur]))
+    })
+  }, right(new Task(async () => new Array<A>())))
+}
+
 /**
  * @since 1.0.0
  */

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -380,7 +380,7 @@ export const bracket = <L, A, B>(
   )
 }
 
-export const all = <L, A>(ts: Array<TaskEither<L,A>>): TaskEither<L,Array<A>> => {
+export const all = <L, A>(ts: Array<TaskEither<L, A>>): TaskEither<L, Array<A>> => {
   return ts.reduce((prevTask, curTask) => {
     return prevTask.chain(prev => {
       return curTask.map(cur => prev.concat([cur]))

--- a/test/Task.ts
+++ b/test/Task.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert'
 import { left, right } from '../src/Either'
 import { IO } from '../src/IO'
 import { monoidString } from '../src/Monoid'
-import { Task, fromIO, getMonoid, getRaceMonoid, task, tryCatch, delay, taskSeq } from '../src/Task'
+import { Task, fromIO, getMonoid, getRaceMonoid, task, tryCatch, delay, taskSeq, all } from '../src/Task'
 import { sequence } from '../src/Traversable'
 import { array } from '../src/Array'
 
@@ -160,5 +160,10 @@ describe('Task', () => {
         assert.deepStrictEqual(ns, [2, 4])
         assert.deepStrictEqual(log, ['start 1', 'end 1', 'start 2', 'end 2'])
       })
+  })
+
+  it('all', () => {
+    const ts = [new Task(async () => 1), new Task(async () => 2)]
+    all(ts).run().then(ns => assert.deepStrictEqual(ns, [1, 2]))
   })
 })

--- a/test/Task.ts
+++ b/test/Task.ts
@@ -164,6 +164,8 @@ describe('Task', () => {
 
   it('all', () => {
     const ts = [new Task(async () => 1), new Task(async () => 2)]
-    all(ts).run().then(ns => assert.deepStrictEqual(ns, [1, 2]))
+    all(ts)
+      .run()
+      .then(ns => assert.deepStrictEqual(ns, [1, 2]))
   })
 })

--- a/test/TaskEither.ts
+++ b/test/TaskEither.ts
@@ -3,6 +3,7 @@ import { left as eitherLeft, right as eitherRight } from '../src/Either'
 import { IO } from '../src/IO'
 import { Task, task, delay } from '../src/Task'
 import {
+  all,
   bracket,
   TaskEither,
   fromIO,
@@ -111,6 +112,11 @@ describe('TaskEither', () => {
           assert.deepStrictEqual(e, eitherLeft('release failure'))
         })
     })
+  })
+
+  it('all', () => {
+    const ts = [right(new Task(async () => 1)), right(new Task(async () => 2))]
+    all(ts).run().then(ts => assert.deepStrictEqual(ts, [1, 2]))
   })
 
   it('ap', () => {

--- a/test/TaskEither.ts
+++ b/test/TaskEither.ts
@@ -118,7 +118,7 @@ describe('TaskEither', () => {
     const ts = [right(new Task(async () => 1)), right(new Task(async () => 2))]
     all(ts)
       .run()
-      .then(ts => assert.deepStrictEqual(ts, [1, 2]))
+      .then(ts => assert.deepStrictEqual(ts.getOrElse([]), [1, 2]))
   })
 
   it('ap', () => {

--- a/test/TaskEither.ts
+++ b/test/TaskEither.ts
@@ -116,7 +116,9 @@ describe('TaskEither', () => {
 
   it('all', () => {
     const ts = [right(new Task(async () => 1)), right(new Task(async () => 2))]
-    all(ts).run().then(ts => assert.deepStrictEqual(ts, [1, 2]))
+    all(ts)
+      .run()
+      .then(ts => assert.deepStrictEqual(ts, [1, 2]))
   })
 
   it('ap', () => {


### PR DESCRIPTION
I added `all` to `Task` and `TaskEither` same as `Promise.all`.
i.e., `all` convert `Array<Task<A>>` to `Task<Array<A>>`
```typescript 
const tasks = [new Task(async () => 1), new Task(async () => 1)]
all(tasks).run().then(console.log)
 ```
