### PR TITLE
getOrElse returns the right value or result of orElse

### DIFF
--- a/docs/modules/Either.ts.md
+++ b/docs/modules/Either.ts.md
@@ -268,7 +268,7 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export function getOrElse<E, A>(onLeft: (e: E) => A): (ma: Either<E, A>) => A { ... }
+export function getOrElse<E, A, B = A>(onLeft: (e: E) => B): (ma: Either<E, A>) => A | B { ... }
 ```
 
 Added in v2.0.0

--- a/docs/modules/Option.ts.md
+++ b/docs/modules/Option.ts.md
@@ -493,7 +493,7 @@ Extracts the value out of the structure, if it exists. Otherwise returns the giv
 **Signature**
 
 ```ts
-export function getOrElse<A>(onNone: () => A): (ma: Option<A>) => A { ... }
+export function getOrElse<A, B = A>(onNone: () => B): (ma: Option<A>) => A | B { ... }
 ```
 
 **Example**

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -275,7 +275,7 @@ export function orElse<E, A, M>(onLeft: (e: E) => Either<M, A>): (ma: Either<E, 
 /**
  * @since 2.0.0
  */
-export function getOrElse<E, A>(onLeft: (e: E) => A): (ma: Either<E, A>) => A {
+export function getOrElse<E, A, B = A>(onLeft: (e: E) => B): (ma: Either<E, A>) => A | B {
   return ma => (isLeft(ma) ? onLeft(ma.left) : ma.right)
 }
 

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -243,7 +243,7 @@ export function toUndefined<A>(ma: Option<A>): A | undefined {
  *
  * @since 2.0.0
  */
-export function getOrElse<A>(onNone: () => A): (ma: Option<A>) => A {
+export function getOrElse<A, B = A>(onNone: () => B): (ma: Option<A>) => A | B {
   return ma => (isNone(ma) ? onNone() : ma.value)
 }
 


### PR DESCRIPTION
Minor change to `getOrElse` for `Either` and `Option` to allow the `onLeft/onNone` methods to return an alternate type