### PR TITLE
refactor: make Functor, Apply, FunctorComposition and ApplicativeComposition data-last

### DIFF
--- a/docs/modules/Applicative.ts.md
+++ b/docs/modules/Applicative.ts.md
@@ -126,7 +126,7 @@ Added in v2.0.0
 ```ts
 export interface ApplicativeComposition<F, G> extends FunctorComposition<F, G> {
   readonly of: <A>(a: A) => HKT<F, HKT<G, A>>
-  readonly ap: <A, B>(fgab: HKT<F, HKT<G, (a: A) => B>>, fga: HKT<F, HKT<G, A>>) => HKT<F, HKT<G, B>>
+  readonly ap: <A, B>(fgab: HKT<F, HKT<G, (a: A) => B>>) => (fga: HKT<F, HKT<G, A>>) => HKT<F, HKT<G, B>>
 }
 ```
 
@@ -139,7 +139,7 @@ Added in v2.0.0
 ```ts
 export interface ApplicativeComposition11<F extends URIS, G extends URIS> extends FunctorComposition11<F, G> {
   readonly of: <A>(a: A) => Kind<F, Kind<G, A>>
-  readonly ap: <A, B>(fgab: Kind<F, Kind<G, (a: A) => B>>, fga: Kind<F, Kind<G, A>>) => Kind<F, Kind<G, B>>
+  readonly ap: <A, B>(fgab: Kind<F, Kind<G, (a: A) => B>>) => (fga: Kind<F, Kind<G, A>>) => Kind<F, Kind<G, B>>
 }
 ```
 
@@ -153,9 +153,8 @@ Added in v2.0.0
 export interface ApplicativeComposition12<F extends URIS, G extends URIS2> extends FunctorComposition12<F, G> {
   readonly of: <E, A>(a: A) => Kind<F, Kind2<G, E, A>>
   readonly ap: <E, A, B>(
-    fgab: Kind<F, Kind2<G, E, (a: A) => B>>,
-    fga: Kind<F, Kind2<G, E, A>>
-  ) => Kind<F, Kind2<G, E, B>>
+    fgab: Kind<F, Kind2<G, E, (a: A) => B>>
+  ) => (fga: Kind<F, Kind2<G, E, A>>) => Kind<F, Kind2<G, E, B>>
 }
 ```
 
@@ -168,7 +167,9 @@ Added in v2.0.0
 ```ts
 export interface ApplicativeComposition12C<F extends URIS, G extends URIS2, E> extends FunctorComposition12C<F, G, E> {
   readonly of: <A>(a: A) => Kind<F, Kind2<G, E, A>>
-  readonly ap: <A, B>(fgab: Kind<F, Kind2<G, E, (a: A) => B>>, fga: Kind<F, Kind2<G, E, A>>) => Kind<F, Kind2<G, E, B>>
+  readonly ap: <A, B>(
+    fgab: Kind<F, Kind2<G, E, (a: A) => B>>
+  ) => (fga: Kind<F, Kind2<G, E, A>>) => Kind<F, Kind2<G, E, B>>
 }
 ```
 
@@ -182,9 +183,8 @@ Added in v2.0.0
 export interface ApplicativeComposition21<F extends URIS2, G extends URIS> extends FunctorComposition21<F, G> {
   readonly of: <E, A>(a: A) => Kind2<F, E, Kind<G, A>>
   readonly ap: <E, A, B>(
-    fgab: Kind2<F, E, Kind<G, (a: A) => B>>,
-    fga: Kind2<F, E, Kind<G, A>>
-  ) => Kind2<F, E, Kind<G, B>>
+    fgab: Kind2<F, E, Kind<G, (a: A) => B>>
+  ) => (fga: Kind2<F, E, Kind<G, A>>) => Kind2<F, E, Kind<G, B>>
 }
 ```
 
@@ -198,9 +198,8 @@ Added in v2.0.0
 export interface ApplicativeComposition22<F extends URIS2, G extends URIS2> extends FunctorComposition22<F, G> {
   readonly of: <FE, GE, A>(a: A) => Kind2<F, FE, Kind2<G, GE, A>>
   readonly ap: <FE, GE, A, B>(
-    fgab: Kind2<F, FE, Kind2<G, GE, (a: A) => B>>,
-    fga: Kind2<F, FE, Kind2<G, GE, A>>
-  ) => Kind2<F, FE, Kind2<G, GE, B>>
+    fgab: Kind2<F, FE, Kind2<G, GE, (a: A) => B>>
+  ) => (fga: Kind2<F, FE, Kind2<G, GE, A>>) => Kind2<F, FE, Kind2<G, GE, B>>
 }
 ```
 
@@ -214,9 +213,8 @@ Added in v2.0.0
 export interface ApplicativeComposition22C<F extends URIS2, G extends URIS2, E> extends FunctorComposition22C<F, G, E> {
   readonly of: <FE, A>(a: A) => Kind2<F, FE, Kind2<G, E, A>>
   readonly ap: <FE, A, B>(
-    fgab: Kind2<F, FE, Kind2<G, E, (a: A) => B>>,
-    fga: Kind2<F, FE, Kind2<G, E, A>>
-  ) => Kind2<F, FE, Kind2<G, E, B>>
+    fgab: Kind2<F, FE, Kind2<G, E, (a: A) => B>>
+  ) => (fga: Kind2<F, FE, Kind2<G, E, A>>) => Kind2<F, FE, Kind2<G, E, B>>
 }
 ```
 
@@ -229,7 +227,9 @@ Added in v2.0.0
 ```ts
 export interface ApplicativeComposition2C1<F extends URIS2, G extends URIS, E> extends FunctorComposition2C1<F, G, E> {
   readonly of: <A>(a: A) => Kind2<F, E, Kind<G, A>>
-  readonly ap: <A, B>(fgab: Kind2<F, E, Kind<G, (a: A) => B>>, fga: Kind2<F, E, Kind<G, A>>) => Kind2<F, E, Kind<G, B>>
+  readonly ap: <A, B>(
+    fgab: Kind2<F, E, Kind<G, (a: A) => B>>
+  ) => (fga: Kind2<F, E, Kind<G, A>>) => Kind2<F, E, Kind<G, B>>
 }
 ```
 
@@ -242,7 +242,7 @@ Added in v2.0.0
 ```ts
 export interface ApplicativeCompositionHKT1<F, G extends URIS> extends FunctorCompositionHKT1<F, G> {
   readonly of: <A>(a: A) => HKT<F, Kind<G, A>>
-  readonly ap: <A, B>(fgab: HKT<F, Kind<G, (a: A) => B>>, fga: HKT<F, Kind<G, A>>) => HKT<F, Kind<G, B>>
+  readonly ap: <A, B>(fgab: HKT<F, Kind<G, (a: A) => B>>) => (fga: HKT<F, Kind<G, A>>) => HKT<F, Kind<G, B>>
 }
 ```
 
@@ -255,7 +255,9 @@ Added in v2.0.0
 ```ts
 export interface ApplicativeCompositionHKT2<F, G extends URIS2> extends FunctorCompositionHKT2<F, G> {
   readonly of: <E, A>(a: A) => HKT<F, Kind2<G, E, A>>
-  readonly ap: <E, A, B>(fgab: HKT<F, Kind2<G, E, (a: A) => B>>, fga: HKT<F, Kind2<G, E, A>>) => HKT<F, Kind2<G, E, B>>
+  readonly ap: <E, A, B>(
+    fgab: HKT<F, Kind2<G, E, (a: A) => B>>
+  ) => (fga: HKT<F, Kind2<G, E, A>>) => HKT<F, Kind2<G, E, B>>
 }
 ```
 
@@ -268,7 +270,7 @@ Added in v2.0.0
 ```ts
 export interface ApplicativeCompositionHKT2C<F, G extends URIS2, E> extends FunctorCompositionHKT2C<F, G, E> {
   readonly of: <A>(a: A) => HKT<F, Kind2<G, E, A>>
-  readonly ap: <A, B>(fgab: HKT<F, Kind2<G, E, (a: A) => B>>, fga: HKT<F, Kind2<G, E, A>>) => HKT<F, Kind2<G, E, B>>
+  readonly ap: <A, B>(fgab: HKT<F, Kind2<G, E, (a: A) => B>>) => (fga: HKT<F, Kind2<G, E, A>>) => HKT<F, Kind2<G, E, B>>
 }
 ```
 
@@ -339,7 +341,7 @@ const y: Task<Option<number>> = task.of(some(2))
 
 const sum = (a: number) => (b: number): number => a + b
 
