### PR TITLE
Add kleisli-ts module

### DIFF
--- a/docs/introduction/ecosystem.md
+++ b/docs/introduction/ecosystem.md
@@ -23,6 +23,7 @@ has_toc: false
 - [fp-ts-local-storage](https://github.com/gcanti/fp-ts-local-storage) - fp-ts bindings for LocalStorage
 - [circuit-breaker-monad](https://github.com/YBogomolov/circuit-breaker-monad) - Circuit Breaker pattern as a monad
 - [waveguide](https://github.com/rzeigler/waveguide) - Bifunctor effect type and concurrent data structures.
+- [kleisli-ts](https://github.com/YBogomolov/kleisli-ts) - Kleisli arrows for bifunctor MonadThrow (IOEither, TaskEither)
 
 ## Bindings
 


### PR DESCRIPTION
I've created a [module with Kleisli arrows](https://github.com/YBogomolov/kleisli-ts), a port of Scala ZIO's `KleisliIO` by John A. De Goes. It uses MonadThrow and Bifunctor instances from fp-ts.