### PR TITLE
getUnionSetoid, setoidAll, setoidNull and setoidUndefined added

### DIFF
--- a/docs/modules/Setoid.ts.md
+++ b/docs/modules/Setoid.ts.md
@@ -4,27 +4,18 @@ nav_order: 78
 parent: Modules
 ---
 
-# Overview
-
-The `Setoid` type class represents types which support decidable equality.
-
-Instances must satisfy the following laws:
-
-1. Reflexivity: `S.equals(a, a) === true`
-2. Symmetry: `S.equals(a, b) === S.equals(b, a)`
-3. Transitivity: if `S.equals(a, b) === true` and `S.equals(b, c) === true`, then `S.equals(a, c) === true`
-
-See [Getting started with fp-ts: Setoid](https://dev.to/gcanti/getting-started-with-fp-ts-setoid-39f3)
-
 ---
 
 <h2 class="text-delta">Table of contents</h2>
 
 - [Setoid (interface)](#setoid-interface)
+- [setoidAll (constant)](#setoidall-constant)
 - [setoidBoolean (constant)](#setoidboolean-constant)
 - [setoidDate (constant)](#setoiddate-constant)
+- [setoidNull (constant)](#setoidnull-constant)
 - [setoidNumber (constant)](#setoidnumber-constant)
 - [setoidString (constant)](#setoidstring-constant)
+- [setoidUndefined (constant)](#setoidundefined-constant)
 - [contramap (function)](#contramap-function)
 - [fromEquals (function)](#fromequals-function)
 - [getArraySetoid (function)](#getarraysetoid-function)
@@ -32,6 +23,7 @@ See [Getting started with fp-ts: Setoid](https://dev.to/gcanti/getting-started-w
 - [~~getRecordSetoid~~ (function)](#getrecordsetoid-function)
 - [getStructSetoid (function)](#getstructsetoid-function)
 - [getTupleSetoid (function)](#gettuplesetoid-function)
+- [getUnionSetoid (function)](#getunionsetoid-function)
 - [strictEqual (function)](#strictequal-function)
 
 ---
@@ -47,6 +39,16 @@ export interface Setoid<A> {
 ```
 
 Added in v1.0.0
+
+# setoidAll (constant)
+
+**Signature**
+
+```ts
+export const setoidAll: Setoid<any> = ...
+```
+
+Added in v1.16.0
 
 # setoidBoolean (constant)
 
@@ -68,6 +70,16 @@ export const setoidDate: Setoid<Date> = ...
 
 Added in v1.4.0
 
+# setoidNull (constant)
+
+**Signature**
+
+```ts
+export const setoidNull: Setoid<null> = ...
+```
+
+Added in v1.16.0
+
 # setoidNumber (constant)
 
 **Signature**
@@ -87,6 +99,16 @@ export const setoidString: Setoid<string> = ...
 ```
 
 Added in v1.0.0
+
+# setoidUndefined (constant)
+
+**Signature**
+
+```ts
+export const setoidUndefined: Setoid<undefined> = ...
+```
+
+Added in v1.16.0
 
 # contramap (function)
 
@@ -183,6 +205,32 @@ assert.strictEqual(S.equals(['a', 1, true], ['a', 1, false]), false)
 ```
 
 Added in v1.14.2
+
+# getUnionSetoid (function)
+
+Allows the combination of multiple `Setoid` to one `Setoid`
+
+**Signature**
+
+```ts
+export const getUnionSetoid = <T extends Array<Setoid<any>>>(
+  ...setoids: T
+): Setoid<{ [K in keyof T]: T[K] extends Setoid<infer A> ? A : never }[number]> => ...
+```
+
+**Example**
+
+```ts
+import { getUnionSetoid, setoidString, setoidUndefined } from 'fp-ts/lib/Setoid'
+
+const S = getUnionSetoid(setoidString, setoidUndefined)
+assert.strictEqual(S.equals(undefined, undefined), true)
+assert.strictEqual(S.equals('a', 'a'), true)
+assert.strictEqual(S.equals('a', undefined), false)
+assert.strictEqual(S.equals(undefined, 'a'), false)
+```
+
+Added in v1.16.0
 
 # strictEqual (function)
 

--- a/src/Setoid.ts
+++ b/src/Setoid.ts
@@ -1,3 +1,5 @@
+import { constTrue } from './function'
+
 /**
  * @file The `Setoid` type class represents types which support decidable equality.
  *
@@ -51,6 +53,16 @@ export const setoidNumber: Setoid<number> = setoidStrict
 export const setoidBoolean: Setoid<boolean> = setoidStrict
 
 /**
+ * @since 1.16.0
+ */
+export const setoidNull: Setoid<null> = setoidStrict
+
+/**
+ * @since 1.16.0
+ */
+export const setoidUndefined: Setoid<undefined> = setoidStrict
+
+/**
  * @since 1.0.0
  */
 export const getArraySetoid = <A>(S: Setoid<A>): Setoid<Array<A>> => {
@@ -82,6 +94,26 @@ export const getRecordSetoid = <O extends { [key: string]: any }>(
   setoids: { [K in keyof O]: Setoid<O[K]> }
 ): Setoid<O> => {
   return getStructSetoid(setoids)
+}
+
+/**
+ * Allows the combination of multiple `Setoid` to one `Setoid`
+ *
+ * @example
+ * import { getUnionSetoid, setoidString, setoidUndefined } from 'fp-ts/lib/Setoid'
+ *
+ * const S = getUnionSetoid(setoidString, setoidUndefined)
+ * assert.strictEqual(S.equals(undefined, undefined), true)
+ * assert.strictEqual(S.equals('a', 'a'), true)
+ * assert.strictEqual(S.equals('a', undefined), false)
+ * assert.strictEqual(S.equals(undefined, 'a'), false)
+ *
+ * @since 1.16.0
+ */
+export const getUnionSetoid = <T extends Array<Setoid<any>>>(
+  ...setoids: T
+): Setoid<{ [K in keyof T]: T[K] extends Setoid<infer A> ? A : never }[number]> => {
+  return fromEquals((x, y) => setoids.some(S => S.equals(x, y)))
 }
 
 /**
@@ -126,3 +158,10 @@ export const contramap = <A, B>(f: (b: B) => A, fa: Setoid<A>): Setoid<B> => {
  * @since 1.4.0
  */
 export const setoidDate: Setoid<Date> = contramap(date => date.valueOf(), setoidNumber)
+
+/**
+ * @since 1.16.0
+ */
+export const setoidAll: Setoid<any> = {
+  equals: constTrue
+}

--- a/test/Setoid.ts
+++ b/test/Setoid.ts
@@ -8,7 +8,10 @@ import {
   setoidString,
   fromEquals,
   getTupleSetoid,
-  setoidBoolean
+  setoidBoolean,
+  getUnionSetoid,
+  setoidUndefined,
+  setoidNull
 } from '../src/Setoid'
 
 describe('Setoid', () => {
@@ -39,6 +42,20 @@ describe('Setoid', () => {
     assert.strictEqual(nbCall, 0)
     S1.equals(a1, a2)
     assert.strictEqual(nbCall, 1)
+  })
+
+  it('getUnionSetoid', () => {
+    const S = getUnionSetoid(setoidString, setoidUndefined, setoidNull)
+    assert.strictEqual(S.equals(undefined, undefined), true)
+    assert.strictEqual(S.equals(undefined, null), false)
+    assert.strictEqual(S.equals(null, undefined), false)
+    assert.strictEqual(S.equals(null, null), true)
+    assert.strictEqual(S.equals('a', null), false)
+    assert.strictEqual(S.equals('a', undefined), false)
+    assert.strictEqual(S.equals(undefined, 'a'), false)
+    assert.strictEqual(S.equals(null, 'a'), false)
+    assert.strictEqual(S.equals('a', 'a'), true)
+    assert.strictEqual(S.equals('a', 'b'), false)
   })
 
   it('getRecordSetoid', () => {


### PR DESCRIPTION
This pull requests adds `getUnionSetoid`, `setoidAll`, `setoidNull` and `setoidUndefined` to the `Setoid` module.

`getUnionSetoid` allows the combination of multiple setoids to one. My use case is the creation of new setoids that union types. Example I want to compare two values of type `string | undefined`.

```ts
const a: string | undefined;
const b: string | undefined;

setoidString.equals(a, b) // TypeScript Error

const S = getUnionSetoid(setoidString, setoidUndefined);
S.equals(a, b); // Works and typechecks correctly
```

`setoidAll` is a helper to ignore certain properties in a struct type cause it always returns `true`.

Example

```ts
interface Foo {
  a: string;
  b: number;
}

const setoidFoo = getStructSetoid<Foo>({
  a: setoidString,
  b: setoidAll
});

setoidFoo.equals({ a: 'a', b: 0 }, { a: 'a', b: 1 }) === true
```