### PR TITLE
add constrained Filterable instance to IOEither, TaskEither

### DIFF
--- a/docs/modules/IOEither.ts.md
+++ b/docs/modules/IOEither.ts.md
@@ -195,7 +195,7 @@ Added in v2.0.0
 export function getFilterable<E>(M: Monoid<E>): Filterable2C<URI, E> { ... }
 ```
 
-Added in v2.0.6
+Added in v2.1.0
 
 # getIOValidation (function)
 

--- a/docs/modules/IOEither.ts.md
+++ b/docs/modules/IOEither.ts.md
@@ -26,6 +26,7 @@ error of type `E`. If you want to represent a synchronous computation that never
 - [fold (function)](#fold-function)
 - [getApplyMonoid (function)](#getapplymonoid-function)
 - [getApplySemigroup (function)](#getapplysemigroup-function)
+- [getFilterable (function)](#getfilterable-function)
 - [getIOValidation (function)](#getiovalidation-function)
 - [getOrElse (function)](#getorelse-function)
 - [getSemigroup (function)](#getsemigroup-function)
@@ -185,6 +186,16 @@ export function getApplySemigroup<E, A>(S: Semigroup<A>): Semigroup<IOEither<E, 
 ```
 
 Added in v2.0.0
+
+# getFilterable (function)
+
+**Signature**
+
+```ts
+export function getFilterable<E>(M: Monoid<E>): Filterable2C<URI, E> { ... }
+```
+
+Added in v2.0.6
 
 # getIOValidation (function)
 

