### PR TITLE
Polish: add refinement overloads to filter / partition (Filterable ty…

### DIFF
--- a/docs/modules/Array.ts.md
+++ b/docs/modules/Array.ts.md
@@ -28,7 +28,7 @@ Adapted from https://github.com/purescript/purescript-arrays
 - [dropEnd (function)](#dropend-function)
 - [dropWhile (function)](#dropwhile-function)
 - [elem (function)](#elem-function)
-- [filter (function)](#filter-function)
+- [~~filter~~ (function)](#filter-function)
 - [findFirst (function)](#findfirst-function)
 - [findFirstMap (function)](#findfirstmap-function)
 - [findIndex (function)](#findindex-function)
@@ -58,7 +58,7 @@ Adapted from https://github.com/purescript/purescript-arrays
 - [mapOption (function)](#mapoption-function)
 - [~~member~~ (function)](#member-function)
 - [modifyAt (function)](#modifyat-function)
-- [partition (function)](#partition-function)
+- [~~partition~~ (function)](#partition-function)
 - [partitionMap (function)](#partitionmap-function)
 - [range (function)](#range-function)
 - [~~refine~~ (function)](#refine-function)
@@ -424,9 +424,9 @@ assert.strictEqual(elem(setoidNumber)(4, [1, 2, 3]), false)
 
 Added in v1.14.0
 
-# filter (function)
+# ~~filter~~ (function)
 
-Filter an array, keeping the elements which satisfy a predicate function, creating a new array
+Use `array.filter` instead
 
 **Signature**
 
@@ -1023,7 +1023,9 @@ assert.deepStrictEqual(modifyAt([], 1, double), none)
 
 Added in v1.0.0
 
-# partition (function)
+# ~~partition~~ (function)
+
+Use `array.partition` instead
 
 **Signature**
 
@@ -1079,7 +1081,7 @@ Added in v1.10.0
 
 # ~~refine~~ (function)
 
-Use `filter` instead
+Use `array.filter` instead
 
 **Signature**
 

--- a/docs/modules/Filterable.ts.md
+++ b/docs/modules/Filterable.ts.md
@@ -46,7 +46,7 @@ export interface Filterable<F> extends Functor<F>, Compactable<F> {
   /**
    * Partition a data structure based on a boolean predicate.
    */
-  readonly partition: <A>(fa: HKT<F, A>, p: Predicate<A>) => Separated<HKT<F, A>, HKT<F, A>>
+  readonly partition: Partition<F>
   /**
    * Map over a data structure and filter based on an option predicate.
    */
@@ -54,7 +54,7 @@ export interface Filterable<F> extends Functor<F>, Compactable<F> {
   /**
    * Filter a data structure based on a boolean predicate.
    */
-  readonly filter: <A>(fa: HKT<F, A>, p: Predicate<A>) => HKT<F, A>
+  readonly filter: Filter<F>
 }
 ```
 
@@ -67,9 +67,9 @@ Added in v1.7.0
 ```ts
 export interface Filterable1<F extends URIS> extends Functor1<F>, Compactable1<F> {
   readonly partitionMap: <RL, RR, A>(fa: Type<F, A>, f: (a: A) => Either<RL, RR>) => Separated<Type<F, RL>, Type<F, RR>>
-  readonly partition: <A>(fa: Type<F, A>, p: Predicate<A>) => Separated<Type<F, A>, Type<F, A>>
+  readonly partition: Partition1<F>
   readonly filterMap: <A, B>(fa: Type<F, A>, f: (a: A) => Option<B>) => Type<F, B>
-  readonly filter: <A>(fa: Type<F, A>, p: Predicate<A>) => Type<F, A>
+  readonly filter: Filter1<F>
 }
 ```
 
@@ -85,9 +85,9 @@ export interface Filterable2<F extends URIS2> extends Functor2<F>, Compactable2<
     fa: Type2<F, L, A>,
     f: (a: A) => Either<RL, RR>
   ) => Separated<Type2<F, L, RL>, Type2<F, L, RR>>
-  readonly partition: <L, A>(fa: Type2<F, L, A>, p: Predicate<A>) => Separated<Type2<F, L, A>, Type2<F, L, A>>
+  readonly partition: Partition2<F>
   readonly filterMap: <L, A, B>(fa: Type2<F, L, A>, f: (a: A) => Option<B>) => Type2<F, L, B>
-  readonly filter: <L, A>(fa: Type2<F, L, A>, p: Predicate<A>) => Type2<F, L, A>
+  readonly filter: Filter2<F>
 }
 ```
 
@@ -103,9 +103,9 @@ export interface Filterable2C<F extends URIS2, L> extends Functor2C<F, L>, Compa
     fa: Type2<F, L, A>,
     f: (a: A) => Either<RL, RR>
   ) => Separated<Type2<F, L, RL>, Type2<F, L, RR>>
-  readonly partition: <A>(fa: Type2<F, L, A>, p: Predicate<A>) => Separated<Type2<F, L, A>, Type2<F, L, A>>
+  readonly partition: Partition2C<F, L>
   readonly filterMap: <A, B>(fa: Type2<F, L, A>, f: (a: A) => Option<B>) => Type2<F, L, B>
-  readonly filter: <A>(fa: Type2<F, L, A>, p: Predicate<A>) => Type2<F, L, A>
+  readonly filter: Filter2C<F, L>
 }
 ```
 
@@ -121,12 +121,9 @@ export interface Filterable3<F extends URIS3> extends Functor3<F>, Compactable3<
     fa: Type3<F, U, L, A>,
     f: (a: A) => Either<RL, RR>
   ) => Separated<Type3<F, U, L, RL>, Type3<F, U, L, RR>>
-  readonly partition: <U, L, A>(
-    fa: Type3<F, U, L, A>,
-    p: Predicate<A>
-  ) => Separated<Type3<F, U, L, A>, Type3<F, U, L, A>>
+  readonly partition: Partition3<F>
   readonly filterMap: <U, L, A, B>(fa: Type3<F, U, L, A>, f: (a: A) => Option<B>) => Type3<F, U, L, B>
-  readonly filter: <U, L, A>(fa: Type3<F, U, L, A>, p: Predicate<A>) => Type3<F, U, L, A>
+  readonly filter: Filter3<F>
 }
 ```
 
@@ -142,9 +139,9 @@ export interface Filterable3C<F extends URIS3, U, L> extends Functor3C<F, U, L>,
     fa: Type3<F, U, L, A>,
     f: (a: A) => Either<RL, RR>
   ) => Separated<Type3<F, U, L, RL>, Type3<F, U, L, RR>>
-  readonly partition: <A>(fa: Type3<F, U, L, A>, p: Predicate<A>) => Separated<Type3<F, U, L, A>, Type3<F, U, L, A>>
+  readonly partition: Partition3C<F, U, L>
   readonly filterMap: <A, B>(fa: Type3<F, U, L, A>, f: (a: A) => Option<B>) => Type3<F, U, L, B>
-  readonly filter: <A>(fa: Type3<F, U, L, A>, p: Predicate<A>) => Type3<F, U, L, A>
+  readonly filter: Filter3C<F, U, L>
 }
 ```
 
@@ -160,9 +157,12 @@ export interface FilterableComposition<F, G> extends FunctorComposition<F, G>, C
     fa: HKT<F, HKT<G, A>>,
     f: (a: A) => Either<RL, RR>
   ) => Separated<HKT<F, HKT<G, RL>>, HKT<F, HKT<G, RR>>>
-  readonly partition: <A>(fa: HKT<F, HKT<G, A>>, p: Predicate<A>) => Separated<HKT<F, HKT<G, A>>, HKT<F, HKT<G, A>>>
+  readonly partition: <A>(
+    fa: HKT<F, HKT<G, A>>,
+    predicate: Predicate<A>
+  ) => Separated<HKT<F, HKT<G, A>>, HKT<F, HKT<G, A>>>
   readonly filterMap: <A, B>(fa: HKT<F, HKT<G, A>>, f: (a: A) => Option<B>) => HKT<F, HKT<G, B>>
-  readonly filter: <A>(fa: HKT<F, HKT<G, A>>, p: Predicate<A>) => HKT<F, HKT<G, A>>
+  readonly filter: <A>(fa: HKT<F, HKT<G, A>>, predicate: Predicate<A>) => HKT<F, HKT<G, A>>
 }
 ```
 
@@ -180,10 +180,10 @@ export interface FilterableComposition11<F extends URIS, G extends URIS>
   ) => Separated<Type<F, Type<G, RL>>, Type<F, Type<G, RR>>>
   readonly partition: <A>(
     fa: Type<F, Type<G, A>>,
-    p: Predicate<A>
+    predicate: Predicate<A>
   ) => Separated<Type<F, Type<G, A>>, Type<F, Type<G, A>>>
   readonly filterMap: <A, B>(fa: Type<F, Type<G, A>>, f: (a: A) => Option<B>) => Type<F, Type<G, B>>
-  readonly filter: <A>(fa: Type<F, Type<G, A>>, p: Predicate<A>) => Type<F, Type<G, A>>
+  readonly filter: <A>(fa: Type<F, Type<G, A>>, predicate: Predicate<A>) => Type<F, Type<G, A>>
 }
 ```
 
@@ -201,10 +201,10 @@ export interface FilterableComposition12<F extends URIS, G extends URIS2>
   ) => Separated<Type<F, Type2<G, LG, RL>>, Type<F, Type2<G, LG, RR>>>
   readonly partition: <LG, A>(
     fa: Type<F, Type2<G, LG, A>>,
-    p: Predicate<A>
+    predicate: Predicate<A>
   ) => Separated<Type<F, Type2<G, LG, A>>, Type<F, Type2<G, LG, A>>>
   readonly filterMap: <LG, A, B>(fa: Type<F, Type2<G, LG, A>>, f: (a: A) => Option<B>) => Type<F, Type2<G, LG, B>>
-  readonly filter: <LG, A>(fa: Type<F, Type2<G, LG, A>>, p: Predicate<A>) => Type<F, Type2<G, LG, A>>
+  readonly filter: <LG, A>(fa: Type<F, Type2<G, LG, A>>, predicate: Predicate<A>) => Type<F, Type2<G, LG, A>>
 }
 ```
 
@@ -222,10 +222,10 @@ export interface FilterableComposition12C<F extends URIS, G extends URIS2, LG>
   ) => Separated<Type<F, Type2<G, LG, RL>>, Type<F, Type2<G, LG, RR>>>
   readonly partition: <A>(
     fa: Type<F, Type2<G, LG, A>>,
-    p: Predicate<A>
+    predicate: Predicate<A>
   ) => Separated<Type<F, Type2<G, LG, A>>, Type<F, Type2<G, LG, A>>>
   readonly filterMap: <A, B>(fa: Type<F, Type2<G, LG, A>>, f: (a: A) => Option<B>) => Type<F, Type2<G, LG, B>>
-  readonly filter: <A>(fa: Type<F, Type2<G, LG, A>>, p: Predicate<A>) => Type<F, Type2<G, LG, A>>
+  readonly filter: <A>(fa: Type<F, Type2<G, LG, A>>, predicate: Predicate<A>) => Type<F, Type2<G, LG, A>>
 }
 ```
 
@@ -243,10 +243,10 @@ export interface FilterableComposition21<F extends URIS2, G extends URIS>
   ) => Separated<Type2<F, LF, Type<G, RL>>, Type2<F, LF, Type<G, RR>>>
   readonly partition: <LF, A>(
     fa: Type2<F, LF, Type<G, A>>,
-    p: Predicate<A>
+    predicate: Predicate<A>
   ) => Separated<Type2<F, LF, Type<G, A>>, Type2<F, LF, Type<G, A>>>
   readonly filterMap: <LF, A, B>(fa: Type2<F, LF, Type<G, A>>, f: (a: A) => Option<B>) => Type2<F, LF, Type<G, B>>
-  readonly filter: <LF, A>(fa: Type2<F, LF, Type<G, A>>, p: Predicate<A>) => Type2<F, LF, Type<G, A>>
+  readonly filter: <LF, A>(fa: Type2<F, LF, Type<G, A>>, predicate: Predicate<A>) => Type2<F, LF, Type<G, A>>
 }
 ```
 
@@ -264,13 +264,16 @@ export interface FilterableComposition22<F extends URIS2, G extends URIS2>
   ) => Separated<Type2<F, LF, Type2<G, LG, RL>>, Type2<F, LF, Type2<G, LG, RR>>>
   readonly partition: <LF, LG, A>(
     fa: Type2<F, LF, Type2<G, LG, A>>,
-    p: Predicate<A>
+    predicate: Predicate<A>
   ) => Separated<Type2<F, LF, Type2<G, LG, A>>, Type2<F, LF, Type2<G, LG, A>>>
   readonly filterMap: <LF, LG, A, B>(
     fa: Type2<F, LF, Type2<G, LG, A>>,
     f: (a: A) => Option<B>
   ) => Type2<F, LF, Type2<G, LG, B>>
-  readonly filter: <LF, LG, A>(fa: Type2<F, LF, Type2<G, LG, A>>, p: Predicate<A>) => Type2<F, LF, Type2<G, LG, A>>
+  readonly filter: <LF, LG, A>(
+    fa: Type2<F, LF, Type2<G, LG, A>>,
+    predicate: Predicate<A>
+  ) => Type2<F, LF, Type2<G, LG, A>>
 }
 ```
 
@@ -288,13 +291,13 @@ export interface FilterableComposition22C<F extends URIS2, G extends URIS2, LG>
   ) => Separated<Type2<F, LF, Type2<G, LG, RL>>, Type2<F, LF, Type2<G, LG, RR>>>
   readonly partition: <LF, A>(
     fa: Type2<F, LF, Type2<G, LG, A>>,
-    p: Predicate<A>
+    predicate: Predicate<A>
   ) => Separated<Type2<F, LF, Type2<G, LG, A>>, Type2<F, LF, Type2<G, LG, A>>>
   readonly filterMap: <LF, A, B>(
     fa: Type2<F, LF, Type2<G, LG, A>>,
     f: (a: A) => Option<B>
   ) => Type2<F, LF, Type2<G, LG, B>>
-  readonly filter: <LF, A>(fa: Type2<F, LF, Type2<G, LG, A>>, p: Predicate<A>) => Type2<F, LF, Type2<G, LG, A>>
+  readonly filter: <LF, A>(fa: Type2<F, LF, Type2<G, LG, A>>, predicate: Predicate<A>) => Type2<F, LF, Type2<G, LG, A>>
 }
 ```
 
@@ -312,10 +315,10 @@ export interface FilterableComposition2C1<F extends URIS2, G extends URIS, LF>
   ) => Separated<Type2<F, LF, Type<G, RL>>, Type2<F, LF, Type<G, RR>>>
   readonly partition: <A>(
     fa: Type2<F, LF, Type<G, A>>,
-    p: Predicate<A>
+    predicate: Predicate<A>
   ) => Separated<Type2<F, LF, Type<G, A>>, Type2<F, LF, Type<G, A>>>
   readonly filterMap: <A, B>(fa: Type2<F, LF, Type<G, A>>, f: (a: A) => Option<B>) => Type2<F, LF, Type<G, B>>
-  readonly filter: <A>(fa: Type2<F, LF, Type<G, A>>, p: Predicate<A>) => Type2<F, LF, Type<G, A>>
+  readonly filter: <A>(fa: Type2<F, LF, Type<G, A>>, predicate: Predicate<A>) => Type2<F, LF, Type<G, A>>
 }
 ```
 
@@ -333,10 +336,10 @@ export interface FilterableComposition3C1<F extends URIS3, G extends URIS, UF, L
   ) => Separated<Type3<F, UF, LF, Type<G, RL>>, Type3<F, UF, LF, Type<G, RR>>>
   readonly partition: <A>(
     fa: Type3<F, UF, LF, Type<G, A>>,
-    p: Predicate<A>
+    predicate: Predicate<A>
   ) => Separated<Type3<F, UF, LF, Type<G, A>>, Type3<F, UF, LF, Type<G, A>>>
   readonly filterMap: <A, B>(fa: Type3<F, UF, LF, Type<G, A>>, f: (a: A) => Option<B>) => Type3<F, UF, LF, Type<G, B>>
-  readonly filter: <A>(fa: Type3<F, UF, LF, Type<G, A>>, p: Predicate<A>) => Type3<F, UF, LF, Type<G, A>>
+  readonly filter: <A>(fa: Type3<F, UF, LF, Type<G, A>>, predicate: Predicate<A>) => Type3<F, UF, LF, Type<G, A>>
 }
 ```
 

--- a/docs/modules/FilterableWithIndex.ts.md
+++ b/docs/modules/FilterableWithIndex.ts.md
@@ -27,9 +27,9 @@ export interface FilterableWithIndex<F, I> extends FunctorWithIndex<F, I>, Filte
     fa: HKT<F, A>,
     f: (i: I, a: A) => Either<RL, RR>
   ) => Separated<HKT<F, RL>, HKT<F, RR>>
-  readonly partitionWithIndex: <A>(fa: HKT<F, A>, p: (i: I, a: A) => boolean) => Separated<HKT<F, A>, HKT<F, A>>
+  readonly partitionWithIndex: <A>(fa: HKT<F, A>, predicate: (i: I, a: A) => boolean) => Separated<HKT<F, A>, HKT<F, A>>
   readonly filterMapWithIndex: <A, B>(fa: HKT<F, A>, f: (i: I, a: A) => Option<B>) => HKT<F, B>
-  readonly filterWithIndex: <A>(fa: HKT<F, A>, p: (i: I, a: A) => boolean) => HKT<F, A>
+  readonly filterWithIndex: <A>(fa: HKT<F, A>, predicate: (i: I, a: A) => boolean) => HKT<F, A>
 }
 ```
 
@@ -45,9 +45,12 @@ export interface FilterableWithIndex1<F extends URIS, I> extends FunctorWithInde
     fa: Type<F, A>,
     f: (i: I, a: A) => Either<RL, RR>
   ) => Separated<Type<F, RL>, Type<F, RR>>
-  readonly partitionWithIndex: <A>(fa: Type<F, A>, p: (i: I, a: A) => boolean) => Separated<Type<F, A>, Type<F, A>>
+  readonly partitionWithIndex: <A>(
+    fa: Type<F, A>,
+    predicate: (i: I, a: A) => boolean
+  ) => Separated<Type<F, A>, Type<F, A>>
   readonly filterMapWithIndex: <A, B>(fa: Type<F, A>, f: (i: I, a: A) => Option<B>) => Type<F, B>
-  readonly filterWithIndex: <A>(fa: Type<F, A>, p: (i: I, a: A) => boolean) => Type<F, A>
+  readonly filterWithIndex: <A>(fa: Type<F, A>, predicate: (i: I, a: A) => boolean) => Type<F, A>
 }
 ```
 
@@ -63,10 +66,10 @@ export interface FilterableWithIndex2<F extends URIS2, I> extends FunctorWithInd
   ) => Separated<Type2<F, L, RL>, Type2<F, L, RR>>
   readonly partitionWithIndex: <L, A>(
     fa: Type2<F, L, A>,
-    p: (i: I, a: A) => boolean
+    predicate: (i: I, a: A) => boolean
   ) => Separated<Type2<F, L, A>, Type2<F, L, A>>
   readonly filterMapWithIndex: <L, A, B>(fa: Type2<F, L, A>, f: (i: I, a: A) => Option<B>) => Type2<F, L, B>
-  readonly filterWithIndex: <L, A>(fa: Type2<F, L, A>, p: (i: I, a: A) => boolean) => Type2<F, L, A>
+  readonly filterWithIndex: <L, A>(fa: Type2<F, L, A>, predicate: (i: I, a: A) => boolean) => Type2<F, L, A>
 }
 ```
 
@@ -82,10 +85,10 @@ export interface FilterableWithIndex2C<F extends URIS2, I, L> extends FunctorWit
   ) => Separated<Type2<F, L, RL>, Type2<F, L, RR>>
   readonly partitionWithIndex: <A>(
     fa: Type2<F, L, A>,
-    p: (i: I, a: A) => boolean
+    predicate: (i: I, a: A) => boolean
   ) => Separated<Type2<F, L, A>, Type2<F, L, A>>
   readonly filterMapWithIndex: <A, B>(fa: Type2<F, L, A>, f: (i: I, a: A) => Option<B>) => Type2<F, L, B>
-  readonly filterWithIndex: <A>(fa: Type2<F, L, A>, p: (i: I, a: A) => boolean) => Type2<F, L, A>
+  readonly filterWithIndex: <A>(fa: Type2<F, L, A>, predicate: (i: I, a: A) => boolean) => Type2<F, L, A>
 }
 ```
 
@@ -101,10 +104,10 @@ export interface FilterableWithIndex3<F extends URIS3, I> extends FunctorWithInd
   ) => Separated<Type3<F, U, L, RL>, Type3<F, U, L, RR>>
   readonly partitionWithIndex: <U, L, A>(
     fa: Type3<F, U, L, A>,
-    p: (i: I, a: A) => boolean
+    predicate: (i: I, a: A) => boolean
   ) => Separated<Type3<F, U, L, A>, Type3<F, U, L, A>>
   readonly filterMapWithIndex: <U, L, A, B>(fa: Type3<F, U, L, A>, f: (i: I, a: A) => Option<B>) => Type3<F, U, L, B>
-  readonly filterWithIndex: <U, L, A>(fa: Type3<F, U, L, A>, p: (i: I, a: A) => boolean) => Type3<F, U, L, A>
+  readonly filterWithIndex: <U, L, A>(fa: Type3<F, U, L, A>, predicate: (i: I, a: A) => boolean) => Type3<F, U, L, A>
 }
 ```
 
@@ -122,9 +125,9 @@ export interface FilterableWithIndex3C<F extends URIS3, I, U, L>
   ) => Separated<Type3<F, U, L, RL>, Type3<F, U, L, RR>>
   readonly partitionWithIndex: <A>(
     fa: Type3<F, U, L, A>,
-    p: (i: I, a: A) => boolean
+    predicate: (i: I, a: A) => boolean
   ) => Separated<Type3<F, U, L, A>, Type3<F, U, L, A>>
   readonly filterMapWithIndex: <A, B>(fa: Type3<F, U, L, A>, f: (i: I, a: A) => Option<B>) => Type3<F, U, L, B>
-  readonly filterWithIndex: <A>(fa: Type3<F, U, L, A>, p: (i: I, a: A) => boolean) => Type3<F, U, L, A>
+  readonly filterWithIndex: <A>(fa: Type3<F, U, L, A>, predicate: (i: I, a: A) => boolean) => Type3<F, U, L, A>
 }
 ```

