### PR TITLE
feat: Add fromFoldable2v to Map and deprecate fromFoldable

### DIFF
--- a/src/Map.ts
+++ b/src/Map.ts
@@ -601,8 +601,8 @@ export function fromFoldable<K, F>(
 }
 
 /**
- * Create a map from a foldable collection of key/value pairs, using the
- * specified function to combine values for duplicate keys.
+ * Create a map from a {@link Foldable2v} collection of key/value pairs, using the
+ * specified {@link Magma} instance to combine values for duplicate keys.
  *
  * @since 1.16.1
  */


### PR DESCRIPTION
This PR adds `fromFoldable2v` to `Map` module accepting a `Magma` instance instead of `onConflict` callback and deprecated previous `fromFoldable`. This is a non-breaking change.