### PR TITLE
Add CurriedN

### DIFF
--- a/src/function.ts
+++ b/src/function.ts
@@ -43,14 +43,13 @@ export type Function9<A, B, C, D, E, F, G, H, I, J> = (a: A, b: B, c: C, d: D, e
  *
  * export const sum: CurriedN<[number, number], number> = (a) => (b) => a + b
  */
-export type CurriedN<A extends Array<unknown>, B> =
-    A extends []
-    ? () => B
-    : A extends [unknown]
+export type CurriedN<A extends Array<unknown>, B> = A extends []
+  ? () => B
+  : A extends [unknown]
     ? ((...args: A) => unknown)
     : ((...args: A) => unknown) extends ((head: infer H, ...tail: infer T) => unknown)
-    ? ((...args: [H]) => CurriedN<T, B>)
-    : never
+      ? ((...args: [H]) => CurriedN<T, B>)
+      : never
 
 export type Curried2<A, B, C> = (a: A) => (b: B) => C
 export type Curried3<A, B, C, D> = (a: A) => (b: B) => (c: C) => D

--- a/src/function.ts
+++ b/src/function.ts
@@ -43,14 +43,14 @@ export type Function9<A, B, C, D, E, F, G, H, I, J> = (a: A, b: B, c: C, d: D, e
  *
  * export const sum: CurriedN<[number, number], number> = (a) => (b) => a + b
  */
-export type CurriedN<A extends unknown[], B> =
+export type CurriedN<A extends Array<unknown>, B> =
     A extends []
     ? () => B
     : A extends [unknown]
     ? ((...args: A) => unknown)
     : ((...args: A) => unknown) extends ((head: infer H, ...tail: infer T) => unknown)
     ? ((...args: [H]) => CurriedN<T, B>)
-    : never;
+    : never
 
 export type Curried2<A, B, C> = (a: A) => (b: B) => C
 export type Curried3<A, B, C, D> = (a: A) => (b: B) => (c: C) => D

--- a/src/function.ts
+++ b/src/function.ts
@@ -37,6 +37,21 @@ export type Function7<A, B, C, D, E, F, G, H> = (a: A, b: B, c: C, d: D, e: E, f
 export type Function8<A, B, C, D, E, F, G, H, I> = (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H) => I
 export type Function9<A, B, C, D, E, F, G, H, I, J> = (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I) => J
 
+/**
+ * @example
+ * import { CurriedN } from 'fp-ts/lib/function'
+ *
+ * export const sum: CurriedN<[number, number], number> = (a) => (b) => a + b
+ */
+export type CurriedN<A extends unknown[], B> =
+    A extends []
+    ? () => B
+    : A extends [unknown]
+    ? ((...args: A) => unknown)
+    : ((...args: A) => unknown) extends ((head: infer H, ...tail: infer T) => unknown)
+    ? ((...args: [H]) => CurriedN<T, B>)
+    : never;
+
 export type Curried2<A, B, C> = (a: A) => (b: B) => C
 export type Curried3<A, B, C, D> = (a: A) => (b: B) => (c: C) => D
 export type Curried4<A, B, C, D, E> = (a: A) => (b: B) => (c: C) => (d: D) => E


### PR DESCRIPTION
I added new curried function alias as such as `FunctionN`.
It consists of two parts. First one is `CurriedN<[],A> == () => A`, second one is `CurriedN<[A,...B], C> == (a: A) => CurriedN<B, C>` and `CurriedN<[],C>==C`. Please see also example code.

```typescript
import {CurriedN} from "fp-ts/lib/function";
const f: CurriedN<[number, number], number> = a=>b=>a+b; // FunctionN<[number],FunctionN<[number], number>>
const g: CurriedN<[], number> = () =>1; // FunctionN<[], number>
```

