### PR TITLE
Add tryCatchK in TaskEither module

### DIFF
--- a/docs/modules/TaskEither.ts.md
+++ b/docs/modules/TaskEither.ts.md
@@ -57,6 +57,7 @@ Added in v2.0.0
 - [taskEitherSeq](#taskeitherseq)
 - [taskify](#taskify)
 - [tryCatch](#trycatch)
+- [tryCatchK](#trycatchk)
 
 ---
 
@@ -559,3 +560,18 @@ tryCatch(() => Promise.reject('error'), String)().then(result => {
 ```
 
 Added in v2.0.0
+
+# tryCatchK
+
+Converts a function returning a `Promise` to one returning a `TaskEither`.
+
+**Signature**
+
+```ts
+export function tryCatchK<E, A extends Array<unknown>, B>(
+  f: (...a: A) => Promise<B>,
+  onRejected: (reason: unknown) => E
+): (...a: A) => TaskEither<E, B> { ... }
+```
+
+Added in v2.5.0

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -299,6 +299,18 @@ export function chainIOEitherK<E, A, B>(f: (a: A) => IOEither<E, B>): (ma: TaskE
 }
 
 /**
+ * Converts a function returning a `Promise` to one returning a `TaskEither`.
+ *
+ * @since 2.5.0
+ */
+export function tryCatchK<E, A extends Array<unknown>, B>(
+  f: (...a: A) => Promise<B>,
+  onRejected: (reason: unknown) => E
+): (...a: A) => TaskEither<E, B> {
+  return (...a) => tryCatch(() => f(...a), onRejected)
+}
+
+/**
  * @since 2.0.0
  */
 export const taskEither: Monad2<URI> & Bifunctor2<URI> & Alt2<URI> & MonadTask2<URI> & MonadThrow2<URI> = {

--- a/test/TaskEither.ts
+++ b/test/TaskEither.ts
@@ -375,4 +375,18 @@ describe('TaskEither', () => {
     const x = await pipe(_.right('a'), _.chainIOEitherK(f))()
     assert.deepStrictEqual(x, E.right(1))
   })
+
+  describe('tryCatchK', () => {
+    const handleRejection = () => 'rejected'
+
+    it('resolving', () => {
+      const fOk = (n: number, s: string) => Promise.resolve(n + s.length)
+      return _.tryCatchK(fOk, handleRejection)(2, '1')().then(x => assert.deepStrictEqual(x, E.right(3)))
+    })
+
+    it('rejecting', () => {
+      const fReject = () => Promise.reject()
+      return _.tryCatchK(fReject, handleRejection)()().then(x => assert.deepStrictEqual(x, E.left('rejected')))
+    })
+  })
 })


### PR DESCRIPTION
This PR adds `tryCatchK`, which converts a function returning a `Promise` to one returning a `TaskEither`.
