### PR TITLE
Add es6 module step to build for tree-shaking support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.log
 node_modules
 lib
+es6
 dev
 .idea
 coverage

--- a/README.md
+++ b/README.md
@@ -57,6 +57,24 @@ npm install fp-ts
 
 Make sure to always have a single version of `fp-ts` installed in your project. Multiple versions are known to cause `tsc` to hang during compilation. You can check the versions currently installed using `npm ls fp-ts` (make sure there's a single version and all the others are marked as `deduped`).
 
+## Consuming fp-ts
+
+Most examples will use the following import syntax:
+
+```
+import { Option, some, none } from 'fp-ts/lib/Option'
+```
+
+This will give you the widest support across tools, as you will be importing CommonJS modules.
+
+If you use a bundler such as webpack or Rollup that supports tree-shaking, you can take advantage of this by opting to import ECMAScript modules instead:
+
+```
+import { Option, some, none } from 'fp-ts/es6/Option'
+```
+
+Note that there are caveats such as some tools (e.g. Jest) not supporting ES6 module syntax natively yet.
+
 ## TypeScript compatibility
 
 **Strictness** – This library is conceived, tested and is supposed to be consumed by TypeScript with the `strict` flag turned on.

--- a/package.json
+++ b/package.json
@@ -3,10 +3,13 @@
   "version": "1.15.0",
   "description": "Functional programming in TypeScript",
   "files": [
-    "lib"
+    "lib",
+    "es6"
   ],
   "main": "lib/index.js",
+  "module": "es6/index.js",
   "typings": "lib/index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "lint": "tslint -p tsconfig.tslint.json src/**/*.ts test/**/*.ts",
     "jest-clear-cache": "jest --clearCache",
@@ -14,8 +17,8 @@
     "prettier": "prettier --list-different \"./{src,test,examples,tutorial}/**/*.ts\"",
     "fix-prettier": "prettier --write \"./{src,test,examples,tutorial}/**/*.ts\"",
     "test": "npm run lint && npm run prettier && npm run dtslint && npm run jest-clear-cache && npm run jest && npm run docs",
-    "clean": "rimraf lib/*",
-    "build": "npm run clean && tsc",
+    "clean": "rimraf lib/* es6/*",
+    "build": "npm run clean && tsc && tsc -p tsconfig.es6.json",
     "prepublish": "npm run build",
     "doctoc": "doctoc README.md docs/introduction/code-conventions.md --title \"**Table of contents**\"",
     "mocha": "mocha -r ts-node/register test/*.ts",

--- a/tsconfig.es6.json
+++ b/tsconfig.es6.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./es6",
+    "target": "es6",
+    "module": "es6"
+  }
+}


### PR DESCRIPTION
This PR resolves #813 

Adds another step to the build script which outputs a bundle into `/es6` using es6 module syntax. Users can optionally switch to importing from `fp-ts/es6/*` rather than `fp-ts/lib/*` in order to make use of tree-shaking.