--- a/docs/modules/FilterableWithIndex.ts.md
+++ b/docs/modules/FilterableWithIndex.ts.md
@@ -27,9 +27,9 @@ export interface FilterableWithIndex<F, I> extends FunctorWithIndex<F, I>, Filte
     fa: HKT<F, A>,
     f: (i: I, a: A) => Either<RL, RR>
   ) => Separated<HKT<F, RL>, HKT<F, RR>>
-  readonly partitionWithIndex: <A>(fa: HKT<F, A>, predicate: (i: I, a: A) => boolean) => Separated<HKT<F, A>, HKT<F, A>>
+  readonly partitionWithIndex: PartitionWithIndex<F, I>
   readonly filterMapWithIndex: <A, B>(fa: HKT<F, A>, f: (i: I, a: A) => Option<B>) => HKT<F, B>
-  readonly filterWithIndex: <A>(fa: HKT<F, A>, predicate: (i: I, a: A) => boolean) => HKT<F, A>
+  readonly filterWithIndex: FilterWithIndex<F, I>
 }
 ```
 
@@ -45,12 +45,9 @@ export interface FilterableWithIndex1<F extends URIS, I> extends FunctorWithInde
     fa: Type<F, A>,
     f: (i: I, a: A) => Either<RL, RR>
   ) => Separated<Type<F, RL>, Type<F, RR>>
-  readonly partitionWithIndex: <A>(
-    fa: Type<F, A>,
-    predicate: (i: I, a: A) => boolean
-  ) => Separated<Type<F, A>, Type<F, A>>
+  readonly partitionWithIndex: PartitionWithIndex1<F, I>
   readonly filterMapWithIndex: <A, B>(fa: Type<F, A>, f: (i: I, a: A) => Option<B>) => Type<F, B>
-  readonly filterWithIndex: <A>(fa: Type<F, A>, predicate: (i: I, a: A) => boolean) => Type<F, A>
+  readonly filterWithIndex: FilterWithIndex1<F, I>
 }
 ```
 
