### PR TITLE
Fix outdated documentation in IO.ts

### DIFF
--- a/docs/modules/IO.ts.md
+++ b/docs/modules/IO.ts.md
@@ -53,21 +53,19 @@ const logger = (input: number | null) =>
 logger(123)() // returns undefined and outputs "Received 123" to console
 ```
 
-In addition to creating `IO` actions we need a way to combine them to build the application. For example we might
-have several `IO<void>` actions that only cause side effects without returning a result. We can combine several
-`IO<void>` actions into one for sequential execution with `sequence_(io, array)` as follows. This is useful when you
-care about the execution order but do not care about the results.
+In addition to creating `IO` actions we need a way to combine them to build the application. For
+example, we might want to combine several `IO<void>` actions into one `IO<void[]>` action for
+sequential execution. This can be done with `array.sequence(io)` as follows.
 
 ```ts
 import { IO, io } from 'fp-ts/lib/IO'
 import { array } from 'fp-ts/lib/Array'
-import { sequence_ } from 'fp-ts/lib/Foldable'
 import { log } from 'fp-ts/lib/Console'
 
 const logGiraffe: IO<void> = log('giraffe')
 const logZebra: IO<void> = log('zebra')
 
-const logGiraffeThenZebra: IO<void> = sequence_(io, array)([logGiraffe, logZebra])
+const logGiraffeThenZebra: IO<void[]> = array.sequence(io)([logGiraffe, logZebra])
 
 logGiraffeThenZebra() // returns undefined and outputs words "giraffe" and "zebra" to console
 ```

--- a/src/IO.ts
+++ b/src/IO.ts
@@ -50,7 +50,7 @@
  *
  * In addition to creating `IO` actions we need a way to combine them to build the application. For
  * example, we might want to combine several `IO<void>` actions into one `IO<void[]>` action for
- * sequential execution with `array.sequence(io)` as follows.
+ * sequential execution. This can be done with `array.sequence(io)` as follows.
  *
  * ```ts
  * import { IO, io } from 'fp-ts/lib/IO'

--- a/src/IO.ts
+++ b/src/IO.ts
@@ -48,10 +48,9 @@
  * logger(123)() // returns undefined and outputs "Received 123" to console
  * ```
  *
- * In addition to creating `IO` actions we need a way to combine them to build the application. For example we might
- * have several `IO<void>` actions that only cause side effects without returning a result.  We can combine several
- * `IO<void>` actions into one for sequential execution with `array.sequence(io)` as follows. This is useful when you
- * care about the execution order but do not care about the results.
+ * In addition to creating `IO` actions we need a way to combine them to build the application. For
+ * example, we might want to combine several `IO<void>` actions into one `IO<void[]>` action for
+ * sequential execution with `array.sequence(io)` as follows.
  *
  * ```ts
  * import { IO, io } from 'fp-ts/lib/IO'
@@ -61,7 +60,7 @@
  * const logGiraffe: IO<void> = log('giraffe');
  * const logZebra: IO<void> = log('zebra');
  *
- * const logGiraffeThenZebra: IO<void> = array.sequence(io)([ logGiraffe, logZebra ])
+ * const logGiraffeThenZebra: IO<void[]> = array.sequence(io)([ logGiraffe, logZebra ])
  *
  * logGiraffeThenZebra() // returns undefined and outputs words "giraffe" and "zebra" to console
  * ```

--- a/src/IO.ts
+++ b/src/IO.ts
@@ -50,19 +50,18 @@
  *
  * In addition to creating `IO` actions we need a way to combine them to build the application. For example we might
  * have several `IO<void>` actions that only cause side effects without returning a result.  We can combine several
- * `IO<void>` actions into one for sequential execution with `sequence_(io, array)` as follows. This is useful when you
+ * `IO<void>` actions into one for sequential execution with `array.sequence(io)` as follows. This is useful when you
  * care about the execution order but do not care about the results.
  *
  * ```ts
  * import { IO, io } from 'fp-ts/lib/IO'
  * import { array } from 'fp-ts/lib/Array'
- * import { sequence_ } from 'fp-ts/lib/Foldable'
  * import { log } from 'fp-ts/lib/Console'
  *
  * const logGiraffe: IO<void> = log('giraffe');
  * const logZebra: IO<void> = log('zebra');
  *
- * const logGiraffeThenZebra: IO<void> = sequence_(io, array)([ logGiraffe, logZebra ])
+ * const logGiraffeThenZebra: IO<void> = array.sequence(io)([ logGiraffe, logZebra ])
  *
  * logGiraffeThenZebra() // returns undefined and outputs words "giraffe" and "zebra" to console
  * ```


### PR DESCRIPTION
Thanks for the awesome library! The part on sequencing IOs is outdated as `sequence_` is not exported from `Foldable` anymore, so I replaced that with `array.sequence(io)`. I'm not sure if this was the correct way to do replace the example as `array.sequence(io)` also allows accessing the results, and the current docs are talking about discarding the results. To an FP newbie like me an example that combines the actions without dropping the results seems a bit more useful (one can always discard the results with `io.map(() => (})`).