### PR TITLE
add runState to State and StateReaderTaskEither

### DIFF
--- a/docs/modules/State.ts.md
+++ b/docs/modules/State.ts.md
@@ -27,6 +27,7 @@ Added in v2.0.0
 - [modify (constant)](#modify-constant)
 - [of (constant)](#of-constant)
 - [put (constant)](#put-constant)
+- [runState (constant)](#runstate-constant)
 - [state (constant)](#state-constant)
 - [ap (export)](#ap-export)
 - [apFirst (export)](#apfirst-export)
@@ -151,6 +152,18 @@ export const put: <S>(s: S) => State<S, void> = ...
 ```
 
 Added in v2.0.0
+
+# runState (constant)
+
+Run a computation in the `State` monad, returning a tuple of final state and result
+
+**Signature**
+
+```ts
+export const runState: <S, A>(ma: State<S, A>, s: S) => [A, S] = ...
+```
+
+Added in v2.4.0
 
 # state (constant)
 

--- a/docs/modules/StateReaderTaskEither.ts.md
+++ b/docs/modules/StateReaderTaskEither.ts.md
@@ -24,6 +24,7 @@ Added in v2.0.0
 - [put (constant)](#put-constant)
 - [right (constant)](#right-constant)
 - [rightState (constant)](#rightstate-constant)
+- [runState (constant)](#runstate-constant)
 - [stateReaderTaskEither (constant)](#statereadertaskeither-constant)
 - [stateReaderTaskEitherSeq (constant)](#statereadertaskeitherseq-constant)
 - [chainEither (function)](#chaineither-function)
@@ -187,6 +188,18 @@ export const rightState: <S, R, E = ...
 ```
 
 Added in v2.0.0
+
+# runState (constant)
+
+Run a computation in the `StateReaderTaskEither` monad, retaining a tuple final state and result
+
+**Signature**
+
+```ts
+export const : <S, R, E, A>(ma: StateReaderTaskEither<S, R, E, A>, s: S) => RTE.ReaderTaskEither<R, E, [A, S]> = ...
+```
+
+Added in v2.4.0
 
 # stateReaderTaskEither (constant)
 

--- a/docs/modules/StateT.ts.md
+++ b/docs/modules/StateT.ts.md
@@ -40,6 +40,7 @@ export interface StateM<M> {
   readonly gets: <S, A>(f: (s: S) => A) => StateT<M, S, A>
   readonly fromState: <S, A>(fa: State<S, A>) => StateT<M, S, A>
   readonly fromM: <S, A>(ma: HKT<M, A>) => StateT<M, S, A>
+  readonly runState: <S, A>(ma: StateT<M, S, A>, s: S) => HKT<M, [A, S]>
   readonly evalState: <S, A>(ma: StateT<M, S, A>, s: S) => HKT<M, A>
   readonly execState: <S, A>(ma: StateT<M, S, A>, s: S) => HKT<M, S>
 }
@@ -63,6 +64,7 @@ export interface StateM1<M extends URIS> {
   readonly gets: <S, A>(f: (s: S) => A) => StateT1<M, S, A>
   readonly fromState: <S, A>(fa: State<S, A>) => StateT1<M, S, A>
   readonly fromM: <S, A>(ma: Kind<M, A>) => StateT1<M, S, A>
+  readonly runState: <S, A>(ma: StateT1<M, S, A>, s: S) => Kind<M, [A, S]>
   readonly evalState: <S, A>(ma: StateT1<M, S, A>, s: S) => Kind<M, A>
   readonly execState: <S, A>(ma: StateT1<M, S, A>, s: S) => Kind<M, S>
 }
@@ -86,6 +88,7 @@ export interface StateM2<M extends URIS2> {
   readonly gets: <S, E, A>(f: (s: S) => A) => StateT2<M, S, E, A>
   readonly fromState: <S, E, A>(fa: State<S, A>) => StateT2<M, S, E, A>
   readonly fromM: <S, E, A>(ma: Kind2<M, E, A>) => StateT2<M, S, E, A>
+  readonly runState: <S, E, A>(ma: StateT2<M, S, E, A>, s: S) => Kind2<M, E, [A, S]>
   readonly evalState: <S, E, A>(ma: StateT2<M, S, E, A>, s: S) => Kind2<M, E, A>
   readonly execState: <S, E, A>(ma: StateT2<M, S, E, A>, s: S) => Kind2<M, E, S>
 }
@@ -115,6 +118,7 @@ export interface StateM3<M extends URIS3> {
   readonly gets: <S, R, E, A>(f: (s: S) => A) => StateT3<M, S, R, E, A>
   readonly fromState: <S, R, E, A>(fa: State<S, A>) => StateT3<M, S, R, E, A>
   readonly fromM: <S, R, E, A>(ma: Kind3<M, R, E, A>) => StateT3<M, S, R, E, A>
+  readonly runState: <S, R, E, A>(ma: StateT3<M, S, R, E, A>, s: S) => Kind3<M, R, E, [A, S]>
   readonly evalState: <S, R, E, A>(ma: StateT3<M, S, R, E, A>, s: S) => Kind3<M, R, E, A>
   readonly execState: <S, R, E, A>(ma: StateT3<M, S, R, E, A>, s: S) => Kind3<M, R, E, S>
 }

--- a/src/State.ts
+++ b/src/State.ts
@@ -37,6 +37,13 @@ export interface State<S, A> {
 }
 
 /**
+ * Run a computation in the `State` monad, returning a tuple of final state and result
+ *
+ * @since 2.4.0
+ */
+export const runState: <S, A>(ma: State<S, A>, s: S) => [A, S] = T.runState
+
+/**
  * Run a computation in the `State` monad, discarding the final state
  *
  * @since 2.0.0

--- a/src/StateReaderTaskEither.ts
+++ b/src/StateReaderTaskEither.ts
@@ -50,6 +50,14 @@ export function run<S, R, E, A>(ma: StateReaderTaskEither<S, R, E, A>, s: S, r: 
 }
 
 /**
+ * Run a computation in the `StateReaderTaskEither` monad, retaining a tuple final state and result
+ *
+ * @since 2.4.0
+ */
+export const runState: <S, R, E, A>(ma: StateReaderTaskEither<S, R, E, A>, s: S) => ReaderTaskEither<R, E, [A, S]> =
+  T.runState
+
+/**
  * Run a computation in the `StateReaderTaskEither` monad, discarding the final state
  *
  * @since 2.0.0

--- a/src/StateT.ts
+++ b/src/StateT.ts
@@ -26,6 +26,7 @@ export interface StateM<M> {
   readonly gets: <S, A>(f: (s: S) => A) => StateT<M, S, A>
   readonly fromState: <S, A>(fa: State<S, A>) => StateT<M, S, A>
   readonly fromM: <S, A>(ma: HKT<M, A>) => StateT<M, S, A>
+  readonly runState: <S, A>(ma: StateT<M, S, A>, s: S) => HKT<M, [A, S]>
   readonly evalState: <S, A>(ma: StateT<M, S, A>, s: S) => HKT<M, A>
   readonly execState: <S, A>(ma: StateT<M, S, A>, s: S) => HKT<M, S>
 }
@@ -51,6 +52,7 @@ export interface StateM1<M extends URIS> {
   readonly gets: <S, A>(f: (s: S) => A) => StateT1<M, S, A>
   readonly fromState: <S, A>(fa: State<S, A>) => StateT1<M, S, A>
   readonly fromM: <S, A>(ma: Kind<M, A>) => StateT1<M, S, A>
+  readonly runState: <S, A>(ma: StateT1<M, S, A>, s: S) => Kind<M, [A, S]>
   readonly evalState: <S, A>(ma: StateT1<M, S, A>, s: S) => Kind<M, A>
   readonly execState: <S, A>(ma: StateT1<M, S, A>, s: S) => Kind<M, S>
 }
@@ -76,6 +78,7 @@ export interface StateM2<M extends URIS2> {
   readonly gets: <S, E, A>(f: (s: S) => A) => StateT2<M, S, E, A>
   readonly fromState: <S, E, A>(fa: State<S, A>) => StateT2<M, S, E, A>
   readonly fromM: <S, E, A>(ma: Kind2<M, E, A>) => StateT2<M, S, E, A>
+  readonly runState: <S, E, A>(ma: StateT2<M, S, E, A>, s: S) => Kind2<M, E, [A, S]>
   readonly evalState: <S, E, A>(ma: StateT2<M, S, E, A>, s: S) => Kind2<M, E, A>
   readonly execState: <S, E, A>(ma: StateT2<M, S, E, A>, s: S) => Kind2<M, E, S>
 }
@@ -107,6 +110,7 @@ export interface StateM3<M extends URIS3> {
   readonly gets: <S, R, E, A>(f: (s: S) => A) => StateT3<M, S, R, E, A>
   readonly fromState: <S, R, E, A>(fa: State<S, A>) => StateT3<M, S, R, E, A>
   readonly fromM: <S, R, E, A>(ma: Kind3<M, R, E, A>) => StateT3<M, S, R, E, A>
+  readonly runState: <S, R, E, A>(ma: StateT3<M, S, R, E, A>, s: S) => Kind3<M, R, E, [A, S]>
   readonly evalState: <S, R, E, A>(ma: StateT3<M, S, R, E, A>, s: S) => Kind3<M, R, E, A>
   readonly execState: <S, R, E, A>(ma: StateT3<M, S, R, E, A>, s: S) => Kind3<M, R, E, S>
 }
@@ -130,6 +134,7 @@ export function getStateM<M>(M: Monad<M>): StateM<M> {
     gets: f => s => M.of([f(s), s]),
     fromState: sa => s => M.of(sa(s)),
     fromM: ma => s => M.map(ma, a => [a, s]),
+    runState: (ma, s) => M.map(ma(s), ([a, s]) => [a, s]),
     evalState: (ma, s) => M.map(ma(s), ([a]) => a),
     execState: (ma, s) => M.map(ma(s), ([_, s]) => s)
   }

--- a/test/State.ts
+++ b/test/State.ts
@@ -3,6 +3,10 @@ import * as S from '../src/State'
 import { tuple } from '../src/function'
 
 describe('State', () => {
+  it('run', () => {
+    assert.deepStrictEqual(S.runState(S.state.of<number, string>('a'), 0), ['a', 0])
+  })
+
   it('eval', () => {
     assert.deepStrictEqual(S.evalState(S.state.of<number, string>('a'), 0), 'a')
   })

--- a/test/StateReaderTaskEither.ts
+++ b/test/StateReaderTaskEither.ts
@@ -51,6 +51,13 @@ describe('StateReaderTaskEither', () => {
     })
   })
 
+  it('runState', async () => {
+    const ma = _.right('aaa')
+    const s = {}
+    const e = await RTE.run(_.runState(ma, s), {})
+    assert.deepStrictEqual(e, E.right(['aaa', {}]))
+  })
+
   it('execState', async () => {
     const ma = _.right('aaa')
     const s = {}


### PR DESCRIPTION
Add `runState` function to State monad.

This is something I was hoping to use after my experience with Crocks which has the same function:
https://crocks.dev/docs/crocks/State.html#runwith

Maybe this is overcomplicated and I can just use `M.map(ma(s), ...)` directly, given the implementation of `eval/exec`?
```
    evalState: (ma, s) => M.map(ma(s), ([a]) => a),
    execState: (ma, s) => M.map(ma(s), ([_, s]) => s)
```

This should match the Haskell state monad equivalent, looking at
https://en.wikibooks.org/wiki/Haskell/Understanding_monads/State#Getting_Values_and_State
http://hackage.haskell.org/package/mtl-2.2.2/docs/Control-Monad-State-Lazy.html#v:runState

where it looks like `evalState` and `execState` are implemented using `runState`:
```
evalState :: State s a -> s -> a
evalState p s = fst (runState p s)

execState :: State s a -> s -> s
execState p s = snd (runState p s)
```