@@ -64,12 +61,9 @@ export interface FilterableWithIndex2<F extends URIS2, I> extends FunctorWithInd
     fa: Type2<F, L, A>,
     f: (i: I, a: A) => Either<RL, RR>
   ) => Separated<Type2<F, L, RL>, Type2<F, L, RR>>
-  readonly partitionWithIndex: <L, A>(
-    fa: Type2<F, L, A>,
-    predicate: (i: I, a: A) => boolean
-  ) => Separated<Type2<F, L, A>, Type2<F, L, A>>
+  readonly partitionWithIndex: PartitionWithIndex2<F, I>
   readonly filterMapWithIndex: <L, A, B>(fa: Type2<F, L, A>, f: (i: I, a: A) => Option<B>) => Type2<F, L, B>
-  readonly filterWithIndex: <L, A>(fa: Type2<F, L, A>, predicate: (i: I, a: A) => boolean) => Type2<F, L, A>
+  readonly filterWithIndex: FilterWithIndex2<F, I>
 }
 ```
 
@@ -83,12 +77,9 @@ export interface FilterableWithIndex2C<F extends URIS2, I, L> extends FunctorWit
     fa: Type2<F, L, A>,
     f: (i: I, a: A) => Either<RL, RR>
   ) => Separated<Type2<F, L, RL>, Type2<F, L, RR>>
-  readonly partitionWithIndex: <A>(
-    fa: Type2<F, L, A>,
-    predicate: (i: I, a: A) => boolean
-  ) => Separated<Type2<F, L, A>, Type2<F, L, A>>
+  readonly partitionWithIndex: PartitionWithIndex2C<F, I, L>
   readonly filterMapWithIndex: <A, B>(fa: Type2<F, L, A>, f: (i: I, a: A) => Option<B>) => Type2<F, L, B>
-  readonly filterWithIndex: <A>(fa: Type2<F, L, A>, predicate: (i: I, a: A) => boolean) => Type2<F, L, A>
+  readonly filterWithIndex: FilterWithIndex2C<F, I, L>
 }
 ```
 
@@ -102,12 +93,9 @@ export interface FilterableWithIndex3<F extends URIS3, I> extends FunctorWithInd
     fa: Type3<F, U, L, A>,
     f: (i: I, a: A) => Either<RL, RR>
   ) => Separated<Type3<F, U, L, RL>, Type3<F, U, L, RR>>
-  readonly partitionWithIndex: <U, L, A>(
-    fa: Type3<F, U, L, A>,
-    predicate: (i: I, a: A) => boolean
-  ) => Separated<Type3<F, U, L, A>, Type3<F, U, L, A>>
+  readonly partitionWithIndex: PartitionWithIndex3<F, I>
   readonly filterMapWithIndex: <U, L, A, B>(fa: Type3<F, U, L, A>, f: (i: I, a: A) => Option<B>) => Type3<F, U, L, B>
-  readonly filterWithIndex: <U, L, A>(fa: Type3<F, U, L, A>, predicate: (i: I, a: A) => boolean) => Type3<F, U, L, A>
+  readonly filterWithIndex: FilterWithIndex3<F, I>
 }
 ```
 
@@ -123,11 +111,8 @@ export interface FilterableWithIndex3C<F extends URIS3, I, U, L>
     fa: Type3<F, U, L, A>,
     f: (i: I, a: A) => Either<RL, RR>
   ) => Separated<Type3<F, U, L, RL>, Type3<F, U, L, RR>>
-  readonly partitionWithIndex: <A>(
-    fa: Type3<F, U, L, A>,
-    predicate: (i: I, a: A) => boolean
-  ) => Separated<Type3<F, U, L, A>, Type3<F, U, L, A>>
+  readonly partitionWithIndex: PartitionWithIndex3C<F, I, U, L>
   readonly filterMapWithIndex: <A, B>(fa: Type3<F, U, L, A>, f: (i: I, a: A) => Option<B>) => Type3<F, U, L, B>
-  readonly filterWithIndex: <A>(fa: Type3<F, U, L, A>, predicate: (i: I, a: A) => boolean) => Type3<F, U, L, A>
+  readonly filterWithIndex: FilterWithIndex3C<F, I, U, L>
 }
 ```

