### PR TITLE
stack-safe IO

### DIFF
--- a/docs/modules/IO.ts.md
+++ b/docs/modules/IO.ts.md
@@ -184,7 +184,7 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export const of = <A>(a: A): IO<A> => () => ...
+export const of = <A>(a: A): IO<A> => ...
 ```
 
 Added in v2.0.0

--- a/test/IO.ts
+++ b/test/IO.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert'
 import { IO, getSemigroup, io, getMonoid } from '../src/IO'
 import { semigroupSum } from '../src/Semigroup'
 import { monoidSum } from '../src/Monoid'
+import { array, range } from '../src/Array'
 
 describe('IO', () => {
   it('ap', () => {
@@ -31,5 +32,9 @@ describe('IO', () => {
     assert.strictEqual(M.concat(append('a'), M.empty)(), 1)
     assert.strictEqual(M.concat(M.empty, append('b'))(), 2)
     assert.deepStrictEqual(log, ['a', 'b'])
+  })
+
+  it('stack safe', () => {
+    array.sequence(io)(range(0, 20000).map(io.of))()
   })
 })

--- a/test/IOEither.ts
+++ b/test/IOEither.ts
@@ -6,7 +6,7 @@ import { monoidString } from '../src/Monoid'
 import { semigroupSum, semigroupString } from '../src/Semigroup'
 import { none, some } from '../src/Option'
 import { pipe, pipeable } from '../src/pipeable'
-import { getMonoid } from '../src/Array'
+import { getMonoid, array, range } from '../src/Array'
 
 describe('IOEither', () => {
   it('fold', () => {
@@ -282,5 +282,9 @@ describe('IOEither', () => {
       )
       assert.deepStrictEqual(r3(), _.left(['a'])())
     })
+  })
+
+  it('stack safe', () => {
+    array.sequence(_.ioEither)(range(0, 20000).map(_.ioEither.of))()
   })
 })


### PR DESCRIPTION
A porting of https://github.com/purescript/purescript-effect/pull/12 by @safareli

related to #907 

### Pros
- makes operations on `IO` stack safe (currently I get a "Maximum call stack size exceeded" error with e.g. `array.sequence(io)(range(0, 10000).map(io.of))()`)
- non-breaking / doesn't change the underlying representation of an `IO<A>` (a thunk `() => A`)
- slightly better performance on a big number of operations on `IO`

### Cons
- private / obscure implementation details, makes the code harder to read
- slightly worse performance on small number of operations on `IO`

### Notes
- I didn't spend time making the implementation better in terms of type-safety / style (not so relevant since private anyway), but it can definitely be done (e.g. using a proper discriminated union for the operation type, etc.)
- Probably we can do something similar also for `Task` (see e.g. #983)?

### Benchmarks
<details>
 <summary>"big"</summary>

```ts
import * as Benchmark from 'benchmark'
import * as IO from '../src/IO'
import * as oldIO from '../src/old-IO'
import { array, range } from '../src/Array'
const suite = new Benchmark.Suite()

// old IO x 30.75 ops/sec ±0.81% (50 runs sampled)
// IO x 32.49 ops/sec ±0.61% (53 runs sampled)
// Fastest is IO

const arr = range(1, 6000)
suite
  .add('old IO', function() {
    array.sequence(oldIO.io)(arr.map(oldIO.of))()
  })
  .add('IO', function() {
    array.sequence(IO.io)(arr.map(IO.of))()
  })
  .on('cycle', function(event: any) {
    // tslint:disable-next-line: no-console
    console.log(String(event.target))
  })
  .on('complete', function(this: any) {
    // tslint:disable-next-line: no-console
    console.log('Fastest is ' + this.filter('fastest').map('name'))
  })
  .run({ async: true })
```
</details>

<details>
 <summary>"small"</summary>

```ts
import * as Benchmark from 'benchmark'
import * as IO from '../src/IO'
import * as oldIO from '../src/old-IO'
import { array, range } from '../src/Array'
const suite = new Benchmark.Suite()

// old IO x 884,610 ops/sec ±0.82% (89 runs sampled)
// IO x 712,194 ops/sec ±0.66% (89 runs sampled)
// Fastest is old IO

const arr = range(1, 10)
suite
  .add('old IO', function() {
    array.sequence(oldIO.io)(arr.map(oldIO.of))()
  })
  .add('IO', function() {
    array.sequence(IO.io)(arr.map(IO.of))()
  })
  .on('cycle', function(event: any) {
    // tslint:disable-next-line: no-console
    console.log(String(event.target))
  })
  .on('complete', function(this: any) {
    // tslint:disable-next-line: no-console
    console.log('Fastest is ' + this.filter('fastest').map('name'))
  })
  .run({ async: true })
```
</details>

### Opinions?