### PR TITLE
bug(TaskEither): adding try/catch safety to TaskEither.tryCatch

### DIFF
--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -140,7 +140,13 @@ export function getApplyMonoid<E, A>(M: Monoid<A>): Monoid<TaskEither<E, A>> {
  * @since 2.0.0
  */
 export function tryCatch<E, A>(f: Lazy<Promise<A>>, onRejected: (reason: unknown) => E): TaskEither<E, A> {
-  return () => f().then(a => E.right(a), reason => E.left(onRejected(reason)))
+  return () => {
+    try {
+      return f().then(a => E.right(a), reason => E.left(onRejected(reason)))
+    } catch (e) {
+      return Promise.resolve(E.left(onRejected(e)))
+    }
+  }
 }
 
 /**

--- a/test/TaskEither.ts
+++ b/test/TaskEither.ts
@@ -121,13 +121,6 @@ describe('TaskEither', () => {
     assert.deepStrictEqual(e, E.left(1))
   })
 
-  it('tryCatch', async () => {
-    const e1 = await _.tryCatch(() => Promise.resolve(1), () => 'error')()
-    assert.deepStrictEqual(e1, E.right(1))
-    const e2 = await _.tryCatch(() => Promise.reject(undefined), () => 'error')()
-    assert.deepStrictEqual(e2, E.left('error'))
-  })
-
   it('taskify', async () => {
     const api1 = (_path: string, callback: (err: Error | null | undefined, result?: string) => void): void => {
       callback(null, 'ok')
@@ -278,6 +271,8 @@ describe('TaskEither', () => {
     assert.deepStrictEqual(e1, E.right(1))
     const e2 = await _.tryCatch(() => Promise.reject('ouch!'), onrejected)()
     assert.deepStrictEqual(e2, E.left('Error is: ouch!'))
+    const e3 = await _.tryCatch(() => (null as any).errory, onrejected)()
+    assert.deepStrictEqual(e3, E.left("Error is: TypeError: Cannot read property 'errory' of null"))
   })
 
   it('fromOption', async () => {


### PR DESCRIPTION
`TaskEither.tryCatch` only handles promise failures, if the predicate fails it does so silently. This is inline with `Option/IOEither/Either.tryCatch`.