--- a/docs/modules/function.ts.md
+++ b/docs/modules/function.ts.md
@@ -232,7 +232,7 @@ export type Function9<A, B, C, D, E, F, G, H, I, J> = (a: A, b: B, c: C, d: D, e
 **Signature**
 
 ```ts
-export type FunctionN<A extends Array<any>, B> = (...args: A) => B
+export type FunctionN<A extends Array<unknown>, B> = (...args: A) => B
 ```
 
 **Example**

--- a/dtslint/ts3.1/index.ts
+++ b/dtslint/ts3.1/index.ts
@@ -27,6 +27,7 @@ import * as Fu from '../../lib/function'
 import * as Ring from '../../lib/Ring'
 import * as Field from '../../lib/Field'
 import * as NEA2v from '../../lib/NonEmptyArray2v'
+import * as Map from '../../lib/Map'
 
 const double = (n: number): number => n * 2
 const len = (s: string): number => s.length
@@ -437,3 +438,15 @@ const filterableEither = E.getFilterable(Mon.monoidAll)
 
 filterableEither.filter(E.right<boolean, string | number>(1), isString) // $ExpectType Either<boolean, string>
 filterableEither.partition(E.right<boolean, string | number>(1), isString) // $ExpectType Separated<Either<boolean, string | number>, Either<boolean, string>>
+
+declare function isStringWithIndex(i: number, x: unknown): x is string
+
+A.array.filterWithIndex([] as Array<string | number>, isStringWithIndex) // $ExpectType string[]
+A.array.partitionWithIndex([] as Array<string | number>, isStringWithIndex) // $ExpectType Separated<(string | number)[], string[]>
+
+const filterableWithIndexMap = Map.getFilterableWithIndex<'a' | 'b'>()
+
+declare function isStringWithKey(i: 'a' | 'b', x: unknown): x is string
+
+filterableWithIndexMap.filterWithIndex(Map.empty as Map<'a' | 'b', string | number>, isStringWithKey) // $ExpectType Map<"a" | "b", string>
+filterableWithIndexMap.partitionWithIndex(Map.empty as Map<'a' | 'b', string | number>, isStringWithKey) // $ExpectType Separated<Map<"a" | "b", string | number>, Map<"a" | "b", string>>

--- a/dtslint/ts3.1/index.ts
+++ b/dtslint/ts3.1/index.ts
@@ -423,3 +423,17 @@ Fu.tuple() // $ExpectType []
 Fu.tuple(1) // $ExpectType [number]
 Fu.tuple(1, 'a') // $ExpectType [number, string]
 Fu.tuple(1, 'a', true) // $ExpectType [number, string, boolean]
+
+//
+// Filterable overloads
+//
+
+declare function isString(x: unknown): x is string
+
+O.option.filter(O.some<string | number>('a'), isString) // $ExpectType Option<string>
+O.option.partition(O.some<string | number>('a'), isString) // $ExpectType Separated<Option<string | number>, Option<string>>
+
+const filterableEither = E.getFilterable(Mon.monoidAll)
+
+filterableEither.filter(E.right<boolean, string | number>(1), isString) // $ExpectType Either<boolean, string>
+filterableEither.partition(E.right<boolean, string | number>(1), isString) // $ExpectType Separated<Either<boolean, string | number>, Either<boolean, string>>

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -875,12 +875,13 @@ export const findLastIndex = <A>(as: Array<A>, predicate: Predicate<A>): Option<
 }
 
 /**
- * Use `filter` instead
+ * Use `array.filter` instead
  *
  * @since 1.0.0
  * @deprecated
  */
 export const refine = <A, B extends A>(as: Array<A>, refinement: Refinement<A, B>): Array<B> => {
+  // tslint:disable-next-line: deprecation
   return filter(as, refinement)
 }
 
@@ -1325,9 +1326,10 @@ export const partitionMap = <A, L, R>(fa: Array<A>, f: (a: A) => Either<L, R>): 
 }
 
 /**
- * Filter an array, keeping the elements which satisfy a predicate function, creating a new array
+ * Use `array.filter` instead
  *
  * @since 1.0.0
+ * @deprecated
  */
 export function filter<A, B extends A>(as: Array<A>, predicate: Refinement<A, B>): Array<B>
 export function filter<A>(as: Array<A>, predicate: Predicate<A>): Array<A>
@@ -1336,8 +1338,10 @@ export function filter<A>(as: Array<A>, predicate: Predicate<A>): Array<A> {
 }
 
 /**
+ * Use `array.partition` instead
  *
  * @since 1.12.0
+ * @deprecated
  */
 export function partition<A, B extends A>(fa: Array<A>, p: Refinement<A, B>): Separated<Array<A>, Array<B>>
 export function partition<A>(fa: Array<A>, p: Predicate<A>): Separated<Array<A>, Array<A>>

--- a/src/Filterable.ts
+++ b/src/Filterable.ts
@@ -21,7 +21,7 @@ import {
   Separated
 } from './Compactable'
 import { Either } from './Either'
