### PR TITLE
Add applyEither

### DIFF
--- a/src/Either.ts
+++ b/src/Either.ts
@@ -562,11 +562,11 @@ export const isRight = <L, A>(fa: Either<L, A>): fa is Right<L, A> => {
 
 /**
  * Returns a function that applies `f` or `g` depending on type of input.
- * 
+ *
  */
 export const applyEither = <L, A, C>(f: (x: L) => C, g: (x: A) => C) => {
-  return (fa : Either<L, A>) => {
-    return fa.fold(f, g);
+  return (fa: Either<L, A>) => {
+    return fa.fold(f, g)
   }
 }
 

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -561,6 +561,16 @@ export const isRight = <L, A>(fa: Either<L, A>): fa is Right<L, A> => {
 }
 
 /**
+ * Returns a function that applies `f` or `g` depending on type of input.
+ * 
+ */
+export const applyEither = <L, A, C>(f: (x: L) => C, g: (x: A) => C) => {
+  return (fa : Either<L, A>) => {
+    return fa.fold(f, g);
+  }
+}
+
+/**
  * Builds `Compactable` instance for `Either` given `Monoid` for the left side
  *
  * @since 1.7.0

--- a/test/Either.ts
+++ b/test/Either.ts
@@ -24,7 +24,8 @@ import {
   toError,
   parseJSON,
   stringifyJSON,
-  getShow
+  getShow,
+  applyEither
 } from '../src/Either'
 import * as F from '../src/Foldable'
 import { identity } from '../src/function'
@@ -266,6 +267,14 @@ describe('Either', () => {
     assert.strictEqual(left(1).isRight(), false)
     assert.strictEqual(isRight(right(1)), true)
     assert.strictEqual(isRight(left(1)), false)
+  })
+
+  it('applyEither', () => {
+    const f = (n: number) => true
+    const g = (s: string) => false
+    const fun = applyEither<number, string, boolean>(f, g)
+    assert.strictEqual(fun(left(1)), true)
+    assert.strictEqual(fun(right('a')), false)
   })
 
   it('alt', () => {


### PR DESCRIPTION
Function `applyEither` returns a function that applies `f` or `g` depending on the type of input. It is common in fp practice (although trivial), but I have not found an implementation in `fp-ts`. Sorry in advance if it is a dup.
