### PR TITLE
Add `getMonoid` for Ord

### DIFF
--- a/src/Ord.ts
+++ b/src/Ord.ts
@@ -16,6 +16,7 @@ import { Semigroup } from './Semigroup'
 import { Eq } from './Eq'
 import { Contravariant1 } from './Contravariant'
 import { pipeable } from './pipeable'
+import { Monoid } from './Monoid'
 
 declare module './HKT' {
   interface URItoKind<A> {
@@ -223,6 +224,16 @@ export function fromCompare<A>(compare: (x: A, y: A) => Ordering): Ord<A> {
 export function getSemigroup<A = never>(): Semigroup<Ord<A>> {
   return {
     concat: (x, y) => fromCompare((a, b) => semigroupOrdering.concat(x.compare(a, b), y.compare(a, b)))
+  }
+}
+
+/**
+ * @since 2.3.1
+ */
+export function getMonoid<A>(): Monoid<Ord<A>> {
+  return {
+    empty: fromCompare((a1, a2) => 0),
+    concat: getSemigroup<A>().concat
   }
 }
 

--- a/src/Ord.ts
+++ b/src/Ord.ts
@@ -227,12 +227,14 @@ export function getSemigroup<A = never>(): Semigroup<Ord<A>> {
   }
 }
 
+const empty = fromCompare(() => 0)
+
 /**
- * @since 2.3.1
+ * @since 2.4.0
  */
-export function getMonoid<A>(): Monoid<Ord<A>> {
+export function getMonoid<A = never>(): Monoid<Ord<A>> {
   return {
-    empty: fromCompare((a1, a2) => 0),
+    empty,
     concat: getSemigroup<A>().concat
   }
 }

--- a/test/Ord.ts
+++ b/test/Ord.ts
@@ -6,6 +6,7 @@ import {
   clamp,
   getDualOrd,
   getSemigroup,
+  getMonoid,
   ordDate,
   ordNumber,
   ordString,
@@ -15,6 +16,7 @@ import {
   getTupleOrd,
   ordBoolean
 } from '../src/Ord'
+import { fold } from '../src/Monoid'
 
 describe('Ord', () => {
   it('getTupleOrd', () => {
@@ -49,6 +51,33 @@ describe('Ord', () => {
       [1, 'c'],
       [2, 'c']
     ])
+  })
+
+  it('getMonoid', () => {
+    interface Person {
+      name: string
+      age: number
+    }
+    const people: Person[] = [
+      { name: 'John', age: 42 },
+      { name: 'Dorothy', age: 37 },
+      { name: 'John', age: 37 }
+    ]
+
+    const sortByName = ord.contramap(ordString, (p: Person) => p.name)
+    const sortByAge = ord.contramap(ordNumber, (p: Person) => p.age)
+
+    const monoid = getMonoid<Person>()
+    const sortByNameByAge = fold(monoid)([sortByName, sortByAge])
+    const dontSort = fold(monoid)([])
+
+    assert.deepStrictEqual(sort(sortByNameByAge)(people), [
+      { name: 'Dorothy', age: 37 },
+      { name: 'John', age: 37 },
+      { name: 'John', age: 42 }
+    ])
+
+    assert.deepStrictEqual(sort(dontSort)(people), people)
   })
 
   it('ordNumber', () => {


### PR DESCRIPTION
Following https://github.com/gcanti/fp-ts/pull/1046, I think it would be semantically consistent to add a `Monoid<Ord>` instance, with `empty` returning an `Ord` instance which always considers compared elements equal (Js now guarantees to not to change order of elements in such a case - "no sorting applied" - sorting in js is now guaranteed to be stable). Besides consistency with `sortBy` implementation which can now take empty array of ords as input (and then performs "no sorting at all" - data remains untouched) it honestly... makes `sortBy` unnecessary (because we can now always build a specific `Ord` first, using `fold`), which leaves us with nice, terse and consistent interface for sorting, made of one function only - `sort` itself.
