### PR TITLE
bracket behavior to return use error if both use and release fail

### DIFF
--- a/src/ReaderTaskEither.ts
+++ b/src/ReaderTaskEither.ts
@@ -205,6 +205,10 @@ export function local<Q, R>(f: (f: Q) => R): <E, A>(ma: ReaderTaskEither<R, E, A
  * release action is called regardless of whether the body action throws or
  * returns.
  *
+ * If the use action throws an error and then the release action throws an
+ * error as well, the reported error will be that of use, whereas the error
+ * thrown by release will just get logged (via console.err).
+ *
  * @since 2.0.4
  */
 export function bracket<R, E, A, B>(

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -19,6 +19,8 @@ import { getSemigroup as getTaskSemigroup, Task, task } from './Task'
 import { getValidationM } from './ValidationT'
 import { Filterable2C, getFilterableComposition } from './Filterable'
 
+import { error as logError } from './Console'
+
 import Either = E.Either
 
 const T = getEitherM(task)
@@ -148,6 +150,10 @@ export function tryCatch<E, A>(f: Lazy<Promise<A>>, onRejected: (reason: unknown
  * release action is called regardless of whether the body action throws or
  * returns.
  *
+ * If the use action throws an error and then the release action throws an
+ * error as well, the reported error will be that of use, whereas the error
+ * thrown by release will just get logged (via console.err).
+ *
  * @since 2.0.0
  */
 export function bracket<E, A, B>(
@@ -156,8 +162,16 @@ export function bracket<E, A, B>(
   release: (a: A, e: Either<E, B>) => TaskEither<E, void>
 ): TaskEither<E, B> {
   return T.chain(acquire, a =>
-    T.chain(task.map(use(a), E.right), e =>
-      T.chain(release(a, e), () => (E.isLeft(e) ? T.left(e.left) : T.of(e.right)))
+    T.chain(task.map(use(a), E.right), ue =>
+      T.chain(task.map(release(a, ue), E.right), re =>
+        E.isLeft(ue)
+          ? E.isLeft(re)
+            ? task.map(task.fromIO(logError(re.left)), () => ue)
+            : T.left(ue.left)
+          : E.isLeft(re)
+          ? T.left(re.left)
+          : T.of(ue.right)
+      )
     )
   )
 }

--- a/test/IOEither.ts
+++ b/test/IOEither.ts
@@ -194,9 +194,9 @@ describe('IOEither', () => {
       assert.deepStrictEqual(e, E.left('use failure'))
     })
 
-    it('should return the release error if both use and release fail', () => {
+    it('should return the use error if both use and release fail', () => {
       const e = _.bracket(acquireSuccess, useFailure, releaseFailure)()
-      assert.deepStrictEqual(e, E.left('release failure'))
+      assert.deepStrictEqual(e, E.left('use failure'))
     })
 
     it('release must be called if the body returns', () => {

--- a/test/ReaderTaskEither.ts
+++ b/test/ReaderTaskEither.ts
@@ -325,9 +325,9 @@ describe('ReaderTaskEither', () => {
       assert.deepStrictEqual(e, E.left('use failure'))
     })
 
-    it('should return the release error if both use and release fail', async () => {
+    it('should return the use error if both use and release fail', async () => {
       const e = await _.bracket(acquireSuccess, useFailure, releaseFailure)(undefined)()
-      assert.deepStrictEqual(e, E.left('release failure'))
+      assert.deepStrictEqual(e, E.left('use failure'))
     })
 
     it('release must be called if the body returns', async () => {

--- a/test/TaskEither.ts
+++ b/test/TaskEither.ts
@@ -64,9 +64,9 @@ describe('TaskEither', () => {
       assert.deepStrictEqual(e, E.left('use failure'))
     })
 
-    it('should return the release error if both use and release fail', async () => {
+    it('should return the use error if both use and release fail', async () => {
       const e = await _.bracket(acquireSuccess, useFailure, releaseFailure)()
-      assert.deepStrictEqual(e, E.left('release failure'))
+      assert.deepStrictEqual(e, E.left('use failure'))
     })
 
     it('release must be called if the body returns', async () => {


### PR DESCRIPTION
Follow cats-effect in `bracket` behavior. [Docs](https://typelevel.org/cats-effect/datatypes/io.html#bracket):

> if the use action throws an error and then the release action throws an error as well, the reported error will be that of use, whereas the error thrown by release will just get logged (via System.err)