### PR TITLE
Use explicit concat function for getEndomorphismMonoid

### DIFF
--- a/src/Monoid.ts
+++ b/src/Monoid.ts
@@ -1,5 +1,5 @@
 import { Bounded } from './Bounded'
-import { compose, Endomorphism, identity, concat } from './function'
+import { Endomorphism, identity, concat } from './function'
 import {
   fold as foldSemigroup,
   getDictionarySemigroup,
@@ -177,7 +177,7 @@ export const getFunctionMonoid = <M>(M: Monoid<M>) => <A = never>(): Monoid<(a: 
  */
 export const getEndomorphismMonoid = <A = never>(): Monoid<Endomorphism<A>> => {
   return {
-    concat: compose,
+    concat: (x, y) => a => x(y(a)),
     empty: identity
   }
 }


### PR DESCRIPTION
Problem:

```ts
import { fold, getEndomorphismMonoid } from 'fp-ts/lib/Monoid';

fold(getEndomorphismMonoid<number>())([a => a + 1, b => b * 2])(3)
```

throws an error

```
Uncaught TypeError: fns[i].call is not a function
    at function.js:100
```

The problem is that `compose` gets called with 4 instead of 2 parameters. The additional two are `index` and `array` from the `reduce` function call.