### PR TITLE
MonadTask4 added

### DIFF
--- a/docs/modules/MonadIO.ts.md
+++ b/docs/modules/MonadIO.ts.md
@@ -20,6 +20,7 @@ Added in v2.0.0
 - [MonadIO2C (interface)](#monadio2c-interface)
 - [MonadIO3 (interface)](#monadio3-interface)
 - [MonadIO3C (interface)](#monadio3c-interface)
+- [MonadIO4 (interface)](#monadio4-interface)
 
 ---
 
@@ -94,3 +95,15 @@ export interface MonadIO3C<M extends URIS3, E> extends Monad3C<M, E> {
 ```
 
 Added in v2.2.0
+
+# MonadIO4 (interface)
+
+**Signature**
+
+```ts
+export interface MonadIO4<M extends URIS4> extends Monad4<M> {
+  readonly fromIO: <S, R, E, A>(fa: IO<A>) => Kind4<M, S, R, E, A>
+}
+```
+
+Added in v2.4.4

--- a/docs/modules/MonadTask.ts.md
+++ b/docs/modules/MonadTask.ts.md
@@ -20,6 +20,7 @@ Added in v2.0.0
 - [MonadTask2C (interface)](#monadtask2c-interface)
 - [MonadTask3 (interface)](#monadtask3-interface)
 - [MonadTask3C (interface)](#monadtask3c-interface)
+- [MonadTask4 (interface)](#monadtask4-interface)
 
 ---
 
@@ -94,3 +95,15 @@ export interface MonadTask3C<M extends URIS3, E> extends MonadIO3C<M, E> {
 ```
 
 Added in v2.2.0
+
+# MonadTask4 (interface)
+
+**Signature**
+
+```ts
+export interface MonadTask4<M extends URIS4> extends MonadIO4<M> {
+  readonly fromTask: <S, R, E, A>(fa: Task<A>) => Kind4<M, S, R, E, A>
+}
+```
+
+Added in v2.4.4

--- a/docs/modules/StateReaderTaskEither.ts.md
+++ b/docs/modules/StateReaderTaskEither.ts.md
@@ -26,12 +26,14 @@ Added in v2.0.0
 - [chainTaskEitherK](#chaintaskeitherk)
 - [evalState](#evalstate)
 - [execState](#execstate)
+- [filterOrElse](#filterorelse)
 - [flatten](#flatten)
 - [fromEither](#fromeither)
 - [fromEitherK](#fromeitherk)
 - [fromIOEither](#fromioeither)
 - [fromIOEitherK](#fromioeitherk)
 - [fromOption](#fromoption)
+- [fromPredicate](#frompredicate)
 - [fromReaderEither](#fromreadereither)
 - [fromReaderTaskEither](#fromreadertaskeither)
 - [fromReaderTaskEitherK](#fromreadertaskeitherk)
@@ -212,6 +214,16 @@ export const : <S, R, E, A>(ma: StateReaderTaskEither<S, R, E, A>, s: S) => RTE.
 
 Added in v2.0.0
 
+# filterOrElse
+
+**Signature**
+
+```ts
+{ <E, A, B>(refinement: Refinement<A, B>, onFalse: (a: A) => E): <S, R>(ma: StateReaderTaskEither<S, R, E, A>) => StateReaderTaskEither<S, R, E, B>; <E, A>(predicate: Predicate<A>, onFalse: (a: A) => E): <S, R>(ma: StateReaderTaskEither<S, R, E, A>) => StateReaderTaskEither<S, R, E, A>; }
+```
+
+Added in v2.4.4
+
 # flatten
 
 **Signature**
@@ -275,6 +287,16 @@ Added in v2.4.0
 ```
 
 Added in v2.0.0
+
+# fromPredicate
+
+**Signature**
+
+```ts
+{ <E, A, B>(refinement: Refinement<A, B>, onFalse: (a: A) => E): <S, R>(a: A) => StateReaderTaskEither<S, R, E, B>; <E, A>(predicate: Predicate<A>, onFalse: (a: A) => E): <S, R>(a: A) => StateReaderTaskEither<S, R, E, A>; }
+```
+
+Added in v2.4.4
 
 # fromReaderEither
 
@@ -503,7 +525,7 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export const stateReaderTaskEither: Monad4<URI> & MonadThrow4<URI> = ...
+export const stateReaderTaskEither: Monad4<URI> & MonadThrow4<URI> & MonadTask4<URI> = ...
 ```
 
 Added in v2.0.0

--- a/src/MonadIO.ts
+++ b/src/MonadIO.ts
@@ -3,9 +3,9 @@
  *
  * @since 2.0.0
  */
-import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3 } from './HKT'
+import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3, URIS4, Kind4 } from './HKT'
 import { IO } from './IO'
-import { Monad, Monad1, Monad2, Monad3, Monad2C, Monad3C } from './Monad'
+import { Monad, Monad1, Monad2, Monad3, Monad2C, Monad3C, Monad4 } from './Monad'
 
 /**
  * @since 2.0.0
@@ -47,4 +47,11 @@ export interface MonadIO3<M extends URIS3> extends Monad3<M> {
  */
 export interface MonadIO3C<M extends URIS3, E> extends Monad3C<M, E> {
   readonly fromIO: <R, A>(fa: IO<A>) => Kind3<M, R, E, A>
+}
+
+/**
+ * @since 2.4.4
+ */
+export interface MonadIO4<M extends URIS4> extends Monad4<M> {
+  readonly fromIO: <S, R, E, A>(fa: IO<A>) => Kind4<M, S, R, E, A>
 }

--- a/src/MonadTask.ts
+++ b/src/MonadTask.ts
@@ -3,8 +3,8 @@
  *
  * @since 2.0.0
  */
-import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3 } from './HKT'
-import { MonadIO, MonadIO1, MonadIO2, MonadIO2C, MonadIO3, MonadIO3C } from './MonadIO'
+import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3, URIS4, Kind4 } from './HKT'
+import { MonadIO, MonadIO1, MonadIO2, MonadIO2C, MonadIO3, MonadIO3C, MonadIO4 } from './MonadIO'
 import { Task } from './Task'
 
 /**
@@ -47,4 +47,11 @@ export interface MonadTask3<M extends URIS3> extends MonadIO3<M> {
  */
 export interface MonadTask3C<M extends URIS3, E> extends MonadIO3C<M, E> {
   readonly fromTask: <R, A>(fa: Task<A>) => Kind3<M, R, E, A>
+}
+
+/**
+ * @since 2.4.4
+ */
+export interface MonadTask4<M extends URIS4> extends MonadIO4<M> {
+  readonly fromTask: <S, R, E, A>(fa: Task<A>) => Kind4<M, S, R, E, A>
 }

--- a/src/StateReaderTaskEither.ts
+++ b/src/StateReaderTaskEither.ts
@@ -16,6 +16,7 @@ import { TaskEither } from './TaskEither'
 
 import ReaderTaskEither = RTE.ReaderTaskEither
 import { MonadThrow4 } from './MonadThrow'
+import { MonadTask4 } from './MonadTask'
 
 const T = getStateM(RTE.readerTaskEither)
 
@@ -262,12 +263,14 @@ export function chainReaderTaskEitherK<R, E, A, B>(
 /**
  * @since 2.0.0
  */
-export const stateReaderTaskEither: Monad4<URI> & MonadThrow4<URI> = {
+export const stateReaderTaskEither: Monad4<URI> & MonadThrow4<URI> & MonadTask4<URI> = {
   URI,
   map: T.map,
   of: right,
   ap: T.ap,
   chain: T.chain,
+  fromIO: rightIO,
+  fromTask: rightTask,
   throwError: left
 }
 
@@ -280,9 +283,19 @@ export const stateReaderTaskEitherSeq: typeof stateReaderTaskEither = {
   ap: (mab, ma) => stateReaderTaskEither.chain(mab, f => stateReaderTaskEither.map(ma, f))
 }
 
-const { ap, apFirst, apSecond, chain, chainFirst, flatten, map, fromEither, fromOption } = pipeable(
-  stateReaderTaskEither
-)
+const {
+  ap,
+  apFirst,
+  apSecond,
+  chain,
+  chainFirst,
+  flatten,
+  map,
+  fromEither,
+  fromOption,
+  filterOrElse,
+  fromPredicate
+} = pipeable(stateReaderTaskEither)
 
 export {
   /**
@@ -320,5 +333,13 @@ export {
   /**
    * @since 2.0.0
    */
-  fromOption
+  fromOption,
+  /**
+   * @since 2.4.4
+   */
+  fromPredicate,
+  /**
+   * @since 2.4.4
+   */
+  filterOrElse
 }


### PR DESCRIPTION
`MonadTask4` and all upper dependencies added. `MonadTask4` was then added to `StateReaderTaskEither`. I also added the missing exports for `fromPredicate` and `filterOrElse`.