-A.ap(A.map(x, sum), y)().then(result => assert.deepStrictEqual(result, some(3)))
+A.ap(A.map(sum)(x))(y)().then(result => assert.deepStrictEqual(result, some(3)))
 ```
 
 Added in v2.0.0

--- a/docs/modules/Apply.ts.md
+++ b/docs/modules/Apply.ts.md
@@ -38,7 +38,7 @@ Formally, `Apply` represents a strong lax semi-monoidal endofunctor.
 
 ```ts
 export interface Apply<F> extends Functor<F> {
-  readonly ap: <A, B>(fab: HKT<F, (a: A) => B>, fa: HKT<F, A>) => HKT<F, B>
+  readonly ap: <A, B>(fab: HKT<F, (a: A) => B>) => (fa: HKT<F, A>) => HKT<F, B>
 }
 ```
 
@@ -50,7 +50,7 @@ Added in v2.0.0
 
 ```ts
 export interface Apply1<F extends URIS> extends Functor1<F> {
-  readonly ap: <A, B>(fab: Kind<F, (a: A) => B>, fa: Kind<F, A>) => Kind<F, B>
+  readonly ap: <A, B>(fab: Kind<F, (a: A) => B>) => (fa: Kind<F, A>) => Kind<F, B>
 }
 ```
 
@@ -62,7 +62,7 @@ Added in v2.0.0
 
 ```ts
 export interface Apply2<F extends URIS2> extends Functor2<F> {
-  readonly ap: <E, A, B>(fab: Kind2<F, E, (a: A) => B>, fa: Kind2<F, E, A>) => Kind2<F, E, B>
+  readonly ap: <E, A, B>(fab: Kind2<F, E, (a: A) => B>) => (fa: Kind2<F, E, A>) => Kind2<F, E, B>
 }
 ```
 
@@ -74,7 +74,7 @@ Added in v2.0.0
 
 ```ts
 export interface Apply2C<F extends URIS2, E> extends Functor2C<F, E> {
-  readonly ap: <A, B>(fab: Kind2<F, E, (a: A) => B>, fa: Kind2<F, E, A>) => Kind2<F, E, B>
+  readonly ap: <A, B>(fab: Kind2<F, E, (a: A) => B>) => (fa: Kind2<F, E, A>) => Kind2<F, E, B>
 }
 ```
 
@@ -86,7 +86,7 @@ Added in v2.0.0
 
 ```ts
 export interface Apply3<F extends URIS3> extends Functor3<F> {
-  readonly ap: <R, E, A, B>(fab: Kind3<F, R, E, (a: A) => B>, fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+  readonly ap: <R, E, A, B>(fab: Kind3<F, R, E, (a: A) => B>) => (fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
 }
 ```
 
@@ -98,7 +98,9 @@ Added in v2.0.0
 
 ```ts
 export interface Apply4<F extends URIS4> extends Functor4<F> {
-  readonly ap: <S, R, E, A, B>(fab: Kind4<F, S, R, E, (a: A) => B>, fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, B>
+  readonly ap: <S, R, E, A, B>(
+    fab: Kind4<F, S, R, E, (a: A) => B>
+  ) => (fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, B>
 }
 ```
 

--- a/docs/modules/Functor.ts.md
+++ b/docs/modules/Functor.ts.md
@@ -48,7 +48,7 @@ Instances must satisfy the following laws:
 ```ts
 export interface Functor<F> {
   readonly URI: F
-  readonly map: <A, B>(fa: HKT<F, A>, f: (a: A) => B) => HKT<F, B>
+  readonly map: <A, B>(f: (a: A) => B) => (fa: HKT<F, A>) => HKT<F, B>
 }
 ```
 
@@ -61,7 +61,7 @@ Added in v2.0.0
 ```ts
 export interface Functor1<F extends URIS> {
   readonly URI: F
-  readonly map: <A, B>(fa: Kind<F, A>, f: (a: A) => B) => Kind<F, B>
+  readonly map: <A, B>(f: (a: A) => B) => (fa: Kind<F, A>) => Kind<F, B>
 }
 ```
 
@@ -74,7 +74,7 @@ Added in v2.0.0
 ```ts
 export interface Functor2<F extends URIS2> {
   readonly URI: F
-  readonly map: <E, A, B>(fa: Kind2<F, E, A>, f: (a: A) => B) => Kind2<F, E, B>
+  readonly map: <A, B>(f: (a: A) => B) => <E>(fa: Kind2<F, E, A>) => Kind2<F, E, B>
 }
 ```
 
@@ -88,7 +88,7 @@ Added in v2.0.0
 export interface Functor2C<F extends URIS2, E> {
   readonly URI: F
   readonly _E: E
-  readonly map: <A, B>(fa: Kind2<F, E, A>, f: (a: A) => B) => Kind2<F, E, B>
+  readonly map: <A, B>(f: (a: A) => B) => (fa: Kind2<F, E, A>) => Kind2<F, E, B>
 }
 ```
 
@@ -101,7 +101,7 @@ Added in v2.0.0
 ```ts
 export interface Functor3<F extends URIS3> {
   readonly URI: F
-  readonly map: <R, E, A, B>(fa: Kind3<F, R, E, A>, f: (a: A) => B) => Kind3<F, R, E, B>
+  readonly map: <A, B>(f: (a: A) => B) => <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
 }
 ```
 
@@ -114,7 +114,7 @@ Added in v2.0.0
 ```ts
 export interface Functor4<F extends URIS4> {
   readonly URI: F
-  readonly map: <S, R, E, A, B>(fa: Kind4<F, S, R, E, A>, f: (a: A) => B) => Kind4<F, S, R, E, B>
+  readonly map: <A, B>(f: (a: A) => B) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, B>
 }
 ```
 
@@ -126,7 +126,7 @@ Added in v2.0.0
 
 ```ts
 export interface FunctorComposition<F, G> {
-  readonly map: <A, B>(fa: HKT<F, HKT<G, A>>, f: (a: A) => B) => HKT<F, HKT<G, B>>
+  readonly map: <A, B>(f: (a: A) => B) => (fa: HKT<F, HKT<G, A>>) => HKT<F, HKT<G, B>>
 }
 ```
 
@@ -138,7 +138,7 @@ Added in v2.0.0
 
 ```ts
 export interface FunctorComposition11<F extends URIS, G extends URIS> {
-  readonly map: <A, B>(fa: Kind<F, Kind<G, A>>, f: (a: A) => B) => Kind<F, Kind<G, B>>
+  readonly map: <A, B>(f: (a: A) => B) => (fa: Kind<F, Kind<G, A>>) => Kind<F, Kind<G, B>>
 }
 ```
 
@@ -150,7 +150,7 @@ Added in v2.0.0
 
 ```ts
 export interface FunctorComposition12<F extends URIS, G extends URIS2> {
-  readonly map: <E, A, B>(fa: Kind<F, Kind2<G, E, A>>, f: (a: A) => B) => Kind<F, Kind2<G, E, B>>
+  readonly map: <A, B>(f: (a: A) => B) => <E>(fa: Kind<F, Kind2<G, E, A>>) => Kind<F, Kind2<G, E, B>>
 }
 ```
 
@@ -162,7 +162,7 @@ Added in v2.0.0
 
 ```ts
 export interface FunctorComposition12C<F extends URIS, G extends URIS2, E> {
-  readonly map: <A, B>(fa: Kind<F, Kind2<G, E, A>>, f: (a: A) => B) => Kind<F, Kind2<G, E, B>>
+  readonly map: <A, B>(f: (a: A) => B) => (fa: Kind<F, Kind2<G, E, A>>) => Kind<F, Kind2<G, E, B>>
 }
 ```
 
@@ -174,7 +174,7 @@ Added in v2.0.0
 
 ```ts
 export interface FunctorComposition21<F extends URIS2, G extends URIS> {
-  readonly map: <E, A, B>(fa: Kind2<F, E, Kind<G, A>>, f: (a: A) => B) => Kind2<F, E, Kind<G, B>>
+  readonly map: <A, B>(f: (a: A) => B) => <E>(fa: Kind2<F, E, Kind<G, A>>) => Kind2<F, E, Kind<G, B>>
 }
 ```
 
@@ -186,7 +186,7 @@ Added in v2.0.0
 
 ```ts
 export interface FunctorComposition22<F extends URIS2, G extends URIS2> {
-  readonly map: <FE, GE, A, B>(fa: Kind2<F, FE, Kind2<G, GE, A>>, f: (a: A) => B) => Kind2<F, FE, Kind2<G, GE, B>>
+  readonly map: <A, B>(f: (a: A) => B) => <FE, GE>(fa: Kind2<F, FE, Kind2<G, GE, A>>) => Kind2<F, FE, Kind2<G, GE, B>>
 }
 ```
 
@@ -198,7 +198,7 @@ Added in v2.0.0
 
 ```ts
 export interface FunctorComposition22C<F extends URIS2, G extends URIS2, E> {
-  readonly map: <FE, A, B>(fa: Kind2<F, FE, Kind2<G, E, A>>, f: (a: A) => B) => Kind2<F, FE, Kind2<G, E, B>>
+  readonly map: <A, B>(f: (a: A) => B) => <FE>(fa: Kind2<F, FE, Kind2<G, E, A>>) => Kind2<F, FE, Kind2<G, E, B>>
 }
 ```
 
@@ -210,7 +210,7 @@ Added in v2.0.0
 
 ```ts
 export interface FunctorComposition2C1<F extends URIS2, G extends URIS, E> {
-  readonly map: <A, B>(fa: Kind2<F, E, Kind<G, A>>, f: (a: A) => B) => Kind2<F, E, Kind<G, B>>
+  readonly map: <A, B>(f: (a: A) => B) => (fa: Kind2<F, E, Kind<G, A>>) => Kind2<F, E, Kind<G, B>>
 }
 ```
 
@@ -222,7 +222,7 @@ Added in v2.0.0
 
 ```ts
 export interface FunctorCompositionHKT1<F, G extends URIS> {
-  readonly map: <A, B>(fa: HKT<F, Kind<G, A>>, f: (a: A) => B) => HKT<F, Kind<G, B>>
+  readonly map: <A, B>(f: (a: A) => B) => (fa: HKT<F, Kind<G, A>>) => HKT<F, Kind<G, B>>
 }
 ```
 
@@ -234,7 +234,7 @@ Added in v2.0.0
 
 ```ts
 export interface FunctorCompositionHKT2<F, G extends URIS2> {
-  readonly map: <E, A, B>(fa: HKT<F, Kind2<G, E, A>>, f: (a: A) => B) => HKT<F, Kind2<G, E, B>>
+  readonly map: <A, B>(f: (a: A) => B) => <E>(fa: HKT<F, Kind2<G, E, A>>) => HKT<F, Kind2<G, E, B>>
 }
 ```
 
@@ -246,7 +246,7 @@ Added in v2.0.0
 
 ```ts
 export interface FunctorCompositionHKT2C<F, G extends URIS2, E> {
-  readonly map: <A, B>(fa: HKT<F, Kind2<G, E, A>>, f: (a: A) => B) => HKT<F, Kind2<G, E, B>>
+  readonly map: <A, B>(f: (a: A) => B) => (fa: HKT<F, Kind2<G, E, A>>) => HKT<F, Kind2<G, E, B>>
 }
 ```
 

--- a/docs/modules/Profunctor.ts.md
+++ b/docs/modules/Profunctor.ts.md
@@ -23,7 +23,7 @@ parent: Modules
 ```ts
 export interface Profunctor<F> {
   readonly URI: F
-  readonly map: <E, A, B>(fa: HKT2<F, E, A>, f: (a: A) => B) => HKT<F, B>
+  readonly map: <A, B>(f: (a: A) => B) => <E>(fa: HKT2<F, E, A>) => HKT<F, B>
   readonly promap: <E, A, D, B>(fbc: HKT2<F, E, A>, f: (d: D) => E, g: (a: A) => B) => HKT2<F, D, B>
 }
 ```

--- a/docs/modules/ReaderT.ts.md
+++ b/docs/modules/ReaderT.ts.md
@@ -26,9 +26,9 @@ parent: Modules
 
 ```ts
 export interface ReaderM<M> {
-  readonly map: <R, A, B>(ma: ReaderT<M, R, A>, f: (a: A) => B) => ReaderT<M, R, B>
+  readonly map: <A, B>(f: (a: A) => B) => <R>(ma: ReaderT<M, R, A>) => ReaderT<M, R, B>
   readonly of: <R, A>(a: A) => ReaderT<M, R, A>
-  readonly ap: <R, A, B>(mab: ReaderT<M, R, (a: A) => B>, ma: ReaderT<M, R, A>) => ReaderT<M, R, B>
+  readonly ap: <R, A, B>(mab: ReaderT<M, R, (a: A) => B>) => (ma: ReaderT<M, R, A>) => ReaderT<M, R, B>
   readonly chain: <R, A, B>(ma: ReaderT<M, R, A>, f: (a: A) => ReaderT<M, R, B>) => ReaderT<M, R, B>
   readonly ask: <R>() => ReaderT<M, R, R>
   readonly asks: <R, A>(f: (r: R) => A) => ReaderT<M, R, A>
@@ -46,9 +46,9 @@ Added in v2.0.0
 
 ```ts
 export interface ReaderM1<M extends URIS> {
-  readonly map: <R, A, B>(ma: ReaderT1<M, R, A>, f: (a: A) => B) => ReaderT1<M, R, B>
+  readonly map: <A, B>(f: (a: A) => B) => <R>(ma: ReaderT1<M, R, A>) => ReaderT1<M, R, B>
   readonly of: <R, A>(a: A) => ReaderT1<M, R, A>
-  readonly ap: <R, A, B>(mab: ReaderT1<M, R, (a: A) => B>, ma: ReaderT1<M, R, A>) => ReaderT1<M, R, B>
+  readonly ap: <R, A, B>(mab: ReaderT1<M, R, (a: A) => B>) => (ma: ReaderT1<M, R, A>) => ReaderT1<M, R, B>
   readonly chain: <R, A, B>(ma: ReaderT1<M, R, A>, f: (a: A) => ReaderT1<M, R, B>) => ReaderT1<M, R, B>
   readonly ask: <R>() => ReaderT1<M, R, R>
   readonly asks: <R, A>(f: (r: R) => A) => ReaderT1<M, R, A>
@@ -66,9 +66,9 @@ Added in v2.0.0
 
 ```ts
 export interface ReaderM2<M extends URIS2> {
-  readonly map: <R, E, A, B>(ma: ReaderT2<M, R, E, A>, f: (a: A) => B) => ReaderT2<M, R, E, B>
+  readonly map: <A, B>(f: (a: A) => B) => <R, E>(ma: ReaderT2<M, R, E, A>) => ReaderT2<M, R, E, B>
   readonly of: <R, E, A>(a: A) => ReaderT2<M, R, E, A>
-  readonly ap: <R, E, A, B>(mab: ReaderT2<M, R, E, (a: A) => B>, ma: ReaderT2<M, R, E, A>) => ReaderT2<M, R, E, B>
+  readonly ap: <R, E, A, B>(mab: ReaderT2<M, R, E, (a: A) => B>) => (ma: ReaderT2<M, R, E, A>) => ReaderT2<M, R, E, B>
   readonly chain: <R, E, A, B>(ma: ReaderT2<M, R, E, A>, f: (a: A) => ReaderT2<M, R, E, B>) => ReaderT2<M, R, E, B>
   readonly ask: <R, E>() => ReaderT2<M, R, E, R>
   readonly asks: <R, E, A>(f: (r: R) => A) => ReaderT2<M, R, E, A>
@@ -86,12 +86,11 @@ Added in v2.0.0
 
 ```ts
 export interface ReaderM3<M extends URIS3> {
-  readonly map: <R, U, E, A, B>(ma: ReaderT3<M, R, U, E, A>, f: (a: A) => B) => ReaderT3<M, R, U, E, B>
+  readonly map: <A, B>(f: (a: A) => B) => <R, U, E>(ma: ReaderT3<M, R, U, E, A>) => ReaderT3<M, R, U, E, B>
   readonly of: <R, U, E, A>(a: A) => ReaderT3<M, R, U, E, A>
   readonly ap: <R, U, E, A, B>(
-    mab: ReaderT3<M, R, U, E, (a: A) => B>,
-    ma: ReaderT3<M, R, U, E, A>
-  ) => ReaderT3<M, R, U, E, B>
+    mab: ReaderT3<M, R, U, E, (a: A) => B>
+  ) => (ma: ReaderT3<M, R, U, E, A>) => ReaderT3<M, R, U, E, B>
   readonly chain: <R, U, E, A, B>(
     ma: ReaderT3<M, R, U, E, A>,
     f: (a: A) => ReaderT3<M, R, U, E, B>

--- a/docs/modules/StateT.ts.md
+++ b/docs/modules/StateT.ts.md
@@ -26,9 +26,9 @@ parent: Modules
 
 ```ts
 export interface StateM<M> {
-  readonly map: <S, A, B>(fa: StateT<M, S, A>, f: (a: A) => B) => StateT<M, S, B>
+  readonly map: <A, B>(f: (a: A) => B) => <S>(fa: StateT<M, S, A>) => StateT<M, S, B>
   readonly of: <S, A>(a: A) => StateT<M, S, A>
-  readonly ap: <S, A, B>(fab: StateT<M, S, (a: A) => B>, fa: StateT<M, S, A>) => StateT<M, S, B>
+  readonly ap: <S, A, B>(fab: StateT<M, S, (a: A) => B>) => (fa: StateT<M, S, A>) => StateT<M, S, B>
   readonly chain: <S, A, B>(fa: StateT<M, S, A>, f: (a: A) => StateT<M, S, B>) => StateT<M, S, B>
   readonly get: <S>() => StateT<M, S, S>
   readonly put: <S>(s: S) => StateT<M, S, void>
@@ -49,9 +49,9 @@ Added in v2.0.0
 
 ```ts
 export interface StateM1<M extends URIS> {
-  readonly map: <S, A, B>(fa: StateT1<M, S, A>, f: (a: A) => B) => StateT1<M, S, B>
+  readonly map: <A, B>(f: (a: A) => B) => <S>(fa: StateT1<M, S, A>) => StateT1<M, S, B>
   readonly of: <S, A>(a: A) => StateT1<M, S, A>
-  readonly ap: <S, A, B>(fab: StateT1<M, S, (a: A) => B>, fa: StateT1<M, S, A>) => StateT1<M, S, B>
+  readonly ap: <S, A, B>(fab: StateT1<M, S, (a: A) => B>) => (fa: StateT1<M, S, A>) => StateT1<M, S, B>
   readonly chain: <S, A, B>(fa: StateT1<M, S, A>, f: (a: A) => StateT1<M, S, B>) => StateT1<M, S, B>
   readonly get: <S>() => StateT1<M, S, S>
   readonly put: <S>(s: S) => StateT1<M, S, void>
@@ -72,9 +72,9 @@ Added in v2.0.0
 
 ```ts
 export interface StateM2<M extends URIS2> {
-  readonly map: <S, E, A, B>(fa: StateT2<M, S, E, A>, f: (a: A) => B) => StateT2<M, S, E, B>
+  readonly map: <A, B>(f: (a: A) => B) => <S, E>(fa: StateT2<M, S, E, A>) => StateT2<M, S, E, B>
   readonly of: <S, E, A>(a: A) => StateT2<M, S, E, A>
-  readonly ap: <S, E, A, B>(fab: StateT2<M, S, E, (a: A) => B>, fa: StateT2<M, S, E, A>) => StateT2<M, S, E, B>
+  readonly ap: <S, E, A, B>(fab: StateT2<M, S, E, (a: A) => B>) => (fa: StateT2<M, S, E, A>) => StateT2<M, S, E, B>
   readonly chain: <S, E, A, B>(fa: StateT2<M, S, E, A>, f: (a: A) => StateT2<M, S, E, B>) => StateT2<M, S, E, B>
   readonly get: <E, S>() => StateT2<M, S, E, S>
   readonly put: <E, S>(s: S) => StateT2<M, S, E, void>
@@ -95,12 +95,11 @@ Added in v2.0.0
 
 ```ts
 export interface StateM3<M extends URIS3> {
-  readonly map: <S, R, E, A, B>(fa: StateT3<M, S, R, E, A>, f: (a: A) => B) => StateT3<M, S, R, E, B>
+  readonly map: <A, B>(f: (a: A) => B) => <S, R, E>(fa: StateT3<M, S, R, E, A>) => StateT3<M, S, R, E, B>
   readonly of: <S, R, E, A>(a: A) => StateT3<M, S, R, E, A>
   readonly ap: <S, R, E, A, B>(
-    fab: StateT3<M, S, R, E, (a: A) => B>,
-    fa: StateT3<M, S, R, E, A>
-  ) => StateT3<M, S, R, E, B>
+    fab: StateT3<M, S, R, E, (a: A) => B>
+  ) => (fa: StateT3<M, S, R, E, A>) => StateT3<M, S, R, E, B>
   readonly chain: <S, R, E, A, B>(
     fa: StateT3<M, S, R, E, A>,
     f: (a: A) => StateT3<M, S, R, E, B>

--- a/dtslint/ts3.5/index.ts
+++ b/dtslint/ts3.5/index.ts
@@ -52,8 +52,9 @@ export function factoryS<F extends H.URIS>(
   a8: H.Kind<F, number>,
   a9: H.Kind<F, boolean>
 ): H.Kind<F, boolean> {
-  return F.map(Apy.sequenceS(F)({ a1, a2, a3, a4, a5, a6, a7, a8, a9 }), ({ a1, a2, a3, a4, a5, a6, a7, a8, a9 }) =>
-    functionForfactoryS(a1, a2, a3, a4, a5, a6, a7, a8, a9)
+  return pipe(
+    Apy.sequenceS(F)({ a1, a2, a3, a4, a5, a6, a7, a8, a9 }),
+    F.map(({ a1, a2, a3, a4, a5, a6, a7, a8, a9 }) => functionForfactoryS(a1, a2, a3, a4, a5, a6, a7, a8, a9))
   )
 }
 
@@ -99,8 +100,9 @@ export function factoryT<F extends H.URIS>(
   f8: H.Kind<F, number>,
   f9: H.Kind<F, boolean>
 ): H.Kind<F, boolean> {
-  return F.map(Apy.sequenceT(F)(f1, f2, f3, f4, f5, f6, f7, f8, f9), ([a1, a2, a3, a4, a5, a6, a7, a8, a9]) =>
-    functionForfactoryS(a1, a2, a3, a4, a5, a6, a7, a8, a9)
+  return pipe(
+    Apy.sequenceT(F)(f1, f2, f3, f4, f5, f6, f7, f8, f9),
+    F.map(([a1, a2, a3, a4, a5, a6, a7, a8, a9]) => functionForfactoryS(a1, a2, a3, a4, a5, a6, a7, a8, a9))
   )
 }
 
@@ -130,7 +132,7 @@ sequenceTf2(sequenceS5, sequenceS6, sequenceS7) // $ExpectType ReaderTaskEither<
 
 const applicativeValidation = E.getValidation(S.semigroupString)
 
-Apv.getApplicativeComposition(Re.reader, applicativeValidation).map // $ExpectType <FE, A, B>(fa: Reader<FE, Either<string, A>>, f: (a: A) => B) => Reader<FE, Either<string, B>>
+Apv.getApplicativeComposition(Re.reader, applicativeValidation).map // $ExpectType <A, B>(f: (a: A) => B) => <FE>(fa: Reader<FE, Either<string, A>>) => Reader<FE, Either<string, B>>
 
 //
 // Const

--- a/src/Applicative.ts
+++ b/src/Applicative.ts
@@ -79,7 +79,7 @@ export interface Applicative4<F extends URIS4> extends Apply4<F> {
  */
 export interface ApplicativeComposition<F, G> extends FunctorComposition<F, G> {
   readonly of: <A>(a: A) => HKT<F, HKT<G, A>>
-  readonly ap: <A, B>(fgab: HKT<F, HKT<G, (a: A) => B>>, fga: HKT<F, HKT<G, A>>) => HKT<F, HKT<G, B>>
+  readonly ap: <A, B>(fgab: HKT<F, HKT<G, (a: A) => B>>) => (fga: HKT<F, HKT<G, A>>) => HKT<F, HKT<G, B>>
 }
 
 /**
@@ -87,7 +87,7 @@ export interface ApplicativeComposition<F, G> extends FunctorComposition<F, G> {
  */
 export interface ApplicativeCompositionHKT1<F, G extends URIS> extends FunctorCompositionHKT1<F, G> {
   readonly of: <A>(a: A) => HKT<F, Kind<G, A>>
-  readonly ap: <A, B>(fgab: HKT<F, Kind<G, (a: A) => B>>, fga: HKT<F, Kind<G, A>>) => HKT<F, Kind<G, B>>
+  readonly ap: <A, B>(fgab: HKT<F, Kind<G, (a: A) => B>>) => (fga: HKT<F, Kind<G, A>>) => HKT<F, Kind<G, B>>
 }
 
 /**
@@ -95,7 +95,9 @@ export interface ApplicativeCompositionHKT1<F, G extends URIS> extends FunctorCo
  */
 export interface ApplicativeCompositionHKT2<F, G extends URIS2> extends FunctorCompositionHKT2<F, G> {
   readonly of: <E, A>(a: A) => HKT<F, Kind2<G, E, A>>
-  readonly ap: <E, A, B>(fgab: HKT<F, Kind2<G, E, (a: A) => B>>, fga: HKT<F, Kind2<G, E, A>>) => HKT<F, Kind2<G, E, B>>
+  readonly ap: <E, A, B>(
+    fgab: HKT<F, Kind2<G, E, (a: A) => B>>
+  ) => (fga: HKT<F, Kind2<G, E, A>>) => HKT<F, Kind2<G, E, B>>
 }
 
 /**
@@ -103,7 +105,7 @@ export interface ApplicativeCompositionHKT2<F, G extends URIS2> extends FunctorC
  */
 export interface ApplicativeCompositionHKT2C<F, G extends URIS2, E> extends FunctorCompositionHKT2C<F, G, E> {
   readonly of: <A>(a: A) => HKT<F, Kind2<G, E, A>>
-  readonly ap: <A, B>(fgab: HKT<F, Kind2<G, E, (a: A) => B>>, fga: HKT<F, Kind2<G, E, A>>) => HKT<F, Kind2<G, E, B>>
+  readonly ap: <A, B>(fgab: HKT<F, Kind2<G, E, (a: A) => B>>) => (fga: HKT<F, Kind2<G, E, A>>) => HKT<F, Kind2<G, E, B>>
 }
 
 /**
@@ -111,7 +113,7 @@ export interface ApplicativeCompositionHKT2C<F, G extends URIS2, E> extends Func
  */
 export interface ApplicativeComposition11<F extends URIS, G extends URIS> extends FunctorComposition11<F, G> {
   readonly of: <A>(a: A) => Kind<F, Kind<G, A>>
-  readonly ap: <A, B>(fgab: Kind<F, Kind<G, (a: A) => B>>, fga: Kind<F, Kind<G, A>>) => Kind<F, Kind<G, B>>
+  readonly ap: <A, B>(fgab: Kind<F, Kind<G, (a: A) => B>>) => (fga: Kind<F, Kind<G, A>>) => Kind<F, Kind<G, B>>
 }
 
 /**
@@ -120,9 +122,8 @@ export interface ApplicativeComposition11<F extends URIS, G extends URIS> extend
 export interface ApplicativeComposition12<F extends URIS, G extends URIS2> extends FunctorComposition12<F, G> {
   readonly of: <E, A>(a: A) => Kind<F, Kind2<G, E, A>>
   readonly ap: <E, A, B>(
-    fgab: Kind<F, Kind2<G, E, (a: A) => B>>,
-    fga: Kind<F, Kind2<G, E, A>>
-  ) => Kind<F, Kind2<G, E, B>>
+    fgab: Kind<F, Kind2<G, E, (a: A) => B>>
+  ) => (fga: Kind<F, Kind2<G, E, A>>) => Kind<F, Kind2<G, E, B>>
 }
 
 /**
@@ -130,7 +131,9 @@ export interface ApplicativeComposition12<F extends URIS, G extends URIS2> exten
  */
 export interface ApplicativeComposition12C<F extends URIS, G extends URIS2, E> extends FunctorComposition12C<F, G, E> {
   readonly of: <A>(a: A) => Kind<F, Kind2<G, E, A>>
-  readonly ap: <A, B>(fgab: Kind<F, Kind2<G, E, (a: A) => B>>, fga: Kind<F, Kind2<G, E, A>>) => Kind<F, Kind2<G, E, B>>
+  readonly ap: <A, B>(
+    fgab: Kind<F, Kind2<G, E, (a: A) => B>>
+  ) => (fga: Kind<F, Kind2<G, E, A>>) => Kind<F, Kind2<G, E, B>>
 }
 
 /**
@@ -139,9 +142,8 @@ export interface ApplicativeComposition12C<F extends URIS, G extends URIS2, E> e
 export interface ApplicativeComposition21<F extends URIS2, G extends URIS> extends FunctorComposition21<F, G> {
   readonly of: <E, A>(a: A) => Kind2<F, E, Kind<G, A>>
   readonly ap: <E, A, B>(
-    fgab: Kind2<F, E, Kind<G, (a: A) => B>>,
-    fga: Kind2<F, E, Kind<G, A>>
-  ) => Kind2<F, E, Kind<G, B>>
+    fgab: Kind2<F, E, Kind<G, (a: A) => B>>
+  ) => (fga: Kind2<F, E, Kind<G, A>>) => Kind2<F, E, Kind<G, B>>
 }
 
 /**
@@ -149,7 +151,9 @@ export interface ApplicativeComposition21<F extends URIS2, G extends URIS> exten
  */
 export interface ApplicativeComposition2C1<F extends URIS2, G extends URIS, E> extends FunctorComposition2C1<F, G, E> {
   readonly of: <A>(a: A) => Kind2<F, E, Kind<G, A>>
-  readonly ap: <A, B>(fgab: Kind2<F, E, Kind<G, (a: A) => B>>, fga: Kind2<F, E, Kind<G, A>>) => Kind2<F, E, Kind<G, B>>
+  readonly ap: <A, B>(
+    fgab: Kind2<F, E, Kind<G, (a: A) => B>>
+  ) => (fga: Kind2<F, E, Kind<G, A>>) => Kind2<F, E, Kind<G, B>>
 }
 
 /**
@@ -158,9 +162,8 @@ export interface ApplicativeComposition2C1<F extends URIS2, G extends URIS, E> e
 export interface ApplicativeComposition22<F extends URIS2, G extends URIS2> extends FunctorComposition22<F, G> {
   readonly of: <FE, GE, A>(a: A) => Kind2<F, FE, Kind2<G, GE, A>>
   readonly ap: <FE, GE, A, B>(
-    fgab: Kind2<F, FE, Kind2<G, GE, (a: A) => B>>,
-    fga: Kind2<F, FE, Kind2<G, GE, A>>
-  ) => Kind2<F, FE, Kind2<G, GE, B>>
+    fgab: Kind2<F, FE, Kind2<G, GE, (a: A) => B>>
+  ) => (fga: Kind2<F, FE, Kind2<G, GE, A>>) => Kind2<F, FE, Kind2<G, GE, B>>
 }
 
 /**
@@ -169,9 +172,8 @@ export interface ApplicativeComposition22<F extends URIS2, G extends URIS2> exte
 export interface ApplicativeComposition22C<F extends URIS2, G extends URIS2, E> extends FunctorComposition22C<F, G, E> {
   readonly of: <FE, A>(a: A) => Kind2<F, FE, Kind2<G, E, A>>
   readonly ap: <FE, A, B>(
-    fgab: Kind2<F, FE, Kind2<G, E, (a: A) => B>>,
-    fga: Kind2<F, FE, Kind2<G, E, A>>
-  ) => Kind2<F, FE, Kind2<G, E, B>>
+    fgab: Kind2<F, FE, Kind2<G, E, (a: A) => B>>
+  ) => (fga: Kind2<F, FE, Kind2<G, E, A>>) => Kind2<F, FE, Kind2<G, E, B>>
 }
 
 /**
@@ -190,7 +192,7 @@ export interface ApplicativeComposition22C<F extends URIS2, G extends URIS2, E> 
  *
  * const sum = (a: number) => (b: number): number => a + b
  *
- * A.ap(A.map(x, sum), y)()
+ * A.ap(A.map(sum)(x))(y)()
  *   .then(result => assert.deepStrictEqual(result, some(3)))
  *
  * @since 2.0.0
@@ -240,7 +242,6 @@ export function getApplicativeComposition<F, G>(F: Applicative<F>, G: Applicativ
   return {
     ...getFunctorComposition(F, G),
     of: a => F.of(G.of(a)),
-    ap: <A, B>(fgab: HKT<F, HKT<G, (a: A) => B>>, fga: HKT<F, HKT<G, A>>): HKT<F, HKT<G, B>> =>
-      F.ap(F.map(fgab, h => (ga: HKT<G, A>) => G.ap<A, B>(h, ga)), fga)
+    ap: fgab => F.ap(F.map(G.ap)(fgab))
   }
 }

--- a/src/Apply.ts
+++ b/src/Apply.ts
@@ -18,42 +18,44 @@ import { tuple } from './function'
  * @since 2.0.0
  */
 export interface Apply<F> extends Functor<F> {
-  readonly ap: <A, B>(fab: HKT<F, (a: A) => B>, fa: HKT<F, A>) => HKT<F, B>
+  readonly ap: <A, B>(fab: HKT<F, (a: A) => B>) => (fa: HKT<F, A>) => HKT<F, B>
 }
 
 /**
  * @since 2.0.0
  */
 export interface Apply1<F extends URIS> extends Functor1<F> {
-  readonly ap: <A, B>(fab: Kind<F, (a: A) => B>, fa: Kind<F, A>) => Kind<F, B>
+  readonly ap: <A, B>(fab: Kind<F, (a: A) => B>) => (fa: Kind<F, A>) => Kind<F, B>
 }
 
 /**
  * @since 2.0.0
  */
 export interface Apply2<F extends URIS2> extends Functor2<F> {
-  readonly ap: <E, A, B>(fab: Kind2<F, E, (a: A) => B>, fa: Kind2<F, E, A>) => Kind2<F, E, B>
+  readonly ap: <E, A, B>(fab: Kind2<F, E, (a: A) => B>) => (fa: Kind2<F, E, A>) => Kind2<F, E, B>
 }
 
 /**
  * @since 2.0.0
  */
 export interface Apply3<F extends URIS3> extends Functor3<F> {
-  readonly ap: <R, E, A, B>(fab: Kind3<F, R, E, (a: A) => B>, fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+  readonly ap: <R, E, A, B>(fab: Kind3<F, R, E, (a: A) => B>) => (fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
 }
 
 /**
  * @since 2.0.0
  */
 export interface Apply2C<F extends URIS2, E> extends Functor2C<F, E> {
-  readonly ap: <A, B>(fab: Kind2<F, E, (a: A) => B>, fa: Kind2<F, E, A>) => Kind2<F, E, B>
+  readonly ap: <A, B>(fab: Kind2<F, E, (a: A) => B>) => (fa: Kind2<F, E, A>) => Kind2<F, E, B>
 }
 
 /**
  * @since 2.0.0
  */
 export interface Apply4<F extends URIS4> extends Functor4<F> {
-  readonly ap: <S, R, E, A, B>(fab: Kind4<F, S, R, E, (a: A) => B>, fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, B>
+  readonly ap: <S, R, E, A, B>(
+    fab: Kind4<F, S, R, E, (a: A) => B>
+  ) => (fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, B>
 }
 
 function curried(f: Function, n: number, acc: Array<unknown>) {
@@ -116,9 +118,9 @@ export function sequenceT<F>(F: Apply<F>): any {
   return <A>(...args: Array<HKT<F, A>>) => {
     const len = args.length
     const f = getTupleConstructor(len)
-    let fas = F.map(args[0], f)
+    let fas = F.map(f)(args[0])
     for (let i = 1; i < len; i++) {
-      fas = F.ap(fas, args[i])
+      fas = F.ap(fas)(args[i])
     }
     return fas
   }
@@ -197,9 +199,9 @@ export function sequenceS<F>(F: Apply<F>): (r: Record<string, HKT<F, any>>) => H
     const keys = Object.keys(r)
     const len = keys.length
     const f = getRecordConstructor(keys)
-    let fr = F.map(r[keys[0]], f)
+    let fr = F.map(f)(r[keys[0]])
     for (let i = 1; i < len; i++) {
-      fr = F.ap(fr, r[keys[i]])
+      fr = F.ap(fr)(r[keys[i]])
     }
     return fr
   }

--- a/src/Compactable.ts
+++ b/src/Compactable.ts
@@ -215,12 +215,14 @@ export function getCompactableComposition<F, G>(
   G: Compactable<G> & Functor<G>
 ): CompactableComposition<F, G> {
   const FC = getFunctorComposition(F, G)
+  const getLeftFC = FC.map(getLeft)
+  const getRightFC = FC.map(getRight)
   const CC: CompactableComposition<F, G> = {
     ...FC,
-    compact: fga => F.map(fga, G.compact),
+    compact: F.map(G.compact),
     separate: fge => {
-      const left = CC.compact(FC.map(fge, getLeft))
-      const right = CC.compact(FC.map(fge, getRight))
+      const left = CC.compact(getLeftFC(fge))
+      const right = CC.compact(getRightFC(fge))
       return { left, right }
     }
   }

--- a/src/Const.ts
+++ b/src/Const.ts
@@ -57,7 +57,7 @@ export function getApply<E>(S: Semigroup<E>): Apply2C<URI, E> {
     URI,
     _E: undefined as any,
     map: const_.map,
-    ap: (fab, fa) => make(S.concat(fab, fa))
+    ap: fab => fa => make(S.concat(fab, fa))
   }
 }
 
@@ -76,7 +76,7 @@ export function getApplicative<E>(M: Monoid<E>): Applicative2C<URI, E> {
  */
 export const const_: Functor2<URI> & Contravariant2<URI> = {
   URI,
-  map: unsafeCoerce,
+  map: f => fa => unsafeCoerce(fa),
   contramap: unsafeCoerce
 }
 

--- a/src/EitherT.ts
+++ b/src/EitherT.ts
@@ -7,6 +7,7 @@ import {
 import { Either, either, fold, isLeft, left, right, swap, URI } from './Either'
 import { HKT, Kind, Kind2, URIS, URIS2 } from './HKT'
 import { Monad, Monad1, Monad2 } from './Monad'
+import { pipe } from './pipeable'
 
 /**
  * @since 2.0.0
@@ -98,14 +99,22 @@ export function getEitherM<M>(M: Monad<M>): EitherM<M> {
     ...A,
     chain: (ma, f) => M.chain(ma, e => (isLeft(e) ? M.of(left(e.left)) : f(e.right))),
     alt: (fx, f) => M.chain(fx, e => (isLeft(e) ? f() : A.of(e.right))),
-    bimap: (ma, f, g) => M.map(ma, e => either.bimap(e, f, g)),
-    mapLeft: (ma, f) => M.map(ma, e => either.mapLeft(e, f)),
+    bimap: (ma, f, g) =>
+      pipe(
+        ma,
+        M.map(e => either.bimap(e, f, g))
+      ),
+    mapLeft: (ma, f) =>
+      pipe(
+        ma,
+        M.map(e => either.mapLeft(e, f))
+      ),
     fold: (ma, onLeft, onRight) => M.chain(ma, fold(onLeft, onRight)),
     getOrElse: (ma, onLeft) => M.chain(ma, fold(onLeft, M.of)),
     orElse: (ma, f) => M.chain(ma, fold(f, a => A.of(a))),
-    swap: ma => M.map(ma, swap),
-    rightM: ma => M.map(ma, right),
-    leftM: ml => M.map(ml, left),
+    swap: M.map(swap),
+    rightM: M.map(right),
+    leftM: M.map(left),
     left: e => M.of(left(e))
   }
 }

--- a/src/Filterable.ts
+++ b/src/Filterable.ts
@@ -37,6 +37,7 @@ import {
 } from './Functor'
 import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3, URIS4, Kind4 } from './HKT'
 import { getLeft, getRight, Option } from './Option'
+import { pipe } from './pipeable'
 
 /**
  * @since 2.0.0
@@ -420,8 +421,16 @@ export function getFilterableComposition<F, G>(F: Functor<F>, G: Filterable<G>):
       const right = FC.filter(fga, p)
       return { left, right }
     },
-    filterMap: (fga, f) => F.map(fga, ga => G.filterMap(ga, f)),
-    filter: (fga, f) => F.map(fga, ga => G.filter(ga, f))
+    filterMap: (fga, f) =>
+      pipe(
+        fga,
+        F.map(ga => G.filterMap(ga, f))
+      ),
+    filter: (fga, f) =>
+      pipe(
+        fga,
+        F.map(ga => G.filter(ga, f))
+      )
   }
   return FC
 }

--- a/src/Foldable.ts
+++ b/src/Foldable.ts
@@ -308,7 +308,7 @@ export function traverse_<M, F>(
   M: Applicative<M>,
   F: Foldable<F>
 ): <A, B>(fa: HKT<F, A>, f: (a: A) => HKT<M, B>) => HKT<M, void> {
-  const applyFirst = <B>(mu: HKT<M, void>, mb: HKT<M, B>): HKT<M, void> => M.ap(M.map(mu, constant), mb)
+  const applyFirst = <B>(mu: HKT<M, void>, mb: HKT<M, B>): HKT<M, void> => M.ap(M.map(constant)(mu))(mb)
   const mu: HKT<M, void> = M.of(undefined)
   return (fa, f) => F.reduce(fa, mu, (mu, a) => applyFirst(mu, f(a)))
 }

--- a/src/Functor.ts
+++ b/src/Functor.ts
@@ -16,7 +16,7 @@ import { HKT, Kind, Kind2, Kind3, Kind4, URIS, URIS2, URIS3, URIS4 } from './HKT
  */
 export interface Functor<F> {
   readonly URI: F
-  readonly map: <A, B>(fa: HKT<F, A>, f: (a: A) => B) => HKT<F, B>
+  readonly map: <A, B>(f: (a: A) => B) => (fa: HKT<F, A>) => HKT<F, B>
 }
 
 /**
@@ -24,7 +24,7 @@ export interface Functor<F> {
  */
 export interface Functor1<F extends URIS> {
   readonly URI: F
-  readonly map: <A, B>(fa: Kind<F, A>, f: (a: A) => B) => Kind<F, B>
+  readonly map: <A, B>(f: (a: A) => B) => (fa: Kind<F, A>) => Kind<F, B>
 }
 
 /**
@@ -32,7 +32,7 @@ export interface Functor1<F extends URIS> {
  */
 export interface Functor2<F extends URIS2> {
   readonly URI: F
-  readonly map: <E, A, B>(fa: Kind2<F, E, A>, f: (a: A) => B) => Kind2<F, E, B>
+  readonly map: <A, B>(f: (a: A) => B) => <E>(fa: Kind2<F, E, A>) => Kind2<F, E, B>
 }
 
 /**
@@ -41,7 +41,7 @@ export interface Functor2<F extends URIS2> {
 export interface Functor2C<F extends URIS2, E> {
   readonly URI: F
   readonly _E: E
-  readonly map: <A, B>(fa: Kind2<F, E, A>, f: (a: A) => B) => Kind2<F, E, B>
+  readonly map: <A, B>(f: (a: A) => B) => (fa: Kind2<F, E, A>) => Kind2<F, E, B>
 }
 
 /**
@@ -49,7 +49,7 @@ export interface Functor2C<F extends URIS2, E> {
  */
 export interface Functor3<F extends URIS3> {
   readonly URI: F
-  readonly map: <R, E, A, B>(fa: Kind3<F, R, E, A>, f: (a: A) => B) => Kind3<F, R, E, B>
+  readonly map: <A, B>(f: (a: A) => B) => <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
 }
 
 /**
@@ -57,84 +57,84 @@ export interface Functor3<F extends URIS3> {
  */
 export interface Functor4<F extends URIS4> {
   readonly URI: F
-  readonly map: <S, R, E, A, B>(fa: Kind4<F, S, R, E, A>, f: (a: A) => B) => Kind4<F, S, R, E, B>
+  readonly map: <A, B>(f: (a: A) => B) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, B>
 }
 
 /**
  * @since 2.0.0
  */
 export interface FunctorComposition<F, G> {
-  readonly map: <A, B>(fa: HKT<F, HKT<G, A>>, f: (a: A) => B) => HKT<F, HKT<G, B>>
+  readonly map: <A, B>(f: (a: A) => B) => (fa: HKT<F, HKT<G, A>>) => HKT<F, HKT<G, B>>
 }
 
 /**
  * @since 2.0.0
  */
 export interface FunctorCompositionHKT1<F, G extends URIS> {
-  readonly map: <A, B>(fa: HKT<F, Kind<G, A>>, f: (a: A) => B) => HKT<F, Kind<G, B>>
+  readonly map: <A, B>(f: (a: A) => B) => (fa: HKT<F, Kind<G, A>>) => HKT<F, Kind<G, B>>
 }
 
 /**
  * @since 2.0.0
  */
 export interface FunctorCompositionHKT2<F, G extends URIS2> {
-  readonly map: <E, A, B>(fa: HKT<F, Kind2<G, E, A>>, f: (a: A) => B) => HKT<F, Kind2<G, E, B>>
+  readonly map: <A, B>(f: (a: A) => B) => <E>(fa: HKT<F, Kind2<G, E, A>>) => HKT<F, Kind2<G, E, B>>
 }
 
 /**
  * @since 2.0.0
  */
 export interface FunctorCompositionHKT2C<F, G extends URIS2, E> {
-  readonly map: <A, B>(fa: HKT<F, Kind2<G, E, A>>, f: (a: A) => B) => HKT<F, Kind2<G, E, B>>
+  readonly map: <A, B>(f: (a: A) => B) => (fa: HKT<F, Kind2<G, E, A>>) => HKT<F, Kind2<G, E, B>>
 }
 
 /**
  * @since 2.0.0
  */
 export interface FunctorComposition11<F extends URIS, G extends URIS> {
-  readonly map: <A, B>(fa: Kind<F, Kind<G, A>>, f: (a: A) => B) => Kind<F, Kind<G, B>>
+  readonly map: <A, B>(f: (a: A) => B) => (fa: Kind<F, Kind<G, A>>) => Kind<F, Kind<G, B>>
 }
 
 /**
  * @since 2.0.0
  */
 export interface FunctorComposition12<F extends URIS, G extends URIS2> {
-  readonly map: <E, A, B>(fa: Kind<F, Kind2<G, E, A>>, f: (a: A) => B) => Kind<F, Kind2<G, E, B>>
+  readonly map: <A, B>(f: (a: A) => B) => <E>(fa: Kind<F, Kind2<G, E, A>>) => Kind<F, Kind2<G, E, B>>
 }
 
 /**
  * @since 2.0.0
  */
 export interface FunctorComposition12C<F extends URIS, G extends URIS2, E> {
-  readonly map: <A, B>(fa: Kind<F, Kind2<G, E, A>>, f: (a: A) => B) => Kind<F, Kind2<G, E, B>>
+  readonly map: <A, B>(f: (a: A) => B) => (fa: Kind<F, Kind2<G, E, A>>) => Kind<F, Kind2<G, E, B>>
 }
 
 /**
  * @since 2.0.0
  */
 export interface FunctorComposition21<F extends URIS2, G extends URIS> {
-  readonly map: <E, A, B>(fa: Kind2<F, E, Kind<G, A>>, f: (a: A) => B) => Kind2<F, E, Kind<G, B>>
+  readonly map: <A, B>(f: (a: A) => B) => <E>(fa: Kind2<F, E, Kind<G, A>>) => Kind2<F, E, Kind<G, B>>
 }
 
 /**
  * @since 2.0.0
  */
 export interface FunctorComposition2C1<F extends URIS2, G extends URIS, E> {
-  readonly map: <A, B>(fa: Kind2<F, E, Kind<G, A>>, f: (a: A) => B) => Kind2<F, E, Kind<G, B>>
+  readonly map: <A, B>(f: (a: A) => B) => (fa: Kind2<F, E, Kind<G, A>>) => Kind2<F, E, Kind<G, B>>
 }
 
 /**
  * @since 2.0.0
  */
 export interface FunctorComposition22<F extends URIS2, G extends URIS2> {
-  readonly map: <FE, GE, A, B>(fa: Kind2<F, FE, Kind2<G, GE, A>>, f: (a: A) => B) => Kind2<F, FE, Kind2<G, GE, B>>
+  readonly map: <A, B>(f: (a: A) => B) => <FE, GE>(fa: Kind2<F, FE, Kind2<G, GE, A>>) => Kind2<F, FE, Kind2<G, GE, B>>
 }
 
 /**
  * @since 2.0.0
  */
 export interface FunctorComposition22C<F extends URIS2, G extends URIS2, E> {
-  readonly map: <FE, A, B>(fa: Kind2<F, FE, Kind2<G, E, A>>, f: (a: A) => B) => Kind2<F, FE, Kind2<G, E, B>>
+  readonly map: <A, B>(f: (a: A) => B) => <FE>(fa: Kind2<F, FE, Kind2<G, E, A>>) => Kind2<F, FE, Kind2<G, E, B>>
 }
 
 /**
@@ -171,6 +171,6 @@ export function getFunctorComposition<F extends URIS, G extends URIS>(
 export function getFunctorComposition<F, G>(F: Functor<F>, G: Functor<G>): FunctorComposition<F, G>
 export function getFunctorComposition<F, G>(F: Functor<F>, G: Functor<G>): FunctorComposition<F, G> {
   return {
-    map: (fa, f) => F.map(fa, ga => G.map(ga, f))
+    map: f => F.map(G.map(f))
   }
 }

--- a/src/IO.ts
+++ b/src/IO.ts
@@ -148,9 +148,9 @@ export const of = <A>(a: A): IO<A> => () => a
  */
 export const io: Monad1<URI> & MonadIO1<URI> = {
   URI,
-  map: (ma, f) => () => f(ma()),
+  map: f => ma => () => f(ma()),
   of,
-  ap: (mab, ma) => () => mab()(ma()),
+  ap: mab => ma => () => mab()(ma()),
   chain: (ma, f) => () => f(ma())(),
   fromIO: identity
 }

--- a/src/IOEither.ts
+++ b/src/IOEither.ts
@@ -133,7 +133,7 @@ export function bracket<E, A, B>(
   release: (a: A, e: Either<E, B>) => IOEither<E, void>
 ): IOEither<E, B> {
   return T.chain(acquire, a =>
-    T.chain(io.map(use(a), E.right), e => T.chain(release(a, e), () => (E.isLeft(e) ? T.left(e.left) : T.of(e.right))))
+    T.chain(io.map(E.right)(use(a)), e => T.chain(release(a, e), () => (E.isLeft(e) ? T.left(e.left) : T.of(e.right))))
   )
 }
 

--- a/src/Identity.ts
+++ b/src/Identity.ts
@@ -47,19 +47,20 @@ export const getEq: <A>(E: Eq<A>) => Eq<Identity<A>> = id
  */
 export const identity: Monad1<URI> & Foldable1<URI> & Traversable1<URI> & Alt1<URI> & Comonad1<URI> & ChainRec1<URI> = {
   URI,
-  map: (ma, f) => f(ma),
+  map: f => ma => f(ma),
   of: id,
-  ap: (mab, ma) => mab(ma),
+  ap: mab => ma => mab(ma),
   chain: (ma, f) => f(ma),
   reduce: (fa, b, f) => f(b, fa),
   foldMap: _ => (fa, f) => f(fa),
   reduceRight: (fa, b, f) => f(fa, b),
-  traverse: <F>(F: Applicative<F>) => <A, B>(ta: Identity<A>, f: (a: A) => HKT<F, B>): HKT<F, Identity<B>> => {
-    return F.map(f(ta), id)
+  traverse: <F>(F: Applicative<F>) => {
+    const idF = F.map(id)
+    return <A, B>(ta: Identity<A>, f: (a: A) => HKT<F, B>): HKT<F, Identity<B>> => {
+      return idF(f(ta))
+    }
   },
-  sequence: <F>(F: Applicative<F>) => <A>(ta: Identity<HKT<F, A>>): HKT<F, Identity<A>> => {
-    return F.map(ta, id)
-  },
+  sequence: <F>(F: Applicative<F>): (<A>(ta: Identity<HKT<F, A>>) => HKT<F, Identity<A>>) => F.map(id),
   alt: id,
   extract: id,
   extend: (wa, f) => f(wa),

--- a/src/OptionT.ts
+++ b/src/OptionT.ts
@@ -79,7 +79,7 @@ export function getOptionM<M>(M: Monad<M>): OptionM<M> {
     alt: (fx, fy) => M.chain(fx, fold(fy, a => M.of(some(a)))),
     fold: (ma, onNone, onSome) => M.chain(ma, fold(onNone, onSome)),
     getOrElse: (ma, onNone) => M.chain(ma, fold(onNone, M.of)),
-    fromM: ma => M.map(ma, some),
+    fromM: M.map(some),
     none: () => fnone
   }
 }

--- a/src/Profunctor.ts
+++ b/src/Profunctor.ts
@@ -6,7 +6,7 @@ import { HKT, HKT2, Kind2, Kind3, Kind4, URIS2, URIS3, URIS4 } from './HKT'
  */
 export interface Profunctor<F> {
   readonly URI: F
-  readonly map: <E, A, B>(fa: HKT2<F, E, A>, f: (a: A) => B) => HKT<F, B>
+  readonly map: <A, B>(f: (a: A) => B) => <E>(fa: HKT2<F, E, A>) => HKT<F, B>
   readonly promap: <E, A, D, B>(fbc: HKT2<F, E, A>, f: (d: D) => E, g: (a: A) => B) => HKT2<F, D, B>
 }
 

--- a/src/Random.ts
+++ b/src/Random.ts
@@ -19,7 +19,7 @@ export const random: IO<number> = () => Math.random()
  * @since 2.0.0
  */
 export function randomInt(low: number, high: number): IO<number> {
-  return io.map(random, n => Math.floor((high - low + 1) * n + low))
+  return io.map((n: number) => Math.floor((high - low + 1) * n + low))(random)
 }
 
 /**
@@ -29,7 +29,7 @@ export function randomInt(low: number, high: number): IO<number> {
  * @since 2.0.0
  */
 export function randomRange(min: number, max: number): IO<number> {
-  return io.map(random, n => (max - min) * n + min)
+  return io.map((n: number) => (max - min) * n + min)(random)
 }
 
 /**
@@ -37,4 +37,4 @@ export function randomRange(min: number, max: number): IO<number> {
  *
  * @since 2.0.0
  */
-export const randomBool: IO<boolean> = io.map(random, n => n < 0.5)
+export const randomBool: IO<boolean> = io.map((n: number) => n < 0.5)(random)

--- a/src/Reader.ts
+++ b/src/Reader.ts
@@ -88,7 +88,7 @@ export const of: <R, A>(a: A) => Reader<R, A> = T.of
  */
 export const reader: Monad2<URI> & Profunctor2<URI> & Category2<URI> & Strong2<URI> & Choice2<URI> = {
   URI,
-  map: (ma, f) => e => f(ma(e)),
+  map: f => ma => e => f(ma(e)),
   of,
   ap: T.ap,
   chain: T.chain,

--- a/src/ReaderT.ts
+++ b/src/ReaderT.ts
@@ -13,9 +13,9 @@ export interface ReaderT<M, R, A> {
  * @since 2.0.0
  */
 export interface ReaderM<M> {
-  readonly map: <R, A, B>(ma: ReaderT<M, R, A>, f: (a: A) => B) => ReaderT<M, R, B>
+  readonly map: <A, B>(f: (a: A) => B) => <R>(ma: ReaderT<M, R, A>) => ReaderT<M, R, B>
   readonly of: <R, A>(a: A) => ReaderT<M, R, A>
-  readonly ap: <R, A, B>(mab: ReaderT<M, R, (a: A) => B>, ma: ReaderT<M, R, A>) => ReaderT<M, R, B>
+  readonly ap: <R, A, B>(mab: ReaderT<M, R, (a: A) => B>) => (ma: ReaderT<M, R, A>) => ReaderT<M, R, B>
   readonly chain: <R, A, B>(ma: ReaderT<M, R, A>, f: (a: A) => ReaderT<M, R, B>) => ReaderT<M, R, B>
   readonly ask: <R>() => ReaderT<M, R, R>
   readonly asks: <R, A>(f: (r: R) => A) => ReaderT<M, R, A>
@@ -35,9 +35,9 @@ export interface ReaderT1<M extends URIS, R, A> {
  * @since 2.0.0
  */
 export interface ReaderM1<M extends URIS> {
-  readonly map: <R, A, B>(ma: ReaderT1<M, R, A>, f: (a: A) => B) => ReaderT1<M, R, B>
+  readonly map: <A, B>(f: (a: A) => B) => <R>(ma: ReaderT1<M, R, A>) => ReaderT1<M, R, B>
   readonly of: <R, A>(a: A) => ReaderT1<M, R, A>
-  readonly ap: <R, A, B>(mab: ReaderT1<M, R, (a: A) => B>, ma: ReaderT1<M, R, A>) => ReaderT1<M, R, B>
+  readonly ap: <R, A, B>(mab: ReaderT1<M, R, (a: A) => B>) => (ma: ReaderT1<M, R, A>) => ReaderT1<M, R, B>
   readonly chain: <R, A, B>(ma: ReaderT1<M, R, A>, f: (a: A) => ReaderT1<M, R, B>) => ReaderT1<M, R, B>
   readonly ask: <R>() => ReaderT1<M, R, R>
   readonly asks: <R, A>(f: (r: R) => A) => ReaderT1<M, R, A>
@@ -57,9 +57,9 @@ export interface ReaderT2<M extends URIS2, R, E, A> {
  * @since 2.0.0
  */
 export interface ReaderM2<M extends URIS2> {
-  readonly map: <R, E, A, B>(ma: ReaderT2<M, R, E, A>, f: (a: A) => B) => ReaderT2<M, R, E, B>
+  readonly map: <A, B>(f: (a: A) => B) => <R, E>(ma: ReaderT2<M, R, E, A>) => ReaderT2<M, R, E, B>
   readonly of: <R, E, A>(a: A) => ReaderT2<M, R, E, A>
-  readonly ap: <R, E, A, B>(mab: ReaderT2<M, R, E, (a: A) => B>, ma: ReaderT2<M, R, E, A>) => ReaderT2<M, R, E, B>
+  readonly ap: <R, E, A, B>(mab: ReaderT2<M, R, E, (a: A) => B>) => (ma: ReaderT2<M, R, E, A>) => ReaderT2<M, R, E, B>
   readonly chain: <R, E, A, B>(ma: ReaderT2<M, R, E, A>, f: (a: A) => ReaderT2<M, R, E, B>) => ReaderT2<M, R, E, B>
   readonly ask: <R, E>() => ReaderT2<M, R, E, R>
   readonly asks: <R, E, A>(f: (r: R) => A) => ReaderT2<M, R, E, A>
@@ -79,12 +79,11 @@ export interface ReaderT3<M extends URIS3, R, U, E, A> {
  * @since 2.0.0
  */
 export interface ReaderM3<M extends URIS3> {
-  readonly map: <R, U, E, A, B>(ma: ReaderT3<M, R, U, E, A>, f: (a: A) => B) => ReaderT3<M, R, U, E, B>
+  readonly map: <A, B>(f: (a: A) => B) => <R, U, E>(ma: ReaderT3<M, R, U, E, A>) => ReaderT3<M, R, U, E, B>
   readonly of: <R, U, E, A>(a: A) => ReaderT3<M, R, U, E, A>
   readonly ap: <R, U, E, A, B>(
-    mab: ReaderT3<M, R, U, E, (a: A) => B>,
-    ma: ReaderT3<M, R, U, E, A>
-  ) => ReaderT3<M, R, U, E, B>
+    mab: ReaderT3<M, R, U, E, (a: A) => B>
+  ) => (ma: ReaderT3<M, R, U, E, A>) => ReaderT3<M, R, U, E, B>
   readonly chain: <R, U, E, A, B>(
     ma: ReaderT3<M, R, U, E, A>,
     f: (a: A) => ReaderT3<M, R, U, E, B>
@@ -105,12 +104,18 @@ export function getReaderM<M extends URIS>(M: Monad1<M>): ReaderM1<M>
 export function getReaderM<M>(M: Monad<M>): ReaderM<M>
 export function getReaderM<M>(M: Monad<M>): ReaderM<M> {
   return {
-    map: (ma, f) => r => M.map(ma(r), f),
+    map: f => {
+      const fM = M.map(f)
+      return ma => r => fM(ma(r))
+    },
     of: a => () => M.of(a),
-    ap: (mab, ma) => r => M.ap(mab(r), ma(r)),
+    ap: mab => ma => r => M.ap(mab(r))(ma(r)),
     chain: (ma, f) => r => M.chain(ma(r), a => f(a)(r)),
     ask: () => M.of,
-    asks: f => r => M.map(M.of(r), f),
+    asks: f => {
+      const fM = M.map(f)
+      return r => fM(M.of(r))
+    },
     local: (ma, f) => q => ma(f(q)),
     fromReader: ma => r => M.of(ma(r)),
     fromM: ma => () => ma

--- a/src/ReaderTaskEither.ts
+++ b/src/ReaderTaskEither.ts
@@ -238,7 +238,7 @@ export const readerTaskEither: Monad3<URI> & Bifunctor3<URI> & Alt3<URI> & Monad
  */
 export const readerTaskEitherSeq: typeof readerTaskEither = {
   ...readerTaskEither,
-  ap: (mab, ma) => T.chain(mab, f => T.map(ma, f))
+  ap: mab => ma => T.chain(mab, f => T.map(f)(ma))
 }
 
 const {

--- a/src/StateReaderTaskEither.ts
+++ b/src/StateReaderTaskEither.ts
@@ -202,7 +202,7 @@ export const stateReaderTaskEither: Monad4<URI> & MonadThrow4<URI> = {
  */
 export const stateReaderTaskEitherSeq: typeof stateReaderTaskEither = {
   ...stateReaderTaskEither,
-  ap: (mab, ma) => stateReaderTaskEither.chain(mab, f => stateReaderTaskEither.map(ma, f))
+  ap: mab => ma => stateReaderTaskEither.chain(mab, f => stateReaderTaskEither.map(f)(ma))
 }
 
 const { ap, apFirst, apSecond, chain, chainFirst, flatten, map, fromEither, fromOption } = pipeable(

--- a/src/StateT.ts
+++ b/src/StateT.ts
@@ -1,6 +1,7 @@
 import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3 } from './HKT'
 import { Monad, Monad1, Monad2, Monad3 } from './Monad'
 import { State } from './State'
+import { pipe } from './pipeable'
 
 /**
  * @since 2.0.0
@@ -13,9 +14,9 @@ export interface StateT<M, S, A> {
  * @since 2.0.0
  */
 export interface StateM<M> {
-  readonly map: <S, A, B>(fa: StateT<M, S, A>, f: (a: A) => B) => StateT<M, S, B>
+  readonly map: <A, B>(f: (a: A) => B) => <S>(fa: StateT<M, S, A>) => StateT<M, S, B>
   readonly of: <S, A>(a: A) => StateT<M, S, A>
-  readonly ap: <S, A, B>(fab: StateT<M, S, (a: A) => B>, fa: StateT<M, S, A>) => StateT<M, S, B>
+  readonly ap: <S, A, B>(fab: StateT<M, S, (a: A) => B>) => (fa: StateT<M, S, A>) => StateT<M, S, B>
   readonly chain: <S, A, B>(fa: StateT<M, S, A>, f: (a: A) => StateT<M, S, B>) => StateT<M, S, B>
   readonly get: <S>() => StateT<M, S, S>
   readonly put: <S>(s: S) => StateT<M, S, void>
@@ -38,9 +39,9 @@ export interface StateT1<M extends URIS, S, A> {
  * @since 2.0.0
  */
 export interface StateM1<M extends URIS> {
-  readonly map: <S, A, B>(fa: StateT1<M, S, A>, f: (a: A) => B) => StateT1<M, S, B>
+  readonly map: <A, B>(f: (a: A) => B) => <S>(fa: StateT1<M, S, A>) => StateT1<M, S, B>
   readonly of: <S, A>(a: A) => StateT1<M, S, A>
-  readonly ap: <S, A, B>(fab: StateT1<M, S, (a: A) => B>, fa: StateT1<M, S, A>) => StateT1<M, S, B>
+  readonly ap: <S, A, B>(fab: StateT1<M, S, (a: A) => B>) => (fa: StateT1<M, S, A>) => StateT1<M, S, B>
   readonly chain: <S, A, B>(fa: StateT1<M, S, A>, f: (a: A) => StateT1<M, S, B>) => StateT1<M, S, B>
   readonly get: <S>() => StateT1<M, S, S>
   readonly put: <S>(s: S) => StateT1<M, S, void>
@@ -63,9 +64,9 @@ export interface StateT2<M extends URIS2, S, E, A> {
  * @since 2.0.0
  */
 export interface StateM2<M extends URIS2> {
-  readonly map: <S, E, A, B>(fa: StateT2<M, S, E, A>, f: (a: A) => B) => StateT2<M, S, E, B>
+  readonly map: <A, B>(f: (a: A) => B) => <S, E>(fa: StateT2<M, S, E, A>) => StateT2<M, S, E, B>
   readonly of: <S, E, A>(a: A) => StateT2<M, S, E, A>
-  readonly ap: <S, E, A, B>(fab: StateT2<M, S, E, (a: A) => B>, fa: StateT2<M, S, E, A>) => StateT2<M, S, E, B>
+  readonly ap: <S, E, A, B>(fab: StateT2<M, S, E, (a: A) => B>) => (fa: StateT2<M, S, E, A>) => StateT2<M, S, E, B>
   readonly chain: <S, E, A, B>(fa: StateT2<M, S, E, A>, f: (a: A) => StateT2<M, S, E, B>) => StateT2<M, S, E, B>
   readonly get: <E, S>() => StateT2<M, S, E, S>
   readonly put: <E, S>(s: S) => StateT2<M, S, E, void>
@@ -88,12 +89,11 @@ export interface StateT3<M extends URIS3, S, R, E, A> {
  * @since 2.0.0
  */
 export interface StateM3<M extends URIS3> {
-  readonly map: <S, R, E, A, B>(fa: StateT3<M, S, R, E, A>, f: (a: A) => B) => StateT3<M, S, R, E, B>
+  readonly map: <A, B>(f: (a: A) => B) => <S, R, E>(fa: StateT3<M, S, R, E, A>) => StateT3<M, S, R, E, B>
   readonly of: <S, R, E, A>(a: A) => StateT3<M, S, R, E, A>
   readonly ap: <S, R, E, A, B>(
-    fab: StateT3<M, S, R, E, (a: A) => B>,
-    fa: StateT3<M, S, R, E, A>
-  ) => StateT3<M, S, R, E, B>
+    fab: StateT3<M, S, R, E, (a: A) => B>
+  ) => (fa: StateT3<M, S, R, E, A>) => StateT3<M, S, R, E, B>
   readonly chain: <S, R, E, A, B>(
     fa: StateT3<M, S, R, E, A>,
     f: (a: A) => StateT3<M, S, R, E, B>
@@ -117,17 +117,39 @@ export function getStateM<M extends URIS>(M: Monad1<M>): StateM1<M>
 export function getStateM<M>(M: Monad<M>): StateM<M>
 export function getStateM<M>(M: Monad<M>): StateM<M> {
   return {
-    map: (fa, f) => s => M.map(fa(s), ([a, s1]) => [f(a), s1]),
+    map: f => fa => s =>
+      pipe(
+        fa(s),
+        M.map(([a, s1]) => [f(a), s1])
+      ),
     of: a => s => M.of([a, s]),
-    ap: (fab, fa) => s => M.chain(fab(s), ([f, s]) => M.map(fa(s), ([a, s]) => [f(a), s])),
+    ap: fab => fa => s =>
+      M.chain(fab(s), ([f, s]) =>
+        pipe(
+          fa(s),
+          M.map(([a, s]) => [f(a), s])
+        )
+      ),
     chain: (fa, f) => s => M.chain(fa(s), ([a, s1]) => f(a)(s1)),
     get: () => s => M.of([s, s]),
     put: s => () => M.of([undefined, s]),
     modify: f => s => M.of([undefined, f(s)]),
     gets: f => s => M.of([f(s), s]),
     fromState: sa => s => M.of(sa(s)),
-    fromM: ma => s => M.map(ma, a => [a, s]),
-    evalState: (ma, s) => M.map(ma(s), ([a]) => a),
-    execState: (ma, s) => M.map(ma(s), ([_, s]) => s)
+    fromM: ma => s =>
+      pipe(
+        ma,
+        M.map(a => [a, s])
+      ),
+    evalState: (ma, s) =>
+      pipe(
+        ma(s),
+        M.map(([a]) => a)
+      ),
+    execState: (ma, s) =>
+      pipe(
+        ma(s),
+        M.map(([_, s]) => s)
+      )
   }
 }

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -2,7 +2,7 @@ import { Comonad2 } from './Comonad'
 import { Endomorphism } from './function'
 import { Functor, Functor1, Functor2, Functor2C, Functor3 } from './Functor'
 import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3 } from './HKT'
-import { pipeable } from './pipeable'
+import { pipe, pipeable } from './pipeable'
 
 declare module './HKT' {
   interface URItoKind2<E, A> {
@@ -74,7 +74,11 @@ export function experiment<F extends URIS>(
 ): <S>(f: (s: S) => Kind<F, S>) => <A>(wa: Store<S, A>) => Kind<F, A>
 export function experiment<F>(F: Functor<F>): <S>(f: (s: S) => HKT<F, S>) => <A>(wa: Store<S, A>) => HKT<F, A>
 export function experiment<F>(F: Functor<F>): <S>(f: (s: S) => HKT<F, S>) => <A>(wa: Store<S, A>) => HKT<F, A> {
-  return f => wa => F.map(f(wa.pos), s => wa.peek(s))
+  return f => wa =>
+    pipe(
+      f(wa.pos),
+      F.map(s => wa.peek(s))
+    )
 }
 
 /**
@@ -82,7 +86,7 @@ export function experiment<F>(F: Functor<F>): <S>(f: (s: S) => HKT<F, S>) => <A>
  */
 export const store: Comonad2<URI> = {
   URI,
-  map: (wa, f) => ({
+  map: f => wa => ({
     peek: s => f(wa.peek(s)),
     pos: wa.pos
   }),

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -117,9 +117,9 @@ export function of<A>(a: A): Task<A> {
  */
 export const task: Monad1<URI> & MonadTask1<URI> = {
   URI,
-  map: (ma, f) => () => ma().then(f),
+  map: f => ma => () => ma().then(f),
   of,
-  ap: (mab, ma) => () => Promise.all([mab(), ma()]).then(([f, a]) => f(a)),
+  ap: mab => ma => () => Promise.all([mab(), ma()]).then(([f, a]) => f(a)),
   chain: (ma, f) => () => ma().then(a => f(a)()),
   fromIO,
   fromTask: identity
@@ -132,7 +132,7 @@ export const task: Monad1<URI> & MonadTask1<URI> = {
  */
 export const taskSeq: typeof task = {
   ...task,
-  ap: (mab, ma) => () => mab().then(f => ma().then(a => f(a)))
+  ap: mab => ma => () => mab().then(f => ma().then(a => f(a)))
 }
 
 const { ap, apFirst, apSecond, chain, chainFirst, flatten, map } = pipeable(task)

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -154,10 +154,9 @@ export function bracket<E, A, B>(
   use: (a: A) => TaskEither<E, B>,
   release: (a: A, e: Either<E, B>) => TaskEither<E, void>
 ): TaskEither<E, B> {
+  const eRightTask = task.map(E.right)
   return T.chain(acquire, a =>
-    T.chain(task.map(use(a), E.right), e =>
-      T.chain(release(a, e), () => (E.isLeft(e) ? T.left(e.left) : T.of(e.right)))
-    )
+    T.chain(eRightTask(use(a)), e => T.chain(release(a, e), () => (E.isLeft(e) ? T.left(e.left) : T.of(e.right))))
   )
 }
 
@@ -252,7 +251,7 @@ export const taskEither: Monad2<URI> & Bifunctor2<URI> & Alt2<URI> & MonadTask2<
  */
 export const taskEitherSeq: typeof taskEither = {
   ...taskEither,
-  ap: (mab, ma) => T.chain(mab, f => T.map(ma, f))
+  ap: mab => ma => T.chain(mab, f => T.map(f)(ma))
 }
 
 const {

--- a/src/Traced.ts
+++ b/src/Traced.ts
@@ -88,7 +88,7 @@ export function getComonad<P>(monoid: Monoid<P>): Comonad2C<URI, P> {
  */
 export const traced: Functor2<URI> = {
   URI,
-  map: (wa, f) => p => f(wa(p))
+  map: f => wa => p => f(wa(p))
 }
 
 const { map } = pipeable(traced)

--- a/src/Traversable.ts
+++ b/src/Traversable.ts
@@ -346,8 +346,8 @@ export function getTraversableComposition<F, G>(F: Traversable<F>, G: Traversabl
     },
     sequence: H => {
       const sequenceF = F.sequence(H)
-      const sequenceG = G.sequence(H)
-      return fgha => sequenceF(F.map(fgha, sequenceG))
+      const sequenceGF = F.map(G.sequence(H))
+      return fgha => sequenceF(sequenceGF(fgha))
     }
   }
 }

--- a/src/ValidationT.ts
+++ b/src/ValidationT.ts
@@ -8,6 +8,7 @@ import { Either, getValidation, isLeft, isRight, left, URI } from './Either'
 import { HKT, Kind, Kind2, URIS, URIS2 } from './HKT'
 import { Monad, Monad1, Monad2 } from './Monad'
 import { Semigroup } from './Semigroup'
+import { pipe } from './pipeable'
 
 /**
  * @since 2.0.0
@@ -65,7 +66,12 @@ export function getValidationM<E, M>(S: Semigroup<E>, M: Monad<M>): ValidationM<
     chain: (ma, f) => M.chain(ma, e => (isLeft(e) ? M.of(left(e.left)) : f(e.right))),
     alt: (fx, f) =>
       M.chain(fx, e1 =>
-        isRight(e1) ? A.of(e1.right) : M.map(f(), e2 => (isLeft(e2) ? left(S.concat(e1.left, e2.left)) : e2))
+        isRight(e1)
+          ? A.of(e1.right)
+          : pipe(
+              f(),
+              M.map(e2 => (isLeft(e2) ? left(S.concat(e1.left, e2.left)) : e2))
+            )
       )
   }
 }

--- a/src/Writer.ts
+++ b/src/Writer.ts
@@ -106,7 +106,7 @@ export function getMonad<W>(M: Monoid<W>): Monad2C<URI, W> {
     _E: undefined as any,
     map: writer.map,
     of: a => () => [a, M.empty],
-    ap: (mab, ma) => () => {
+    ap: mab => ma => () => {
       const [f, w1] = mab()
       const [a, w2] = ma()
       return [f(a), M.concat(w1, w2)]
@@ -124,7 +124,7 @@ export function getMonad<W>(M: Monoid<W>): Monad2C<URI, W> {
  */
 export const writer: Functor2<URI> = {
   URI,
-  map: (fa, f) => () => {
+  map: f => fa => () => {
     const [a, w] = fa()
     return [f(a), w]
   }

--- a/test/Applicative.ts
+++ b/test/Applicative.ts
@@ -8,12 +8,12 @@ describe('Applicative', () => {
     const arrayOption = getApplicativeComposition(array, option)
     const double = (n: number) => n * 2
     const inc = (n: number) => n + 1
-    assert.deepStrictEqual(arrayOption.ap([some(double), some(inc)], [some(1), some(2)]), [
+    assert.deepStrictEqual(arrayOption.ap([some(double), some(inc)])([some(1), some(2)]), [
       some(2),
       some(4),
       some(2),
       some(3)
     ])
-    assert.deepStrictEqual(arrayOption.ap([some(double), none], [some(1), some(2)]), [some(2), some(4), none, none])
+    assert.deepStrictEqual(arrayOption.ap([some(double), none])([some(1), some(2)]), [some(2), some(4), none, none])
   })
 })

--- a/test/Array.ts
+++ b/test/Array.ts
@@ -69,6 +69,7 @@ import * as I from '../src/Identity'
 import * as C from '../src/Const'
 import { showString } from '../src/Show'
 import { isDeepStrictEqual } from 'util'
+import { pipe } from '../src/pipeable'
 
 const p = (n: number) => n > 2
 
@@ -125,7 +126,10 @@ describe('Array', () => {
   })
 
   it('ap', () => {
-    const as = array.ap([x => x * 2, x => x * 3], [1, 2, 3])
+    const as = pipe(
+      [1, 2, 3],
+      array.ap([x => x * 2, x => x * 3])
+    )
     assert.deepStrictEqual(as, [2, 4, 6, 3, 6, 9])
   })
 
@@ -274,7 +278,7 @@ describe('Array', () => {
 
   const optionStringEq = O.getEq(eqString)
   const multipleOf3: Predicate<number> = (x: number) => x % 3 === 0
-  const multipleOf3AsString = (x: number) => O.option.map(O.fromPredicate(multipleOf3)(x), x => `${x}`)
+  const multipleOf3AsString = (x: number) => O.option.map(x => `${x}`)(O.fromPredicate(multipleOf3)(x))
 
   it('`findFirstMap(arr, fun)` is equivalent to map and `head(mapOption(arr, fun)`', () => {
     fc.assert(
@@ -395,7 +399,13 @@ describe('Array', () => {
   })
 
   it('map', () => {
-    assert.deepStrictEqual(array.map([1, 2, 3], n => n * 2), [2, 4, 6])
+    assert.deepStrictEqual(
+      pipe(
+        [1, 2, 3],
+        array.map(n => n * 2)
+      ),
+      [2, 4, 6]
+    )
   })
 
   it('mapWithIndex', () => {
@@ -403,7 +413,7 @@ describe('Array', () => {
   })
 
   it('ap', () => {
-    assert.deepStrictEqual(array.ap([(n: number) => n * 2, (n: number) => n + 1], [1, 2, 3]), [2, 4, 6, 2, 3, 4])
+    assert.deepStrictEqual(array.ap([(n: number) => n * 2, (n: number) => n + 1])([1, 2, 3]), [2, 4, 6, 2, 3, 4])
   })
 
   it('copy', () => {
@@ -745,7 +755,7 @@ describe('Array', () => {
       bar: () => number
     }
     const f = (a: number, x?: Foo) => (x !== undefined ? `${a}${x.bar()}` : `${a}`)
-    const res = array.map([1, 2], f)
+    const res = array.map(f)([1, 2])
     assert.deepStrictEqual(res, ['1', '2'])
   })
 

--- a/test/Const.ts
+++ b/test/Const.ts
@@ -9,7 +9,7 @@ describe('Const', () => {
   it('map', () => {
     const fa = make('foo')
     const double = (n: number): number => n * 2
-    assert.strictEqual(const_.map(fa, double), fa)
+    assert.strictEqual(const_.map(double)(fa), fa)
   })
 
   it('contramap', () => {
@@ -32,7 +32,7 @@ describe('Const', () => {
   it('getApplicative', () => {
     const F = getApply(semigroupString)
     const fa = make('foo')
-    assert.deepStrictEqual(F.ap(fa, make('bar')), make('foobar'))
+    assert.deepStrictEqual(F.ap(fa)(make('bar')), make('foobar'))
   })
 
   it('getShow', () => {

--- a/test/Either.ts
+++ b/test/Either.ts
@@ -186,19 +186,28 @@ describe('Either', () => {
   describe('Monad', () => {
     it('map', () => {
       const f = (s: string): number => s.length
-      assert.deepStrictEqual(_.either.map(_.right('abc'), f), _.right(3))
-      assert.deepStrictEqual(_.either.map(_.left('s'), f), _.left('s'))
+      assert.deepStrictEqual(_.either.map(f)(_.right('abc')), _.right(3))
+      assert.deepStrictEqual(_.either.map(f)(_.left('s')), _.left('s'))
     })
 
     it('ap', () => {
       const f = (s: string): number => s.length
-      assert.deepStrictEqual(_.either.ap(_.right(f), _.right('abc')), _.right(3))
-      assert.deepStrictEqual(_.either.ap(_.right(f), _.left('maError')), _.left('maError'))
+      assert.deepStrictEqual(_.either.ap(_.right(f))(_.right('abc')), _.right(3))
       assert.deepStrictEqual(
-        _.either.ap(_.left<string, (s: string) => number>('mabError'), _.right('abc')),
+        pipe(
+          _.left('maError'),
+          _.either.ap(_.right(f))
+        ),
+        _.left('maError')
+      )
+      assert.deepStrictEqual(
+        _.either.ap(_.left<string, (s: string) => number>('mabError'))(_.right('abc')),
         _.left('mabError')
       )
-      assert.deepStrictEqual(_.either.ap(_.left('mabError'), _.left('maError')), _.left('mabError'))
+      assert.deepStrictEqual(
+        _.either.ap(_.left<string, (s: string) => number>('mabError'))(_.left('maError')),
+        _.left('mabError')
+      )
     })
 
     it('chain', () => {
@@ -484,10 +493,10 @@ describe('Either', () => {
       assert.deepStrictEqual(M.chain(_.left('a'), () => _.left('b')), _.left('a'))
       assert.deepStrictEqual(M.of(1), _.right(1))
       const double = (n: number) => n * 2
-      assert.deepStrictEqual(M.ap(_.right(double), _.right(1)), _.right(2))
-      assert.deepStrictEqual(M.ap(_.right(double), _.left('foo')), _.left('foo'))
-      assert.deepStrictEqual(M.ap(_.left<string, (n: number) => number>('foo'), _.right(1)), _.left('foo'))
-      assert.deepStrictEqual(M.ap(_.left('foo'), _.left('bar')), _.left('foobar'))
+      assert.deepStrictEqual(M.ap(_.right(double))(_.right(1)), _.right(2))
+      assert.deepStrictEqual(M.ap(_.right(double))(_.left('foo')), _.left('foo'))
+      assert.deepStrictEqual(M.ap(_.left<string, (n: number) => number>('foo'))(_.right(1)), _.left('foo'))
+      assert.deepStrictEqual(M.ap(_.left<string, (n: number) => number>('foo'))(_.left('bar')), _.left('foobar'))
       assert.deepStrictEqual(M.alt(_.left('a'), () => _.right(1)), _.right(1))
       assert.deepStrictEqual(M.alt(_.right(1), () => _.left('a')), _.right(1))
       assert.deepStrictEqual(M.alt(_.left('a'), () => _.left('b')), _.left('ab'))

--- a/test/Functor.ts
+++ b/test/Functor.ts
@@ -7,6 +7,6 @@ describe('Functor', () => {
   it('getFunctorComposition', () => {
     const arrayOption = getFunctorComposition(array, option.option)
     const double = (a: number) => a * 2
-    assert.deepStrictEqual(arrayOption.map([option.some(1)], double), [option.some(2)])
+    assert.deepStrictEqual(arrayOption.map(double)([option.some(1)]), [option.some(2)])
   })
 })

--- a/test/IO.ts
+++ b/test/IO.ts
@@ -8,7 +8,7 @@ describe('IO', () => {
     const double = (n: number): number => n * 2
     const fab = io.of(double)
     const fa = io.of(1)
-    assert.strictEqual(io.ap(fab, fa)(), 2)
+    assert.strictEqual(io.ap(fab)(fa)(), 2)
   })
 
   it('chain', () => {

--- a/test/IOEither.ts
+++ b/test/IOEither.ts
@@ -91,14 +91,14 @@ describe('IOEither', () => {
   describe('Monad', () => {
     it('map', () => {
       const double = (n: number): number => n * 2
-      assert.deepStrictEqual(_.ioEither.map(_.right(1), double)(), E.right(2))
+      assert.deepStrictEqual(_.ioEither.map(double)(_.right(1))(), E.right(2))
     })
 
     it('ap', () => {
       const double = (n: number): number => n * 2
       const mab = _.right(double)
       const ma = _.right(1)
-      assert.deepStrictEqual(_.ioEither.ap(mab, ma)(), E.right(2))
+      assert.deepStrictEqual(_.ioEither.ap(mab)(ma)(), E.right(2))
     })
 
     it('chain', () => {
@@ -223,16 +223,16 @@ describe('IOEither', () => {
 
     it('map', () => {
       const double = (n: number): number => n * 2
-      const e1 = IV.map(IV.of(1), double)()
+      const e1 = IV.map(double)(IV.of(1))()
       assert.deepStrictEqual(e1, E.right(2))
-      const e2 = IV.map(_.left('a'), double)()
+      const e2 = IV.map(double)(_.left('a'))()
       assert.deepStrictEqual(e2, E.left('a'))
     })
 
     it('ap', () => {
       const fab = _.left('a')
       const fa = _.left('b')
-      const e1 = IV.ap(fab, fa)()
+      const e1 = IV.ap(fab)(fa)()
       assert.deepStrictEqual(e1, E.left('ab'))
     })
 

--- a/test/Identity.ts
+++ b/test/Identity.ts
@@ -12,7 +12,7 @@ describe('Identity', () => {
     const double = (n: number): number => n * 2
     const x = I.identity.of(1)
     const expected = I.identity.of(2)
-    assert.deepStrictEqual(I.identity.map(x, double), expected)
+    assert.deepStrictEqual(I.identity.map(double)(x), expected)
   })
 
   it('ap', () => {
@@ -20,7 +20,7 @@ describe('Identity', () => {
     const fab = I.identity.of(double)
     const fa = I.identity.of(1)
     const expected = I.identity.of(2)
-    assert.deepStrictEqual(I.identity.ap(fab, fa), expected)
+    assert.deepStrictEqual(I.identity.ap(fab)(fa), expected)
   })
 
   it('chain', () => {

--- a/test/Map.ts
+++ b/test/Map.ts
@@ -331,7 +331,7 @@ describe('Map', () => {
         const d1 = new Map<string, number>([['k1', 1], ['k2', 2]])
         const expected = new Map<string, number>([['k1', 2], ['k2', 4]])
         const double = (n: number): number => n * 2
-        assert.deepStrictEqual(map(d1, double), expected)
+        assert.deepStrictEqual(map(double)(d1), expected)
       })
     })
 

--- a/test/NonEmptyArray.ts
+++ b/test/NonEmptyArray.ts
@@ -45,7 +45,7 @@ describe('NonEmptyArray', () => {
 
   it('map', () => {
     const double = (n: number) => n * 2
-    assert.deepStrictEqual(nonEmptyArray.map([1, 2], double), [2, 4])
+    assert.deepStrictEqual(nonEmptyArray.map(double)([1, 2]), [2, 4])
   })
 
   it('mapWithIndex', () => {
@@ -59,7 +59,7 @@ describe('NonEmptyArray', () => {
 
   it('ap', () => {
     const double = (n: number) => n * 2
-    assert.deepStrictEqual(nonEmptyArray.ap([double, double], [1, 2]), [2, 4, 2, 4])
+    assert.deepStrictEqual(nonEmptyArray.ap([double, double])([1, 2]), [2, 4, 2, 4])
   })
 
   it('chain', () => {

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -65,8 +65,8 @@ describe('Option', () => {
 
   it('map', () => {
     const f = (n: number) => n * 2
-    assert.deepStrictEqual(O.option.map(O.some(2), f), O.some(4))
-    assert.deepStrictEqual(O.option.map(O.none, f), O.none)
+    assert.deepStrictEqual(O.option.map(f)(O.some(2)), O.some(4))
+    assert.deepStrictEqual(O.option.map(f)(O.none), O.none)
   })
 
   it('getEq', () => {
@@ -132,10 +132,10 @@ describe('Option', () => {
 
   it('ap', () => {
     const f = (n: number) => n * 2
-    assert.deepStrictEqual(O.option.ap(O.some(f), O.some(2)), O.some(4))
-    assert.deepStrictEqual(O.option.ap(O.some(f), O.none), O.none)
-    assert.deepStrictEqual(O.option.ap(O.none, O.some(2)), O.none)
-    assert.deepStrictEqual(O.option.ap(O.none, O.none), O.none)
+    assert.deepStrictEqual(O.option.ap(O.some(f))(O.some(2)), O.some(4))
+    assert.deepStrictEqual(O.option.ap(O.some(f))(O.none), O.none)
+    assert.deepStrictEqual(O.option.ap(O.none)(O.some(2)), O.none)
+    assert.deepStrictEqual(O.option.ap(O.none)(O.none), O.none)
   })
 
   it('chain', () => {

--- a/test/OptionT.ts
+++ b/test/OptionT.ts
@@ -8,7 +8,7 @@ const T = getOptionM(task)
 describe('OptionT', () => {
   it('map', () => {
     const greetingT = T.of('welcome')
-    const excitedGreetingT = T.map(greetingT, s => s + '!')
+    const excitedGreetingT = T.map(s => s + '!')(greetingT)
     return excitedGreetingT().then(o => {
       assert.deepStrictEqual(o, O.some('welcome!'))
     })

--- a/test/Reader.ts
+++ b/test/Reader.ts
@@ -11,7 +11,7 @@ interface Env {
 describe('Reader', () => {
   it('map', () => {
     const double = (n: number): number => n * 2
-    assert.strictEqual(R.reader.map(() => 1, double)({}), 2)
+    assert.strictEqual(R.reader.map(double)(() => 1)({}), 2)
   })
 
   it('of', () => {
@@ -22,7 +22,7 @@ describe('Reader', () => {
     const double = (n: number): number => n * 2
     const f = R.reader.of(double)
     const x = R.reader.of(1)
-    assert.strictEqual(R.reader.ap(f, x)({}), 2)
+    assert.strictEqual(R.reader.ap(f)(x)({}), 2)
   })
 
   it('chain', () => {

--- a/test/ReaderTaskEither.ts
+++ b/test/ReaderTaskEither.ts
@@ -16,7 +16,7 @@ describe('ReaderTaskEither', () => {
   describe('Monad', () => {
     it('map', async () => {
       const double = (n: number): number => n * 2
-      const x = await _.run(_.readerTaskEither.map(_.right(1), double), {})
+      const x = await _.run(_.readerTaskEither.map(double)(_.right(1)), {})
       assert.deepStrictEqual(x, E.right(2))
     })
 
@@ -24,7 +24,7 @@ describe('ReaderTaskEither', () => {
       const double = (n: number): number => n * 2
       const mab = _.right(double)
       const ma = _.right(1)
-      const x = await _.run(_.readerTaskEither.ap(mab, ma), {})
+      const x = await _.run(_.readerTaskEither.ap(mab)(ma), {})
       assert.deepStrictEqual(x, E.right(2))
     })
 

--- a/test/Record.ts
+++ b/test/Record.ts
@@ -33,7 +33,7 @@ describe('Record', () => {
 
   it('record.map', () => {
     const double = (n: number): number => n * 2
-    assert.deepStrictEqual(R.record.map({ a: 1, b: 2 }, double), { a: 2, b: 4 })
+    assert.deepStrictEqual(R.record.map(double)({ a: 1, b: 2 }), { a: 2, b: 4 })
   })
 
   it('reduce', () => {

--- a/test/State.ts
+++ b/test/State.ts
@@ -32,14 +32,14 @@ describe('State', () => {
   it('map', () => {
     const double = (n: number) => n * 2
     const x = (s: number) => tuple(s - 1, s + 1)
-    assert.deepStrictEqual(S.state.map(x, double)(0), [-2, 1])
+    assert.deepStrictEqual(S.state.map(double)(x)(0), [-2, 1])
   })
 
   it('ap', () => {
     const double = (n: number) => n * 2
     const fab = S.state.of(double)
     const fa = S.state.of(1)
-    assert.deepStrictEqual(S.state.ap(fab, fa)(0), [2, 0])
+    assert.deepStrictEqual(S.state.ap(fab)(fa)(0), [2, 0])
   })
 
   it('chain', () => {

--- a/test/StateReaderTaskEither.ts
+++ b/test/StateReaderTaskEither.ts
@@ -22,7 +22,7 @@ describe('StateReaderTaskEither', () => {
     it('map', async () => {
       const len = (s: string): number => s.length
       const ma = _.right('aaa')
-      const e = await RTE.run(_.evalState(_.stateReaderTaskEither.map(ma, len), {}), {})
+      const e = await RTE.run(_.evalState(_.stateReaderTaskEither.map(len)(ma), {}), {})
       assert.deepStrictEqual(e, E.right(3))
     })
 
@@ -30,7 +30,7 @@ describe('StateReaderTaskEither', () => {
       const len = (s: string): number => s.length
       const mab = _.right(len)
       const ma = _.right('aaa')
-      const e = await RTE.run(_.evalState(_.stateReaderTaskEither.ap(mab, ma), {}), {})
+      const e = await RTE.run(_.evalState(_.stateReaderTaskEither.ap(mab)(ma), {}), {})
       assert.deepStrictEqual(e, E.right(3))
     })
 
@@ -38,7 +38,7 @@ describe('StateReaderTaskEither', () => {
       const len = (s: string): number => s.length
       const mab = _.right(len)
       const ma = _.right('aaa')
-      const e = await RTE.run(_.evalState(_.stateReaderTaskEitherSeq.ap(mab, ma), {}), {})
+      const e = await RTE.run(_.evalState(_.stateReaderTaskEitherSeq.ap(mab)(ma), {}), {})
       assert.deepStrictEqual(e, E.right(3))
     })
 

--- a/test/Store.ts
+++ b/test/Store.ts
@@ -8,12 +8,12 @@ const len = (s: string): number => s.length
 describe('Store', () => {
   it('map', () => {
     const wa: Store<string, number> = { peek: len, pos: 'a' }
-    assert.strictEqual(store.extract(store.map(wa, n => n + 1)), 2)
+    assert.strictEqual(store.extract(store.map((n: number) => n + 1)(wa)), 2)
   })
 
   it('extends', () => {
     const wa: Store<string, number> = { peek: len, pos: 'a' }
-    assert.strictEqual(store.extract(store.extend(wa, wa => store.extract(store.map(wa, n => n + 1)))), 2)
+    assert.strictEqual(store.extract(store.extend(wa, wa => store.extract(store.map((n: number) => n + 1)(wa)))), 2)
   })
 
   it('seek', () => {

--- a/test/Task.ts
+++ b/test/Task.ts
@@ -60,7 +60,7 @@ describe('Task', () => {
   describe('Monad', () => {
     it('map', async () => {
       const double = (n: number): number => n * 2
-      const x = await T.task.map(delay(0, 1), double)()
+      const x = await T.task.map(double)(delay(0, 1))()
       assert.strictEqual(x, 2)
     })
 
@@ -68,7 +68,7 @@ describe('Task', () => {
       const double = (n: number): number => n * 2
       const tab = delay(0, double)
       const ta = delay(0, 1)
-      const x = await T.task.ap(tab, ta)()
+      const x = await T.task.ap(tab)(ta)()
       assert.strictEqual(x, 2)
     })
 

--- a/test/TaskEither.ts
+++ b/test/TaskEither.ts
@@ -12,7 +12,7 @@ describe('TaskEither', () => {
   describe('Monad', () => {
     it('map', async () => {
       const double = (n: number): number => n * 2
-      const x = await _.taskEither.map(_.right(1), double)()
+      const x = await _.taskEither.map(double)(_.right(1))()
       assert.deepStrictEqual(x, E.right(2))
     })
 
@@ -20,7 +20,7 @@ describe('TaskEither', () => {
       const double = (n: number): number => n * 2
       const mab = _.right(double)
       const ma = _.right(1)
-      const x = await _.taskEither.ap(mab, ma)()
+      const x = await _.taskEither.ap(mab)(ma)()
       assert.deepStrictEqual(x, E.right(2))
     })
 
@@ -296,16 +296,16 @@ describe('TaskEither', () => {
 
     it('map', async () => {
       const double = (n: number): number => n * 2
-      const e1 = await TV.map(TV.of(1), double)()
+      const e1 = await TV.map(double)(TV.of(1))()
       assert.deepStrictEqual(e1, E.right(2))
-      const e2 = await TV.map(_.left('a'), double)()
+      const e2 = await TV.map(double)(_.left('a'))()
       assert.deepStrictEqual(e2, E.left('a'))
     })
 
     it('ap', async () => {
       const fab = _.left('a')
       const fa = _.left('b')
-      const e1 = await TV.ap(fab, fa)()
+      const e1 = await TV.ap(fab)(fa)()
       assert.deepStrictEqual(e1, E.left('ab'))
     })
 

--- a/test/These.ts
+++ b/test/These.ts
@@ -39,9 +39,9 @@ describe('These', () => {
 
   it('map', () => {
     const double = (n: number) => n * 2
-    assert.deepStrictEqual(_.these.map(_.left(2), double), _.left(2))
-    assert.deepStrictEqual(_.these.map(_.right(2), double), _.right(4))
-    assert.deepStrictEqual(_.these.map(_.both(1, 2), double), _.both(1, 4))
+    assert.deepStrictEqual(_.these.map(double)(_.left(2)), _.left(2))
+    assert.deepStrictEqual(_.these.map(double)(_.right(2)), _.right(4))
+    assert.deepStrictEqual(_.these.map(double)(_.both(1, 2)), _.both(1, 4))
   })
 
   it('getMonad', () => {
@@ -49,7 +49,7 @@ describe('These', () => {
     const F = _.getMonad(semigroupString)
     const fab = F.of(double)
     const fa = F.of(1)
-    assert.deepStrictEqual(F.ap(fab, fa), F.of(2))
+    assert.deepStrictEqual(F.ap(fab)(fa), F.of(2))
   })
 
   it('fold', () => {

--- a/test/Traced.ts
+++ b/test/Traced.ts
@@ -50,7 +50,7 @@ const getProjectName = (project: Project): string => project.projectName
 describe('Traced', () => {
   it('map', () => {
     const wa = buildProject('myproject')
-    assert.deepStrictEqual(traced.map(wa, getProjectName)(M.empty), 'myproject')
+    assert.deepStrictEqual(traced.map(getProjectName)(wa)(M.empty), 'myproject')
   })
 
   it('getComonad', () => {

--- a/test/Tree.ts
+++ b/test/Tree.ts
@@ -11,7 +11,7 @@ describe('Tree', () => {
     const double = (n: number): number => n * 2
     const fa = make(1, [make(2), make(3)])
     const expected = make(2, [make(4), make(6)])
-    assert.deepStrictEqual(tree.map(fa, double), expected)
+    assert.deepStrictEqual(tree.map(double)(fa), expected)
   })
 
   it('ap', () => {
@@ -19,7 +19,7 @@ describe('Tree', () => {
     const fab = tree.of(double)
     const fa = make(1, [make(2), make(3)])
     const expected = make(2, [make(4), make(6)])
-    assert.deepStrictEqual(tree.ap(fab, fa), expected)
+    assert.deepStrictEqual(tree.ap(fab)(fa), expected)
   })
 
   it('chain', () => {

--- a/test/Tuple.ts
+++ b/test/Tuple.ts
@@ -19,7 +19,7 @@ describe('Tuple', () => {
 
   it('map', () => {
     const double = (n: number): number => n * 2
-    assert.deepStrictEqual(T.tuple.map([1, 'a'], double), [2, 'a'])
+    assert.deepStrictEqual(T.tuple.map(double)([1, 'a']), [2, 'a'])
   })
 
   it('extract', () => {
@@ -80,7 +80,7 @@ describe('Tuple', () => {
   it('getApply', () => {
     const apply = T.getApply(monoidString)
     const double = (n: number): number => n * 2
-    assert.deepStrictEqual(apply.ap([double, 'a'], [1, 'b']), [2, 'ab'])
+    assert.deepStrictEqual(apply.ap([double, 'a'])([1, 'b']), [2, 'ab'])
   })
 
   it('getApplicative', () => {

--- a/test/Writer.ts
+++ b/test/Writer.ts
@@ -15,7 +15,7 @@ describe('Writer', () => {
 
   it('map', () => {
     const double = (n: number): number => n * 2
-    assert.deepStrictEqual(W.writer.map(() => [1, 'a'], double)(), [2, 'a'])
+    assert.deepStrictEqual(W.writer.map(double)(() => [1, 'a'])(), [2, 'a'])
   })
 
   it('tell', () => {
@@ -56,7 +56,7 @@ describe('Writer', () => {
     const M = W.getMonad(monoidString)
     assert.deepStrictEqual(M.of(1)(), [1, ''])
     const double = (n: number): number => n * 2
-    assert.deepStrictEqual(M.ap(M.of(double), M.of(1))(), [2, ''])
+    assert.deepStrictEqual(M.ap(M.of(double))(M.of(1))(), [2, ''])
     const f = (n: number) => M.of(n * 2)
     assert.deepStrictEqual(M.chain(M.of(1), f)(), [2, ''])
   })

--- a/test/pipeable.ts
+++ b/test/pipeable.ts
@@ -92,7 +92,7 @@ describe('pipeable', () => {
       some(2)
     ])
     assert.deepStrictEqual(
-      filterMapWithIndex((i, a: Option<number>) => option.map(a, n => n + i))([some(1), none, some(2)]),
+      filterMapWithIndex((i, a: Option<number>) => option.map((n: number) => n + i)(a))([some(1), none, some(2)]),
       [1, 4]
     )
     assert.deepStrictEqual(partitionWithIndex((i, a: Option<number>) => i > 1 && isSome(a))([some(1), none, some(2)]), {


### PR DESCRIPTION
So following https://github.com/gcanti/fp-ts/issues/925#issuecomment-523546371 this PR is a POC of a data-last `Functor`, `Apply`, `FunctorComposition` and `ApplicativeComposition` for seamless usage with `pipe`. 
Monadic data structures as well as their monad transformers now implement data-last typeclasses.

Previously (in the time of `fp-ts@0.x`) we didn't have `pipe` and `TS` couldn't infer the type of curried data-last argument. Now `pipe` allows to start the chain from that argument so that the types are correctly inferred. 

As a side effect this PR is to show that `pipeable` can be made redundant when (if) all typeclasses migrate to data-last