### PR TITLE
NonEmptyArray#groupBy: Allow passing a union of keys to narrow the record type

### DIFF
--- a/src/NonEmptyArray.ts
+++ b/src/NonEmptyArray.ts
@@ -214,9 +214,9 @@ export function groupSort<A>(O: Ord<A>): (as: Array<A>) => Array<NonEmptyArray<A
  *
  * @since 2.0.0
  */
-export function groupBy<A>(f: (a: A) => string): (as: Array<A>) => Record<string, NonEmptyArray<A>> {
+export function groupBy<A, B extends string | number | symbol>(f: (a: A) => B): (as: Array<A>) => Record<B, NonEmptyArray<A>> {
   return as => {
-    const r: Record<string, NonEmptyArray<A>> = {}
+    const r = {} as Record<B, NonEmptyArray<A>>
     for (const a of as) {
       const k = f(a)
       if (r.hasOwnProperty(k)) {


### PR DESCRIPTION
I was wondering how would anyone feel about this change.
I was trying to narrow down the type of Record `groupBy` returns and by default `Record<string, NonEmptyArray<A>>` would always let reference any key and TS would never complain.

```ts
const r: Record<string, string> = {
  foo: "bar"
};

r.foo // ✅
r.bar // ✅TS is happy with this

```
Giving a way of passing a generic `B` we can force the compiler to narrow down to a list of possible keys the record has.

```ts
const list = [{fruit: "banana"}, {fruit: "apple"}]
const record = groupBy<{fruit: string}, "yellow" | "red">(item => item.fruit === "banana" ? "yellow" : "red")(list)

record.yellow // ✅
record.red // ✅
record.orange // ❌
```

The inference isn't so bad when we don't pass the generics specifically, the record would be inferred in that case. 

```ts
type Item = {fruit: string};
const list: Item[] = [{fruit: "banana"}];

pipe(
  list,
  groupBy(item => item.fruit === "banana" ? "yellow" : "red")
)
```

The only issue I see right now is if the function conditionally produces keys, the conditions might never be met which would result in an object at runtime that doesn't have all the keys that were expected but it's already the case with the current types. Maybe in that case, the record type might not be the most appropriate? Let me know what you think.