-import { Predicate } from './function'
+import { Predicate, Refinement } from './function'
 import {
   Functor,
   Functor1,
@@ -40,6 +40,16 @@ import {
 import { HKT, Type, Type2, Type3, URIS, URIS2, URIS3 } from './HKT'
 import { Option, some, none } from './Option'
 
+interface Filter<F> {
+  <A, B extends A>(fa: HKT<F, A>, refinement: Refinement<A, B>): HKT<F, B>
+  <A>(fa: HKT<F, A>, predicate: Predicate<A>): HKT<F, A>
+}
+
+interface Partition<F> {
+  <A, B extends A>(fa: HKT<F, A>, refinement: Refinement<A, B>): Separated<HKT<F, A>, HKT<F, B>>
+  <A>(fa: HKT<F, A>, predicate: Predicate<A>): Separated<HKT<F, A>, HKT<F, A>>
+}
+
 /**
  * @since 1.7.0
  */
@@ -51,7 +61,7 @@ export interface Filterable<F> extends Functor<F>, Compactable<F> {
   /**
    * Partition a data structure based on a boolean predicate.
    */
-  readonly partition: <A>(fa: HKT<F, A>, p: Predicate<A>) => Separated<HKT<F, A>, HKT<F, A>>
+  readonly partition: Partition<F>
   /**
    * Map over a data structure and filter based on an option predicate.
    */
@@ -59,7 +69,17 @@ export interface Filterable<F> extends Functor<F>, Compactable<F> {
   /**
    * Filter a data structure based on a boolean predicate.
    */
-  readonly filter: <A>(fa: HKT<F, A>, p: Predicate<A>) => HKT<F, A>
+  readonly filter: Filter<F>
+}
+
+interface Filter1<F extends URIS> {
+  <A, B extends A>(fa: Type<F, A>, refinement: Refinement<A, B>): Type<F, B>
+  <A>(fa: Type<F, A>, predicate: Predicate<A>): Type<F, A>
+}
+
+interface Partition1<F extends URIS> {
+  <A, B extends A>(fa: Type<F, A>, refinement: Refinement<A, B>): Separated<Type<F, A>, Type<F, B>>
+  <A>(fa: Type<F, A>, predicate: Predicate<A>): Separated<Type<F, A>, Type<F, A>>
 }
 
 /**
@@ -67,9 +87,19 @@ export interface Filterable<F> extends Functor<F>, Compactable<F> {
  */
 export interface Filterable1<F extends URIS> extends Functor1<F>, Compactable1<F> {
   readonly partitionMap: <RL, RR, A>(fa: Type<F, A>, f: (a: A) => Either<RL, RR>) => Separated<Type<F, RL>, Type<F, RR>>
-  readonly partition: <A>(fa: Type<F, A>, p: Predicate<A>) => Separated<Type<F, A>, Type<F, A>>
+  readonly partition: Partition1<F>
   readonly filterMap: <A, B>(fa: Type<F, A>, f: (a: A) => Option<B>) => Type<F, B>
-  readonly filter: <A>(fa: Type<F, A>, p: Predicate<A>) => Type<F, A>
+  readonly filter: Filter1<F>
+}
+
+interface Filter2<F extends URIS2> {
+  <L, A, B extends A>(fa: Type2<F, L, A>, refinement: Refinement<A, B>): Type2<F, L, B>
+  <L, A>(fa: Type2<F, L, A>, predicate: Predicate<A>): Type2<F, L, A>
+}
+
+interface Partition2<F extends URIS2> {
+  <L, A, B extends A>(fa: Type2<F, L, A>, refinement: Refinement<A, B>): Separated<Type2<F, L, A>, Type2<F, L, B>>
+  <L, A>(fa: Type2<F, L, A>, predicate: Predicate<A>): Separated<Type2<F, L, A>, Type2<F, L, A>>
 }
 
 /**
@@ -80,9 +110,19 @@ export interface Filterable2<F extends URIS2> extends Functor2<F>, Compactable2<
     fa: Type2<F, L, A>,
     f: (a: A) => Either<RL, RR>
   ) => Separated<Type2<F, L, RL>, Type2<F, L, RR>>
-  readonly partition: <L, A>(fa: Type2<F, L, A>, p: Predicate<A>) => Separated<Type2<F, L, A>, Type2<F, L, A>>
+  readonly partition: Partition2<F>
   readonly filterMap: <L, A, B>(fa: Type2<F, L, A>, f: (a: A) => Option<B>) => Type2<F, L, B>
-  readonly filter: <L, A>(fa: Type2<F, L, A>, p: Predicate<A>) => Type2<F, L, A>
+  readonly filter: Filter2<F>
+}
+
+interface Filter2C<F extends URIS2, L> {
+  <A, B extends A>(fa: Type2<F, L, A>, refinement: Refinement<A, B>): Type2<F, L, B>
+  <A>(fa: Type2<F, L, A>, predicate: Predicate<A>): Type2<F, L, A>
+}
+
+interface Partition2C<F extends URIS2, L> {
+  <A, B extends A>(fa: Type2<F, L, A>, refinement: Refinement<A, B>): Separated<Type2<F, L, A>, Type2<F, L, B>>
+  <A>(fa: Type2<F, L, A>, predicate: Predicate<A>): Separated<Type2<F, L, A>, Type2<F, L, A>>
 }
 
 /**
@@ -93,9 +133,22 @@ export interface Filterable2C<F extends URIS2, L> extends Functor2C<F, L>, Compa
     fa: Type2<F, L, A>,
     f: (a: A) => Either<RL, RR>
   ) => Separated<Type2<F, L, RL>, Type2<F, L, RR>>
-  readonly partition: <A>(fa: Type2<F, L, A>, p: Predicate<A>) => Separated<Type2<F, L, A>, Type2<F, L, A>>
+  readonly partition: Partition2C<F, L>
   readonly filterMap: <A, B>(fa: Type2<F, L, A>, f: (a: A) => Option<B>) => Type2<F, L, B>
-  readonly filter: <A>(fa: Type2<F, L, A>, p: Predicate<A>) => Type2<F, L, A>
+  readonly filter: Filter2C<F, L>
+}
+
+interface Filter3<F extends URIS3> {
+  <U, L, A, B extends A>(fa: Type3<F, U, L, A>, refinement: Refinement<A, B>): Type3<F, U, L, B>
+  <U, L, A>(fa: Type3<F, U, L, A>, predicate: Predicate<A>): Type3<F, U, L, A>
+}
+
+interface Partition3<F extends URIS3> {
+  <U, L, A, B extends A>(fa: Type3<F, U, L, A>, refinement: Refinement<A, B>): Separated<
+    Type3<F, U, L, A>,
+    Type3<F, U, L, B>
+  >
+  <U, L, A>(fa: Type3<F, U, L, A>, predicate: Predicate<A>): Separated<Type3<F, U, L, A>, Type3<F, U, L, A>>
 }
 
 /**
@@ -106,12 +159,19 @@ export interface Filterable3<F extends URIS3> extends Functor3<F>, Compactable3<
     fa: Type3<F, U, L, A>,
     f: (a: A) => Either<RL, RR>
   ) => Separated<Type3<F, U, L, RL>, Type3<F, U, L, RR>>
-  readonly partition: <U, L, A>(
-    fa: Type3<F, U, L, A>,
-    p: Predicate<A>
-  ) => Separated<Type3<F, U, L, A>, Type3<F, U, L, A>>
+  readonly partition: Partition3<F>
   readonly filterMap: <U, L, A, B>(fa: Type3<F, U, L, A>, f: (a: A) => Option<B>) => Type3<F, U, L, B>
-  readonly filter: <U, L, A>(fa: Type3<F, U, L, A>, p: Predicate<A>) => Type3<F, U, L, A>
+  readonly filter: Filter3<F>
+}
+
+interface Filter3C<F extends URIS3, U, L> {
+  <A, B extends A>(fa: Type3<F, U, L, A>, refinement: Refinement<A, B>): Type3<F, U, L, B>
+  <A>(fa: Type3<F, U, L, A>, predicate: Predicate<A>): Type3<F, U, L, A>
+}
+
+interface Partition3C<F extends URIS3, U, L> {
+  <A, B extends A>(fa: Type3<F, U, L, A>, refinement: Refinement<A, B>): Separated<Type3<F, U, L, A>, Type3<F, U, L, B>>
+  <A>(fa: Type3<F, U, L, A>, predicate: Predicate<A>): Separated<Type3<F, U, L, A>, Type3<F, U, L, A>>
 }
 
 /**
@@ -122,9 +182,9 @@ export interface Filterable3C<F extends URIS3, U, L> extends Functor3C<F, U, L>,
     fa: Type3<F, U, L, A>,
     f: (a: A) => Either<RL, RR>
   ) => Separated<Type3<F, U, L, RL>, Type3<F, U, L, RR>>
-  readonly partition: <A>(fa: Type3<F, U, L, A>, p: Predicate<A>) => Separated<Type3<F, U, L, A>, Type3<F, U, L, A>>
+  readonly partition: Partition3C<F, U, L>
   readonly filterMap: <A, B>(fa: Type3<F, U, L, A>, f: (a: A) => Option<B>) => Type3<F, U, L, B>
-  readonly filter: <A>(fa: Type3<F, U, L, A>, p: Predicate<A>) => Type3<F, U, L, A>
+  readonly filter: Filter3C<F, U, L>
 }
 
 export interface FilterableComposition<F, G> extends FunctorComposition<F, G>, CompactableComposition<F, G> {
@@ -132,9 +192,12 @@ export interface FilterableComposition<F, G> extends FunctorComposition<F, G>, C
     fa: HKT<F, HKT<G, A>>,
     f: (a: A) => Either<RL, RR>
   ) => Separated<HKT<F, HKT<G, RL>>, HKT<F, HKT<G, RR>>>
-  readonly partition: <A>(fa: HKT<F, HKT<G, A>>, p: Predicate<A>) => Separated<HKT<F, HKT<G, A>>, HKT<F, HKT<G, A>>>
+  readonly partition: <A>(
+    fa: HKT<F, HKT<G, A>>,
+    predicate: Predicate<A>
+  ) => Separated<HKT<F, HKT<G, A>>, HKT<F, HKT<G, A>>>
   readonly filterMap: <A, B>(fa: HKT<F, HKT<G, A>>, f: (a: A) => Option<B>) => HKT<F, HKT<G, B>>
-  readonly filter: <A>(fa: HKT<F, HKT<G, A>>, p: Predicate<A>) => HKT<F, HKT<G, A>>
+  readonly filter: <A>(fa: HKT<F, HKT<G, A>>, predicate: Predicate<A>) => HKT<F, HKT<G, A>>
 }
 
 export interface FilterableComposition11<F extends URIS, G extends URIS>
@@ -146,10 +209,10 @@ export interface FilterableComposition11<F extends URIS, G extends URIS>
   ) => Separated<Type<F, Type<G, RL>>, Type<F, Type<G, RR>>>
   readonly partition: <A>(
     fa: Type<F, Type<G, A>>,
-    p: Predicate<A>
+    predicate: Predicate<A>
   ) => Separated<Type<F, Type<G, A>>, Type<F, Type<G, A>>>
   readonly filterMap: <A, B>(fa: Type<F, Type<G, A>>, f: (a: A) => Option<B>) => Type<F, Type<G, B>>
-  readonly filter: <A>(fa: Type<F, Type<G, A>>, p: Predicate<A>) => Type<F, Type<G, A>>
+  readonly filter: <A>(fa: Type<F, Type<G, A>>, predicate: Predicate<A>) => Type<F, Type<G, A>>
 }
 
 export interface FilterableComposition12<F extends URIS, G extends URIS2>
@@ -161,10 +224,10 @@ export interface FilterableComposition12<F extends URIS, G extends URIS2>
   ) => Separated<Type<F, Type2<G, LG, RL>>, Type<F, Type2<G, LG, RR>>>
   readonly partition: <LG, A>(
     fa: Type<F, Type2<G, LG, A>>,
-    p: Predicate<A>
+    predicate: Predicate<A>
   ) => Separated<Type<F, Type2<G, LG, A>>, Type<F, Type2<G, LG, A>>>
   readonly filterMap: <LG, A, B>(fa: Type<F, Type2<G, LG, A>>, f: (a: A) => Option<B>) => Type<F, Type2<G, LG, B>>
-  readonly filter: <LG, A>(fa: Type<F, Type2<G, LG, A>>, p: Predicate<A>) => Type<F, Type2<G, LG, A>>
+  readonly filter: <LG, A>(fa: Type<F, Type2<G, LG, A>>, predicate: Predicate<A>) => Type<F, Type2<G, LG, A>>
 }
 
 export interface FilterableComposition12C<F extends URIS, G extends URIS2, LG>
@@ -176,10 +239,10 @@ export interface FilterableComposition12C<F extends URIS, G extends URIS2, LG>
   ) => Separated<Type<F, Type2<G, LG, RL>>, Type<F, Type2<G, LG, RR>>>
   readonly partition: <A>(
     fa: Type<F, Type2<G, LG, A>>,
-    p: Predicate<A>
+    predicate: Predicate<A>
   ) => Separated<Type<F, Type2<G, LG, A>>, Type<F, Type2<G, LG, A>>>
   readonly filterMap: <A, B>(fa: Type<F, Type2<G, LG, A>>, f: (a: A) => Option<B>) => Type<F, Type2<G, LG, B>>
-  readonly filter: <A>(fa: Type<F, Type2<G, LG, A>>, p: Predicate<A>) => Type<F, Type2<G, LG, A>>
+  readonly filter: <A>(fa: Type<F, Type2<G, LG, A>>, predicate: Predicate<A>) => Type<F, Type2<G, LG, A>>
 }
 
 export interface FilterableComposition21<F extends URIS2, G extends URIS>
@@ -191,10 +254,10 @@ export interface FilterableComposition21<F extends URIS2, G extends URIS>
   ) => Separated<Type2<F, LF, Type<G, RL>>, Type2<F, LF, Type<G, RR>>>
   readonly partition: <LF, A>(
     fa: Type2<F, LF, Type<G, A>>,
-    p: Predicate<A>
+    predicate: Predicate<A>
   ) => Separated<Type2<F, LF, Type<G, A>>, Type2<F, LF, Type<G, A>>>
   readonly filterMap: <LF, A, B>(fa: Type2<F, LF, Type<G, A>>, f: (a: A) => Option<B>) => Type2<F, LF, Type<G, B>>
-  readonly filter: <LF, A>(fa: Type2<F, LF, Type<G, A>>, p: Predicate<A>) => Type2<F, LF, Type<G, A>>
+  readonly filter: <LF, A>(fa: Type2<F, LF, Type<G, A>>, predicate: Predicate<A>) => Type2<F, LF, Type<G, A>>
 }
 
 export interface FilterableComposition2C1<F extends URIS2, G extends URIS, LF>
@@ -206,10 +269,10 @@ export interface FilterableComposition2C1<F extends URIS2, G extends URIS, LF>
   ) => Separated<Type2<F, LF, Type<G, RL>>, Type2<F, LF, Type<G, RR>>>
   readonly partition: <A>(
     fa: Type2<F, LF, Type<G, A>>,
-    p: Predicate<A>
+    predicate: Predicate<A>
   ) => Separated<Type2<F, LF, Type<G, A>>, Type2<F, LF, Type<G, A>>>
   readonly filterMap: <A, B>(fa: Type2<F, LF, Type<G, A>>, f: (a: A) => Option<B>) => Type2<F, LF, Type<G, B>>
-  readonly filter: <A>(fa: Type2<F, LF, Type<G, A>>, p: Predicate<A>) => Type2<F, LF, Type<G, A>>
+  readonly filter: <A>(fa: Type2<F, LF, Type<G, A>>, predicate: Predicate<A>) => Type2<F, LF, Type<G, A>>
 }
 
 export interface FilterableComposition22<F extends URIS2, G extends URIS2>
@@ -221,13 +284,16 @@ export interface FilterableComposition22<F extends URIS2, G extends URIS2>
   ) => Separated<Type2<F, LF, Type2<G, LG, RL>>, Type2<F, LF, Type2<G, LG, RR>>>
   readonly partition: <LF, LG, A>(
     fa: Type2<F, LF, Type2<G, LG, A>>,
-    p: Predicate<A>
+    predicate: Predicate<A>
   ) => Separated<Type2<F, LF, Type2<G, LG, A>>, Type2<F, LF, Type2<G, LG, A>>>
   readonly filterMap: <LF, LG, A, B>(
     fa: Type2<F, LF, Type2<G, LG, A>>,
     f: (a: A) => Option<B>
   ) => Type2<F, LF, Type2<G, LG, B>>
-  readonly filter: <LF, LG, A>(fa: Type2<F, LF, Type2<G, LG, A>>, p: Predicate<A>) => Type2<F, LF, Type2<G, LG, A>>
+  readonly filter: <LF, LG, A>(
+    fa: Type2<F, LF, Type2<G, LG, A>>,
+    predicate: Predicate<A>
+  ) => Type2<F, LF, Type2<G, LG, A>>
 }
 
 export interface FilterableComposition22C<F extends URIS2, G extends URIS2, LG>
@@ -239,13 +305,13 @@ export interface FilterableComposition22C<F extends URIS2, G extends URIS2, LG>
   ) => Separated<Type2<F, LF, Type2<G, LG, RL>>, Type2<F, LF, Type2<G, LG, RR>>>
   readonly partition: <LF, A>(
     fa: Type2<F, LF, Type2<G, LG, A>>,
-    p: Predicate<A>
+    predicate: Predicate<A>
   ) => Separated<Type2<F, LF, Type2<G, LG, A>>, Type2<F, LF, Type2<G, LG, A>>>
   readonly filterMap: <LF, A, B>(
     fa: Type2<F, LF, Type2<G, LG, A>>,
     f: (a: A) => Option<B>
   ) => Type2<F, LF, Type2<G, LG, B>>
-  readonly filter: <LF, A>(fa: Type2<F, LF, Type2<G, LG, A>>, p: Predicate<A>) => Type2<F, LF, Type2<G, LG, A>>
+  readonly filter: <LF, A>(fa: Type2<F, LF, Type2<G, LG, A>>, predicate: Predicate<A>) => Type2<F, LF, Type2<G, LG, A>>
 }
 
 export interface FilterableComposition3C1<F extends URIS3, G extends URIS, UF, LF>
@@ -257,10 +323,10 @@ export interface FilterableComposition3C1<F extends URIS3, G extends URIS, UF, L
   ) => Separated<Type3<F, UF, LF, Type<G, RL>>, Type3<F, UF, LF, Type<G, RR>>>
   readonly partition: <A>(
     fa: Type3<F, UF, LF, Type<G, A>>,
-    p: Predicate<A>
+    predicate: Predicate<A>
   ) => Separated<Type3<F, UF, LF, Type<G, A>>, Type3<F, UF, LF, Type<G, A>>>
   readonly filterMap: <A, B>(fa: Type3<F, UF, LF, Type<G, A>>, f: (a: A) => Option<B>) => Type3<F, UF, LF, Type<G, B>>
-  readonly filter: <A>(fa: Type3<F, UF, LF, Type<G, A>>, p: Predicate<A>) => Type3<F, UF, LF, Type<G, A>>
+  readonly filter: <A>(fa: Type3<F, UF, LF, Type<G, A>>, predicate: Predicate<A>) => Type3<F, UF, LF, Type<G, A>>
 }
 
 /**

--- a/src/FilterableWithIndex.ts
+++ b/src/FilterableWithIndex.ts
@@ -20,9 +20,9 @@ export interface FilterableWithIndex<F, I> extends FunctorWithIndex<F, I>, Filte
     fa: HKT<F, A>,
     f: (i: I, a: A) => Either<RL, RR>
   ) => Separated<HKT<F, RL>, HKT<F, RR>>
-  readonly partitionWithIndex: <A>(fa: HKT<F, A>, p: (i: I, a: A) => boolean) => Separated<HKT<F, A>, HKT<F, A>>
+  readonly partitionWithIndex: <A>(fa: HKT<F, A>, predicate: (i: I, a: A) => boolean) => Separated<HKT<F, A>, HKT<F, A>>
   readonly filterMapWithIndex: <A, B>(fa: HKT<F, A>, f: (i: I, a: A) => Option<B>) => HKT<F, B>
-  readonly filterWithIndex: <A>(fa: HKT<F, A>, p: (i: I, a: A) => boolean) => HKT<F, A>
+  readonly filterWithIndex: <A>(fa: HKT<F, A>, predicate: (i: I, a: A) => boolean) => HKT<F, A>
 }
 
 export interface FilterableWithIndex1<F extends URIS, I> extends FunctorWithIndex1<F, I>, Filterable1<F> {
@@ -30,9 +30,12 @@ export interface FilterableWithIndex1<F extends URIS, I> extends FunctorWithInde
     fa: Type<F, A>,
     f: (i: I, a: A) => Either<RL, RR>
   ) => Separated<Type<F, RL>, Type<F, RR>>
-  readonly partitionWithIndex: <A>(fa: Type<F, A>, p: (i: I, a: A) => boolean) => Separated<Type<F, A>, Type<F, A>>
+  readonly partitionWithIndex: <A>(
+    fa: Type<F, A>,
+    predicate: (i: I, a: A) => boolean
+  ) => Separated<Type<F, A>, Type<F, A>>
   readonly filterMapWithIndex: <A, B>(fa: Type<F, A>, f: (i: I, a: A) => Option<B>) => Type<F, B>
-  readonly filterWithIndex: <A>(fa: Type<F, A>, p: (i: I, a: A) => boolean) => Type<F, A>
+  readonly filterWithIndex: <A>(fa: Type<F, A>, predicate: (i: I, a: A) => boolean) => Type<F, A>
 }
 
 export interface FilterableWithIndex2<F extends URIS2, I> extends FunctorWithIndex2<F, I>, Filterable2<F> {
@@ -42,10 +45,10 @@ export interface FilterableWithIndex2<F extends URIS2, I> extends FunctorWithInd
   ) => Separated<Type2<F, L, RL>, Type2<F, L, RR>>
   readonly partitionWithIndex: <L, A>(
     fa: Type2<F, L, A>,
-    p: (i: I, a: A) => boolean
+    predicate: (i: I, a: A) => boolean
   ) => Separated<Type2<F, L, A>, Type2<F, L, A>>
   readonly filterMapWithIndex: <L, A, B>(fa: Type2<F, L, A>, f: (i: I, a: A) => Option<B>) => Type2<F, L, B>
-  readonly filterWithIndex: <L, A>(fa: Type2<F, L, A>, p: (i: I, a: A) => boolean) => Type2<F, L, A>
+  readonly filterWithIndex: <L, A>(fa: Type2<F, L, A>, predicate: (i: I, a: A) => boolean) => Type2<F, L, A>
 }
 
 export interface FilterableWithIndex2C<F extends URIS2, I, L> extends FunctorWithIndex2C<F, I, L>, Filterable2C<F, L> {
@@ -55,10 +58,10 @@ export interface FilterableWithIndex2C<F extends URIS2, I, L> extends FunctorWit
   ) => Separated<Type2<F, L, RL>, Type2<F, L, RR>>
   readonly partitionWithIndex: <A>(
     fa: Type2<F, L, A>,
-    p: (i: I, a: A) => boolean
+    predicate: (i: I, a: A) => boolean
   ) => Separated<Type2<F, L, A>, Type2<F, L, A>>
   readonly filterMapWithIndex: <A, B>(fa: Type2<F, L, A>, f: (i: I, a: A) => Option<B>) => Type2<F, L, B>
-  readonly filterWithIndex: <A>(fa: Type2<F, L, A>, p: (i: I, a: A) => boolean) => Type2<F, L, A>
+  readonly filterWithIndex: <A>(fa: Type2<F, L, A>, predicate: (i: I, a: A) => boolean) => Type2<F, L, A>
 }
 
 export interface FilterableWithIndex3<F extends URIS3, I> extends FunctorWithIndex3<F, I>, Filterable3<F> {
@@ -68,10 +71,10 @@ export interface FilterableWithIndex3<F extends URIS3, I> extends FunctorWithInd
   ) => Separated<Type3<F, U, L, RL>, Type3<F, U, L, RR>>
   readonly partitionWithIndex: <U, L, A>(
     fa: Type3<F, U, L, A>,
-    p: (i: I, a: A) => boolean
+    predicate: (i: I, a: A) => boolean
   ) => Separated<Type3<F, U, L, A>, Type3<F, U, L, A>>
   readonly filterMapWithIndex: <U, L, A, B>(fa: Type3<F, U, L, A>, f: (i: I, a: A) => Option<B>) => Type3<F, U, L, B>
-  readonly filterWithIndex: <U, L, A>(fa: Type3<F, U, L, A>, p: (i: I, a: A) => boolean) => Type3<F, U, L, A>
+  readonly filterWithIndex: <U, L, A>(fa: Type3<F, U, L, A>, predicate: (i: I, a: A) => boolean) => Type3<F, U, L, A>
 }
 
 export interface FilterableWithIndex3C<F extends URIS3, I, U, L>
@@ -83,8 +86,8 @@ export interface FilterableWithIndex3C<F extends URIS3, I, U, L>
   ) => Separated<Type3<F, U, L, RL>, Type3<F, U, L, RR>>
   readonly partitionWithIndex: <A>(
     fa: Type3<F, U, L, A>,
-    p: (i: I, a: A) => boolean
+    predicate: (i: I, a: A) => boolean
   ) => Separated<Type3<F, U, L, A>, Type3<F, U, L, A>>
   readonly filterMapWithIndex: <A, B>(fa: Type3<F, U, L, A>, f: (i: I, a: A) => Option<B>) => Type3<F, U, L, B>
-  readonly filterWithIndex: <A>(fa: Type3<F, U, L, A>, p: (i: I, a: A) => boolean) => Type3<F, U, L, A>
+  readonly filterWithIndex: <A>(fa: Type3<F, U, L, A>, predicate: (i: I, a: A) => boolean) => Type3<F, U, L, A>
 }

--- a/src/FilterableWithIndex.ts
+++ b/src/FilterableWithIndex.ts
@@ -12,6 +12,19 @@ import {
 import { HKT, Type, Type2, Type3, URIS, URIS2, URIS3 } from './HKT'
 import { Option } from './Option'
 
+type RefinementWithIndex<I, A, B extends A> = (i: I, a: A) => a is B
+type PredicateWithIndex<I, A> = (i: I, a: A) => boolean
+
+interface FilterWithIndex<F, I> {
+  <A, B extends A>(fa: HKT<F, A>, refinementWithIndex: RefinementWithIndex<I, A, B>): HKT<F, B>
+  <A>(fa: HKT<F, A>, predicateWithIndex: PredicateWithIndex<I, A>): HKT<F, A>
+}
+
+interface PartitionWithIndex<F, I> {
+  <A, B extends A>(fa: HKT<F, A>, refinementWithIndex: RefinementWithIndex<I, A, B>): Separated<HKT<F, A>, HKT<F, B>>
+  <A>(fa: HKT<F, A>, predicateWithIndex: PredicateWithIndex<I, A>): Separated<HKT<F, A>, HKT<F, A>>
+}
+
 /**
  * @since 1.12.0
  */
@@ -20,9 +33,19 @@ export interface FilterableWithIndex<F, I> extends FunctorWithIndex<F, I>, Filte
     fa: HKT<F, A>,
     f: (i: I, a: A) => Either<RL, RR>
   ) => Separated<HKT<F, RL>, HKT<F, RR>>
-  readonly partitionWithIndex: <A>(fa: HKT<F, A>, predicate: (i: I, a: A) => boolean) => Separated<HKT<F, A>, HKT<F, A>>
+  readonly partitionWithIndex: PartitionWithIndex<F, I>
   readonly filterMapWithIndex: <A, B>(fa: HKT<F, A>, f: (i: I, a: A) => Option<B>) => HKT<F, B>
-  readonly filterWithIndex: <A>(fa: HKT<F, A>, predicate: (i: I, a: A) => boolean) => HKT<F, A>
+  readonly filterWithIndex: FilterWithIndex<F, I>
+}
+
+interface FilterWithIndex1<F extends URIS, I> {
+  <A, B extends A>(fa: Type<F, A>, refinementWithIndex: RefinementWithIndex<I, A, B>): Type<F, B>
+  <A>(fa: Type<F, A>, predicateWithIndex: PredicateWithIndex<I, A>): Type<F, A>
+}
+
+interface PartitionWithIndex1<F extends URIS, I> {
+  <A, B extends A>(fa: Type<F, A>, refinementWithIndex: RefinementWithIndex<I, A, B>): Separated<Type<F, A>, Type<F, B>>
+  <A>(fa: Type<F, A>, predicateWithIndex: PredicateWithIndex<I, A>): Separated<Type<F, A>, Type<F, A>>
 }
 
 export interface FilterableWithIndex1<F extends URIS, I> extends FunctorWithIndex1<F, I>, Filterable1<F> {
@@ -30,12 +53,22 @@ export interface FilterableWithIndex1<F extends URIS, I> extends FunctorWithInde
     fa: Type<F, A>,
     f: (i: I, a: A) => Either<RL, RR>
   ) => Separated<Type<F, RL>, Type<F, RR>>
-  readonly partitionWithIndex: <A>(
-    fa: Type<F, A>,
-    predicate: (i: I, a: A) => boolean
-  ) => Separated<Type<F, A>, Type<F, A>>
+  readonly partitionWithIndex: PartitionWithIndex1<F, I>
   readonly filterMapWithIndex: <A, B>(fa: Type<F, A>, f: (i: I, a: A) => Option<B>) => Type<F, B>
-  readonly filterWithIndex: <A>(fa: Type<F, A>, predicate: (i: I, a: A) => boolean) => Type<F, A>
+  readonly filterWithIndex: FilterWithIndex1<F, I>
+}
+
+interface FilterWithIndex2<F extends URIS2, I> {
+  <L, A, B extends A>(fa: Type2<F, L, A>, refinementWithIndex: RefinementWithIndex<I, A, B>): Type2<F, L, B>
+  <L, A>(fa: Type2<F, L, A>, predicateWithIndex: PredicateWithIndex<I, A>): Type2<F, L, A>
+}
+
+interface PartitionWithIndex2<F extends URIS2, I> {
+  <L, A, B extends A>(fa: Type2<F, L, A>, refinementWithIndex: RefinementWithIndex<I, A, B>): Separated<
+    Type2<F, L, A>,
+    Type2<F, L, B>
+  >
+  <L, A>(fa: Type2<F, L, A>, predicateWithIndex: PredicateWithIndex<I, A>): Separated<Type2<F, L, A>, Type2<F, L, A>>
 }
 
 export interface FilterableWithIndex2<F extends URIS2, I> extends FunctorWithIndex2<F, I>, Filterable2<F> {
@@ -43,12 +76,22 @@ export interface FilterableWithIndex2<F extends URIS2, I> extends FunctorWithInd
     fa: Type2<F, L, A>,
     f: (i: I, a: A) => Either<RL, RR>
   ) => Separated<Type2<F, L, RL>, Type2<F, L, RR>>
