### PR TITLE
add ReaderM2C

### DIFF
--- a/docs/modules/ReaderT.ts.md
+++ b/docs/modules/ReaderT.ts.md
@@ -11,6 +11,7 @@ parent: Modules
 - [ReaderM (interface)](#readerm-interface)
 - [ReaderM1 (interface)](#readerm1-interface)
 - [ReaderM2 (interface)](#readerm2-interface)
+- [ReaderM2C (interface)](#readerm2c-interface)
 - [ReaderM3 (interface)](#readerm3-interface)
 - [ReaderT (interface)](#readert-interface)
 - [ReaderT1 (interface)](#readert1-interface)
@@ -79,6 +80,26 @@ export interface ReaderM2<M extends URIS2> {
 ```
 
 Added in v2.0.0
+
+# ReaderM2C (interface)
+
+**Signature**
+
+```ts
+export interface ReaderM2C<M extends URIS2, E> {
+  readonly map: <R, A, B>(ma: ReaderT2<M, R, E, A>, f: (a: A) => B) => ReaderT2<M, R, E, B>
+  readonly of: <R, A>(a: A) => ReaderT2<M, R, E, A>
+  readonly ap: <R, A, B>(mab: ReaderT2<M, R, E, (a: A) => B>, ma: ReaderT2<M, R, E, A>) => ReaderT2<M, R, E, B>
+  readonly chain: <R, A, B>(ma: ReaderT2<M, R, E, A>, f: (a: A) => ReaderT2<M, R, E, B>) => ReaderT2<M, R, E, B>
+  readonly ask: <R>() => ReaderT2<M, R, E, R>
+  readonly asks: <R, A>(f: (r: R) => A) => ReaderT2<M, R, E, A>
+  readonly local: <R, A, Q>(ma: ReaderT2<M, R, E, A>, f: (d: Q) => R) => ReaderT2<M, Q, E, A>
+  readonly fromReader: <R, A>(ma: Reader<R, A>) => ReaderT2<M, R, E, A>
+  readonly fromM: <R, A>(ma: Kind2<M, E, A>) => ReaderT2<M, R, E, A>
+}
+```
+
+Added in v2.2.0
 
 # ReaderM3 (interface)
 
@@ -161,6 +182,7 @@ Added in v2.0.0
 ```ts
 export function getReaderM<M extends URIS3>(M: Monad3<M>): ReaderM3<M>
 export function getReaderM<M extends URIS2>(M: Monad2<M>): ReaderM2<M>
+export function getReaderM<M extends URIS2, E>(M: Monad2C<M, E>): ReaderM2C<M, E>
 export function getReaderM<M extends URIS>(M: Monad1<M>): ReaderM1<M>
 export function getReaderM<M>(M: Monad<M>): ReaderM<M> { ... }
 ```

--- a/docs/modules/boolean.ts.md
+++ b/docs/modules/boolean.ts.md
@@ -34,7 +34,12 @@ import { fold } from 'fp-ts/lib/boolean'
 assert.deepStrictEqual(
   pipe(
     some(true),
-    map(fold(() => 'false', () => 'true'))
+    map(
+      fold(
+        () => 'false',
+        () => 'true'
+      )
+    )
   ),
   some('true')
 )

--- a/src/ReaderT.ts
+++ b/src/ReaderT.ts
@@ -1,5 +1,5 @@
 import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3 } from './HKT'
-import { Monad, Monad1, Monad2, Monad3 } from './Monad'
+import { Monad, Monad1, Monad2, Monad2C, Monad3 } from './Monad'
 import { Reader } from './Reader'
 
 /**
@@ -69,6 +69,21 @@ export interface ReaderM2<M extends URIS2> {
 }
 
 /**
+ * @since 2.2.0
+ */
+export interface ReaderM2C<M extends URIS2, E> {
+  readonly map: <R, A, B>(ma: ReaderT2<M, R, E, A>, f: (a: A) => B) => ReaderT2<M, R, E, B>
+  readonly of: <R, A>(a: A) => ReaderT2<M, R, E, A>
+  readonly ap: <R, A, B>(mab: ReaderT2<M, R, E, (a: A) => B>, ma: ReaderT2<M, R, E, A>) => ReaderT2<M, R, E, B>
+  readonly chain: <R, A, B>(ma: ReaderT2<M, R, E, A>, f: (a: A) => ReaderT2<M, R, E, B>) => ReaderT2<M, R, E, B>
+  readonly ask: <R>() => ReaderT2<M, R, E, R>
+  readonly asks: <R, A>(f: (r: R) => A) => ReaderT2<M, R, E, A>
+  readonly local: <R, A, Q>(ma: ReaderT2<M, R, E, A>, f: (d: Q) => R) => ReaderT2<M, Q, E, A>
+  readonly fromReader: <R, A>(ma: Reader<R, A>) => ReaderT2<M, R, E, A>
+  readonly fromM: <R, A>(ma: Kind2<M, E, A>) => ReaderT2<M, R, E, A>
+}
+
+/**
  * @since 2.0.0
  */
 export interface ReaderT3<M extends URIS3, R, U, E, A> {
@@ -101,6 +116,7 @@ export interface ReaderM3<M extends URIS3> {
  */
 export function getReaderM<M extends URIS3>(M: Monad3<M>): ReaderM3<M>
 export function getReaderM<M extends URIS2>(M: Monad2<M>): ReaderM2<M>
+export function getReaderM<M extends URIS2, E>(M: Monad2C<M, E>): ReaderM2C<M, E>
 export function getReaderM<M extends URIS>(M: Monad1<M>): ReaderM1<M>
 export function getReaderM<M>(M: Monad<M>): ReaderM<M>
 export function getReaderM<M>(M: Monad<M>): ReaderM<M> {


### PR DESCRIPTION
This PR allows to define `ReaderThese` using `getReaderM` as helper

```ts
import { getMonoid } from 'fp-ts/lib/Array'
import { getReaderM } from 'fp-ts/lib/ReaderT'
import { getMonad } from 'fp-ts/lib/These'

const monadThese = getMonad(getMonoid<string>())
export const M = getReaderM(monadThese) // <= this errored out
```