--- a/docs/modules/TaskEither.ts.md
+++ b/docs/modules/TaskEither.ts.md
@@ -28,6 +28,7 @@ error of type `E`. If you want to represent an asynchronous computation that nev
 - [fold (function)](#fold-function)
 - [getApplyMonoid (function)](#getapplymonoid-function)
 - [getApplySemigroup (function)](#getapplysemigroup-function)
+- [getFilterable (function)](#getfilterable-function)
 - [getOrElse (function)](#getorelse-function)
 - [getSemigroup (function)](#getsemigroup-function)
 - [getTaskValidation (function)](#gettaskvalidation-function)
@@ -215,6 +216,16 @@ export function getApplySemigroup<E, A>(S: Semigroup<A>): Semigroup<TaskEither<E
 ```
 
 Added in v2.0.0
+
+# getFilterable (function)
+
+**Signature**
+
+```ts
+export function getFilterable<E>(M: Monoid<E>): Filterable2C<URI, E> { ... }
+```
+
+Added in v2.0.6
 
 # getOrElse (function)
 

--- a/docs/modules/TaskEither.ts.md
+++ b/docs/modules/TaskEither.ts.md
@@ -225,7 +225,7 @@ Added in v2.0.0
 export function getFilterable<E>(M: Monoid<E>): Filterable2C<URI, E> { ... }
 ```
 
-Added in v2.0.6
+Added in v2.1.0
 
 # getOrElse (function)
 

--- a/src/IOEither.ts
+++ b/src/IOEither.ts
@@ -15,6 +15,7 @@ import { Monoid } from './Monoid'
 import { pipeable } from './pipeable'
 import { Semigroup } from './Semigroup'
 import { getValidationM } from './ValidationT'
+import { Filterable2C, getFilterableComposition } from './Filterable'
 
 import Either = E.Either
 
@@ -146,6 +147,21 @@ export function getIOValidation<E>(S: Semigroup<E>): Monad2C<URI, E> & Alt2C<URI
     URI,
     _E: undefined as any,
     ...T
+  }
+}
+
+const phantom: any = undefined
+
+/**
+ * @since 2.0.6
+ */
+export function getFilterable<E>(M: Monoid<E>): Filterable2C<URI, E> {
+  const F = E.getWitherable(M)
+
+  return {
+    URI,
+    _E: phantom,
+    ...getFilterableComposition(io, F)
   }
 }
 

--- a/src/IOEither.ts
+++ b/src/IOEither.ts
@@ -153,7 +153,7 @@ export function getIOValidation<E>(S: Semigroup<E>): Monad2C<URI, E> & Alt2C<URI
 const phantom: any = undefined
 
 /**
- * @since 2.0.6
+ * @since 2.1.0
  */
 export function getFilterable<E>(M: Monoid<E>): Filterable2C<URI, E> {
   const F = E.getWitherable(M)

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -232,7 +232,7 @@ export function getTaskValidation<E>(S: Semigroup<E>): Monad2C<URI, E> & Alt2C<U
 const phantom: any = undefined
 
 /**
- * @since 2.0.6
+ * @since 2.1.0
  */
 export function getFilterable<E>(M: Monoid<E>): Filterable2C<URI, E> {
   const F = E.getWitherable(M)

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -17,6 +17,7 @@ import { pipeable } from './pipeable'
 import { Semigroup } from './Semigroup'
 import { getSemigroup as getTaskSemigroup, Task, task } from './Task'
 import { getValidationM } from './ValidationT'
+import { Filterable2C, getFilterableComposition } from './Filterable'
 
 import Either = E.Either
 
@@ -225,6 +226,21 @@ export function getTaskValidation<E>(S: Semigroup<E>): Monad2C<URI, E> & Alt2C<U
     URI,
     _E: undefined as any,
     ...T
+  }
+}
+
+const phantom: any = undefined
+
+/**
+ * @since 2.0.6
+ */
+export function getFilterable<E>(M: Monoid<E>): Filterable2C<URI, E> {
+  const F = E.getWitherable(M)
+
+  return {
+    URI,
+    _E: phantom,
+    ...getFilterableComposition(task, F)
   }
 }
 

--- a/test/IOEither.ts
+++ b/test/IOEither.ts
@@ -263,25 +263,7 @@ describe('IOEither', () => {
       ..._.ioEither,
       ..._.getFilterable(getMonoid<string>())
     }
-    const { compact, filter } = pipeable(F_)
-
-    it('compact', async () => {
-      const r1 = pipe(
-        _.right(some(1)),
-        compact
-      )
-      assert.deepStrictEqual(r1(), _.right(1)())
-      const r2 = pipe(
-        _.right(none),
-        compact
-      )
-      assert.deepStrictEqual(r2(), _.left([])())
-      const r3 = pipe(
-        _.left(['a']),
-        compact
-      )
-      assert.deepStrictEqual(r3(), _.left(['a'])())
-    })
+    const { filter } = pipeable(F_)
 
     it('filter', async () => {
       const r1 = pipe(

--- a/test/IOEither.ts
+++ b/test/IOEither.ts
@@ -5,7 +5,8 @@ import * as _ from '../src/IOEither'
 import { monoidString } from '../src/Monoid'
 import { semigroupSum, semigroupString } from '../src/Semigroup'
 import { none, some } from '../src/Option'
-import { pipe } from '../src/pipeable'
+import { pipe, pipeable } from '../src/pipeable'
+import { getMonoid } from '../src/Array'
 
 describe('IOEither', () => {
   it('fold', () => {
@@ -254,6 +255,50 @@ describe('IOEither', () => {
       assert.deepStrictEqual(e3, E.right(1))
       const e4 = IV.alt(_.left('a'), () => _.left('b'))()
       assert.deepStrictEqual(e4, E.left('ab'))
+    })
+  })
+
+  describe('getFilterable', () => {
+    const F_ = {
+      ..._.ioEither,
+      ..._.getFilterable(getMonoid<string>())
+    }
+    const { compact, filter } = pipeable(F_)
+
+    it('compact', async () => {
+      const r1 = pipe(
+        _.right(some(1)),
+        compact
+      )
+      assert.deepStrictEqual(r1(), _.right(1)())
+      const r2 = pipe(
+        _.right(none),
+        compact
+      )
+      assert.deepStrictEqual(r2(), _.left([])())
+      const r3 = pipe(
+        _.left(['a']),
+        compact
+      )
+      assert.deepStrictEqual(r3(), _.left(['a'])())
+    })
+
+    it('filter', async () => {
+      const r1 = pipe(
+        _.right(1),
+        filter(n => n > 0)
+      )
+      assert.deepStrictEqual(r1(), _.right(1)())
+      const r2 = pipe(
+        _.right(-1),
+        filter(n => n > 0)
+      )
+      assert.deepStrictEqual(r2(), _.left([])())
+      const r3 = pipe(
+        _.left(['a']),
+        filter(n => n > 0)
+      )
+      assert.deepStrictEqual(r3(), _.left(['a'])())
     })
   })
 })

--- a/test/TaskEither.ts
+++ b/test/TaskEither.ts
@@ -335,25 +335,7 @@ describe('TaskEither', () => {
       ..._.taskEither,
       ..._.getFilterable(getMonoid<string>())
     }
-    const { compact, filter } = pipeable(F_)
-
-    it('compact', async () => {
-      const r1 = pipe(
-        _.right(some(1)),
-        compact
-      )
-      assert.deepStrictEqual(await r1(), await _.right(1)())
-      const r2 = pipe(
-        _.right(none),
-        compact
-      )
-      assert.deepStrictEqual(await r2(), await _.left([])())
-      const r3 = pipe(
-        _.left(['a']),
-        compact
-      )
-      assert.deepStrictEqual(await r3(), await _.left(['a'])())
-    })
+    const { filter } = pipeable(F_)
 
     it('filter', async () => {
       const r1 = pipe(


### PR DESCRIPTION
A few doubts:
- ~I'm not sure the tests add any value (if yes, I will add them for other functions too)~ EDIT: left a single one just to obtain the necessary jest coverage
- ~I wanted to add `getFilterable` to `Either` but then stopped and just reused `getWitherable` in order to avoid duplicating part of the logic. If you feel it would add clarity, even at the cost of some duplication, I will split them~ EDIT: discussed offline with @gcanti , it should be already aligned to other similar constrained instances, where a new function has been added only if the constraint changes