-  readonly partitionWithIndex: <L, A>(
-    fa: Type2<F, L, A>,
-    predicate: (i: I, a: A) => boolean
-  ) => Separated<Type2<F, L, A>, Type2<F, L, A>>
+  readonly partitionWithIndex: PartitionWithIndex2<F, I>
   readonly filterMapWithIndex: <L, A, B>(fa: Type2<F, L, A>, f: (i: I, a: A) => Option<B>) => Type2<F, L, B>
-  readonly filterWithIndex: <L, A>(fa: Type2<F, L, A>, predicate: (i: I, a: A) => boolean) => Type2<F, L, A>
+  readonly filterWithIndex: FilterWithIndex2<F, I>
+}
+
+interface FilterWithIndex2C<F extends URIS2, I, L> {
+  <A, B extends A>(fa: Type2<F, L, A>, refinementWithIndex: RefinementWithIndex<I, A, B>): Type2<F, L, B>
+  <A>(fa: Type2<F, L, A>, predicateWithIndex: PredicateWithIndex<I, A>): Type2<F, L, A>
+}
+
+interface PartitionWithIndex2C<F extends URIS2, I, L> {
+  <A, B extends A>(fa: Type2<F, L, A>, refinementWithIndex: RefinementWithIndex<I, A, B>): Separated<
+    Type2<F, L, A>,
+    Type2<F, L, B>
+  >
+  <A>(fa: Type2<F, L, A>, predicateWithIndex: PredicateWithIndex<I, A>): Separated<Type2<F, L, A>, Type2<F, L, A>>
 }
 
 export interface FilterableWithIndex2C<F extends URIS2, I, L> extends FunctorWithIndex2C<F, I, L>, Filterable2C<F, L> {
@@ -56,12 +99,25 @@ export interface FilterableWithIndex2C<F extends URIS2, I, L> extends FunctorWit
     fa: Type2<F, L, A>,
     f: (i: I, a: A) => Either<RL, RR>
   ) => Separated<Type2<F, L, RL>, Type2<F, L, RR>>
