### PR TITLE
Adding sequenceT and sequenceS overload signatures for Kind4, fixes #969

### DIFF
--- a/src/Apply.ts
+++ b/src/Apply.ts
@@ -86,6 +86,11 @@ function getTupleConstructor(len: number): (a: unknown) => any {
  *
  * @since 2.0.0
  */
+export function sequenceT<F extends URIS4>(
+  F: Apply4<F>
+): <S, R, E, T extends Array<Kind4<F, S, R, E, any>>>(
+  ...t: T & { 0: Kind4<F, S, R, E, any> }
+) => Kind4<F, S, R, E, { [K in keyof T]: [T[K]] extends [Kind4<F, S, R, E, infer A>] ? A : never }>
 export function sequenceT<F extends URIS3>(
   F: Apply3<F>
 ): <R, E, T extends Array<Kind3<F, R, E, any>>>(
@@ -167,6 +172,11 @@ function getRecordConstructor(keys: Array<string>) {
  *
  * @since 2.0.0
  */
+export function sequenceS<F extends URIS4>(
+  F: Apply4<F>
+): <S, R, E, NER extends Record<string, Kind4<F, S, R, E, any>>>(
+  r: EnforceNonEmptyRecord<NER> & Record<string, Kind4<F, S, R, E, any>>
+) => Kind4<F, S, R, E, { [K in keyof NER]: [NER[K]] extends [Kind4<F, any, any, any, infer A>] ? A : never }>
 export function sequenceS<F extends URIS3>(
   F: Apply3<F>
 ): <R, E, NER extends Record<string, Kind3<F, R, E, any>>>(


### PR DESCRIPTION
Without this, sequenceT and sequenceS would not work with HKT4s, such as StateReaderTaskEither:

```ts
import { StateReaderTaskEither, stateReaderTaskEither } from './../src/StateReaderTaskEither';
import { sequenceS, sequenceT } from '../src/Apply'

const foo: StateReaderTaskEither<number, {}, string, number> = stateReaderTaskEither.of(1)
const bar: StateReaderTaskEither<number, {}, string, string> = stateReaderTaskEither.of("bar")

sequenceT(stateReaderTaskEither)(foo, bar)

sequenceS(stateReaderTaskEither)({
  a: foo,
  b: bar
})
```

**Before submitting a pull request,** please make sure the following is done:

- Fork [the repository](https://github.com/gcanti/fp-ts) and create your branch from `master`.
- Run `npm install` in the repository root.
- If you've fixed a bug or added code that should be tested, add tests!
- Ensure the test suite passes (`npm test`).

**Note**. If you find a typo in the **documentation**, make sure to modify the corresponding source (docs are generated).

**Note**. If you want to send a PR related to `fp-ts@1.x` please create your branch from `1.x`
