### PR TITLE
Perf: add monad stack comparison benchmark

### DIFF
--- a/perf/native-vs-task-taskEither-vs-readerTaskEither.ts
+++ b/perf/native-vs-task-taskEither-vs-readerTaskEither.ts
@@ -1,0 +1,52 @@
+import * as Benchmark from 'benchmark'
+
+const suite = new Benchmark.Suite()
+
+import { taskEither } from 'fp-ts/lib/TaskEither'
+import { right, left } from 'fp-ts/lib/Either'
+import { readerTaskEither } from 'fp-ts/lib/ReaderTaskEither'
+
+const native = () =>
+  Promise.resolve(right('foo'))
+    .then(e => e.fold(err => Promise.resolve(left(err)), s => Promise.resolve(right(s.length))))
+    .then(e => e.fold(err => Promise.resolve(left(err)), n => Promise.resolve(right(n > 2))))
+
+const te = taskEither
+  .of('foo')
+  .chain(s => taskEither.of(s.length))
+  .chain(n => taskEither.of(n > 2))
+
+const rte = readerTaskEither
+  .of('foo')
+  .chain(s => readerTaskEither.of(s.length))
+  .chain(n => readerTaskEither.of(n > 2))
+
+// // tslint:disable-next-line
+// native().then(e => console.log('native', e))
+// // tslint:disable-next-line
+// te.run().then(e => console.log('TaskEither', e))
+// // tslint:disable-next-line
+// rte.run({}).then(e => console.log('ReaderTaskEither', e))
+
+suite
+  .add('TaskEither', function() {
+    // tslint:disable-next-line: no-floating-promises
+    te.run()
+  })
+  .add('native', function() {
+    // tslint:disable-next-line: no-floating-promises
+    native()
+  })
+  .add('ReaderTaskEither', function() {
+    // tslint:disable-next-line: no-floating-promises
+    rte.run({})
+  })
+  .on('cycle', function(event: any) {
+    // tslint:disable-next-line: no-console
+    console.log(String(event.target))
+  })
+  .on('complete', function(this: any) {
+    // tslint:disable-next-line: no-console
+    console.log('Fastest is ' + this.filter('fastest').map('name'))
+  })
+  .run({ async: true })

--- a/perf/native-vs-task-taskEither-vs-readerTaskEither.ts
+++ b/perf/native-vs-task-taskEither-vs-readerTaskEither.ts
@@ -6,9 +6,9 @@ import { taskEither } from '../src/TaskEither'
 const suite = new Benchmark.Suite()
 
 const f = (e: Either<string, string>): Promise<Either<string, number>> =>
-  e.fold(err => Promise.resolve(left(err)), s => Promise.resolve(right(s.length)))
+  e.isLeft() ? Promise.resolve(left(e.value)) : Promise.resolve(right(e.value.length))
 const g = (e: Either<string, number>): Promise<Either<string, boolean>> =>
-  e.fold(err => Promise.resolve(left(err)), n => Promise.resolve(right(n > 2)))
+  e.isLeft() ? Promise.resolve(left(e.value)) : Promise.resolve(right(e.value > 2))
 
 const native = () =>
   Promise.resolve(right<string, string>('foo'))

--- a/perf/native-vs-task-taskEither-vs-readerTaskEither.ts
+++ b/perf/native-vs-task-taskEither-vs-readerTaskEither.ts
@@ -1,15 +1,19 @@
 import * as Benchmark from 'benchmark'
+import { Either, left, right } from '../src/Either'
+import { readerTaskEither } from '../src/ReaderTaskEither'
+import { taskEither } from '../src/TaskEither'
 
 const suite = new Benchmark.Suite()
 
-import { taskEither } from 'fp-ts/lib/TaskEither'
-import { right, left } from 'fp-ts/lib/Either'
-import { readerTaskEither } from 'fp-ts/lib/ReaderTaskEither'
+const f = (e: Either<string, string>): Promise<Either<string, number>> =>
+  e.fold(err => Promise.resolve(left(err)), s => Promise.resolve(right(s.length)))
+const g = (e: Either<string, number>): Promise<Either<string, boolean>> =>
+  e.fold(err => Promise.resolve(left(err)), n => Promise.resolve(right(n > 2)))
 
 const native = () =>
-  Promise.resolve(right('foo'))
-    .then(e => e.fold(err => Promise.resolve(left(err)), s => Promise.resolve(right(s.length))))
-    .then(e => e.fold(err => Promise.resolve(left(err)), n => Promise.resolve(right(n > 2))))
+  Promise.resolve(right<string, string>('foo'))
+    .then(f)
+    .then(g)
 
 const te = taskEither
   .of('foo')


### PR DESCRIPTION
@sledorze I was trying to get an idea of how much we are loosing by stacking monads and the result is surprising (at least for `TaskEither`), is the benchmark code flawed?

TaskEither x 1,507,865 ops/sec ±5.95% (57 runs sampled)
native x 1,153,964 ops/sec ±7.83% (57 runs sampled)
ReaderTaskEither x 405,216 ops/sec ±9.67% (26 runs sampled)
Fastest is **TaskEither**