-  readonly partitionWithIndex: <A>(
-    fa: Type2<F, L, A>,
-    predicate: (i: I, a: A) => boolean
-  ) => Separated<Type2<F, L, A>, Type2<F, L, A>>
+  readonly partitionWithIndex: PartitionWithIndex2C<F, I, L>
   readonly filterMapWithIndex: <A, B>(fa: Type2<F, L, A>, f: (i: I, a: A) => Option<B>) => Type2<F, L, B>
-  readonly filterWithIndex: <A>(fa: Type2<F, L, A>, predicate: (i: I, a: A) => boolean) => Type2<F, L, A>
+  readonly filterWithIndex: FilterWithIndex2C<F, I, L>
+}
+
+interface FilterWithIndex3<F extends URIS3, I> {
+  <U, L, A, B extends A>(fa: Type3<F, U, L, A>, refinementWithIndex: RefinementWithIndex<I, A, B>): Type3<F, U, L, B>
+  <U, L, A>(fa: Type3<F, U, L, A>, predicateWithIndex: PredicateWithIndex<I, A>): Type3<F, U, L, A>
+}
+
+interface PartitionWithIndex3<F extends URIS3, I> {
+  <U, L, A, B extends A>(fa: Type3<F, U, L, A>, refinementWithIndex: RefinementWithIndex<I, A, B>): Separated<
+    Type3<F, U, L, A>,
+    Type3<F, U, L, B>
+  >
+  <U, L, A>(fa: Type3<F, U, L, A>, predicateWithIndex: PredicateWithIndex<I, A>): Separated<
+    Type3<F, U, L, A>,
+    Type3<F, U, L, A>
+  >
 }
 
 export interface FilterableWithIndex3<F extends URIS3, I> extends FunctorWithIndex3<F, I>, Filterable3<F> {
@@ -69,12 +125,25 @@ export interface FilterableWithIndex3<F extends URIS3, I> extends FunctorWithInd
     fa: Type3<F, U, L, A>,
     f: (i: I, a: A) => Either<RL, RR>
   ) => Separated<Type3<F, U, L, RL>, Type3<F, U, L, RR>>
