### PR TITLE
Change `L` to `E`

### DIFF
--- a/docs/recipes/purescript.md
+++ b/docs/recipes/purescript.md
@@ -146,7 +146,7 @@ export interface Functor1<F extends URIS> {
 
 export interface Functor2<F extends URIS2> {
   readonly URI: F
-  readonly map: <E, A, B>(fa: Kind2<F, E, A>, f: (a: A) => B) => Kind2<F, L, B>
+  readonly map: <E, A, B>(fa: Kind2<F, E, A>, f: (a: A) => B) => Kind2<F, E, B>
 }
 
 export interface Functor2C<F extends URIS2, E> {


### PR DESCRIPTION
Typo in `Functor2` definition in PureScript recipes doc. This doesn't appear to be generated from source; the `L` is not in the other docs https://github.com/gcanti/fp-ts/blob/7bda18e34eed996a08afdd6a0a61025087f99593/docs/modules/Functor.ts.md#functor2-interface