-  readonly partitionWithIndex: <U, L, A>(
-    fa: Type3<F, U, L, A>,
-    predicate: (i: I, a: A) => boolean
-  ) => Separated<Type3<F, U, L, A>, Type3<F, U, L, A>>
+  readonly partitionWithIndex: PartitionWithIndex3<F, I>
   readonly filterMapWithIndex: <U, L, A, B>(fa: Type3<F, U, L, A>, f: (i: I, a: A) => Option<B>) => Type3<F, U, L, B>
-  readonly filterWithIndex: <U, L, A>(fa: Type3<F, U, L, A>, predicate: (i: I, a: A) => boolean) => Type3<F, U, L, A>
+  readonly filterWithIndex: FilterWithIndex3<F, I>
+}
+
+interface FilterWithIndex3C<F extends URIS3, I, U, L> {
+  <A, B extends A>(fa: Type3<F, U, L, A>, refinementWithIndex: RefinementWithIndex<I, A, B>): Type3<F, U, L, B>
+  <A>(fa: Type3<F, U, L, A>, predicateWithIndex: PredicateWithIndex<I, A>): Type3<F, U, L, A>
+}
+
+interface PartitionWithIndex3C<F extends URIS3, I, U, L> {
+  <A, B extends A>(fa: Type3<F, U, L, A>, refinementWithIndex: RefinementWithIndex<I, A, B>): Separated<
+    Type3<F, U, L, A>,
+    Type3<F, U, L, B>
+  >
+  <A>(fa: Type3<F, U, L, A>, predicateWithIndex: PredicateWithIndex<I, A>): Separated<
+    Type3<F, U, L, A>,
+    Type3<F, U, L, A>
+  >
 }
 
 export interface FilterableWithIndex3C<F extends URIS3, I, U, L>
@@ -84,10 +153,7 @@ export interface FilterableWithIndex3C<F extends URIS3, I, U, L>
     fa: Type3<F, U, L, A>,
     f: (i: I, a: A) => Either<RL, RR>
   ) => Separated<Type3<F, U, L, RL>, Type3<F, U, L, RR>>
-  readonly partitionWithIndex: <A>(
-    fa: Type3<F, U, L, A>,
-    predicate: (i: I, a: A) => boolean
-  ) => Separated<Type3<F, U, L, A>, Type3<F, U, L, A>>
+  readonly partitionWithIndex: PartitionWithIndex3C<F, I, U, L>
   readonly filterMapWithIndex: <A, B>(fa: Type3<F, U, L, A>, f: (i: I, a: A) => Option<B>) => Type3<F, U, L, B>
-  readonly filterWithIndex: <A>(fa: Type3<F, U, L, A>, predicate: (i: I, a: A) => boolean) => Type3<F, U, L, A>
+  readonly filterWithIndex: FilterWithIndex3C<F, I, U, L>
 }

--- a/test/Array.ts
+++ b/test/Array.ts
@@ -8,7 +8,6 @@ import {
   deleteAt,
   drop,
   dropWhile,
-  filter,
   findFirst,
   findIndex,
   findLast,
@@ -59,7 +58,6 @@ import {
   findLastIndex,
   zipWith,
   comprehension,
-  partition,
   union,
   intersection,
   difference,
@@ -218,11 +216,6 @@ describe('Array', () => {
     assert.deepStrictEqual(takeWhile([], n => n % 2 === 0), [])
     assert.deepStrictEqual(takeWhile([1, 2, 4], n => n % 2 === 0), [])
     assert.deepStrictEqual(takeWhile([2, 4], n => n % 2 === 0), [2, 4])
-
-    // refinements
-    const xs: Array<string | number> = [1, 'a', 3]
-    const isString = (u: string | number): u is string => typeof u === 'string'
-    assert.deepStrictEqual(filter(xs, isString), ['a'])
   })
 
   it('drop', () => {
@@ -592,12 +585,17 @@ describe('Array', () => {
   })
 
   it('filter', () => {
+    const filter = array.filter
     assert.deepStrictEqual(filter([1, 2, 3], n => n % 2 === 1), [1, 3])
     assert.deepStrictEqual(array.filter([1, 2, 3], n => n % 2 === 1), [1, 3])
     const x = filter([some(3), some(2), some(1)], isSome)
     assert.deepStrictEqual(x, [some(3), some(2), some(1)])
     const y = filter([some(3), none, some(1)], isSome)
     assert.deepStrictEqual(y, [some(3), some(1)])
+    // refinements
+    const xs: Array<string | number> = [1, 'a', 3]
+    const isString = (u: string | number): u is string => typeof u === 'string'
+    assert.deepStrictEqual(filter(xs, isString), ['a'])
   })
 
   it('filterWithIndex', () => {
@@ -623,8 +621,9 @@ describe('Array', () => {
   })
 
   it('partition', () => {
-    assert.deepStrictEqual(array.partition([], p), { left: [], right: [] })
-    assert.deepStrictEqual(array.partition([1, 3], p), { left: [1], right: [3] })
+    const partition = array.partition
+    assert.deepStrictEqual(partition([], p), { left: [], right: [] })
+    assert.deepStrictEqual(partition([1, 3], p), { left: [1], right: [3] })
     // refinements
     const xs: Array<string | number> = ['a', 'b', 1]
     const isNumber = (x: string | number): x is number => typeof x === 'number'


### PR DESCRIPTION
…pe class)

This change makes obsolete to define specific overloads of `filter` / `partition` in order to handle refinements (e.g. in the `Array` module) by adding overloads to the `Filterable` type class.

This change is also beneficial to the data types which don't admit a unconstrained `Filterable` instance (e.g. `Either`)

```ts
import * as E from 'fp-ts/lib/Either'
import { monoidAll } from 'fp-ts/lib/Monoid'

declare function isString(x: unknown): x is string

const filterableEither = E.getFilterable(monoidAll)

filterableEither.filter(E.right<boolean, string | number>(1), isString)
// before: E.Either<boolean, string | number>
// after: E.Either<boolean, string>

filterableEither.partition(E.right<boolean, string | number>(1), isString)
// before: Separated<Either<boolean, string | number>, Either<boolean, string | number>>
// after: Separated<Either<boolean, string | number>, Either<boolean, string>>
```

/cc @giogonzo 