### PR TITLE
Porting StateEither from morphic-ts and adding tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fp-ts",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2510,7 +2510,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2531,12 +2532,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2551,17 +2554,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2678,7 +2684,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2690,6 +2697,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2704,6 +2712,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2711,12 +2720,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2735,6 +2746,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2815,7 +2827,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2827,6 +2840,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2912,7 +2926,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2948,6 +2963,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2967,6 +2983,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3010,12 +3027,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/StateEither.ts
+++ b/src/StateEither.ts
@@ -1,0 +1,218 @@
+/**
+ * @since 2.4.4
+ */
+import * as E from './Either'
+import { Monad3 } from './Monad'
+import { MonadThrow3 } from './MonadThrow'
+import { State } from './State'
+import { getStateM } from './StateT'
+import { pipeable } from './pipeable'
+
+const T = getStateM(E.either)
+
+declare module './HKT' {
+  interface URItoKind3<R, E, A> {
+    StateEither: StateEither<R, E, A>
+  }
+}
+
+/**
+ * @since 0.1.0
+ */
+export const URI = 'StateEither'
+
+/**
+ * @since 0.1.0
+ */
+export type URI = typeof URI
+
+/**
+ * @since 0.1.0
+ */
+export interface StateEither<S, E, A> {
+  (s: S): E.Either<E, [A, S]>
+}
+
+/**
+ * @since 0.1.0
+ */
+export function run<S, E, A>(ma: StateEither<S, E, A>, s: S): E.Either<E, [A, S]> {
+  return ma(s)
+}
+
+/**
+ * @since 0.1.0
+ */
+export const evalState: <S, E, A>(ma: StateEither<S, E, A>, s: S) => E.Either<E, A> = T.evalState
+
+/**
+ * @since 0.1.0
+ */
+export const execState: <S, E, A>(ma: StateEither<S, E, A>, s: S) => E.Either<E, S> = T.execState
+
+/**
+ * @since 0.1.0
+ */
+export function left<S, E>(e: E): StateEither<S, E, never> {
+  return StateEither(E.left(e))
+}
+
+/**
+ * @since 0.1.0
+ */
+export const right: <S, A>(a: A) => StateEither<S, never, A> = T.of
+
+/**
+ * @since 0.1.0
+ */
+export const StateEither: <S, E, A>(ma: E.Either<E, A>) => StateEither<S, E, A> = T.fromM
+
+/**
+ * @since 0.1.0
+ */
+export const rightState: <S, A>(ma: State<S, A>) => StateEither<S, never, A> = T.fromState
+
+/**
+ * @since 0.1.0
+ */
+export function leftState<S, E>(me: State<S, E>): StateEither<S, E, never> {
+  return s => E.left(me(s)[0])
+}
+
+/**
+ * @since 0.1.0
+ */
+export const get: <S>() => StateEither<S, never, S> = T.get
+
+/**
+ * @since 0.1.0
+ */
+export const put: <S>(s: S) => StateEither<S, never, void> = T.put
+
+/**
+ * @since 0.1.0
+ */
+export const modify: <S>(f: (s: S) => S) => StateEither<S, never, void> = T.modify
+
+/**
+ * @since 0.1.0
+ */
+export const gets: <S, A>(f: (s: S) => A) => StateEither<S, never, A> = T.gets
+
+/**
+ * @since 0.1.10
+ */
+export function fromEitherK<E, A extends Array<unknown>, B>(
+  f: (...a: A) => E.Either<E, B>
+): <S>(...a: A) => StateEither<S, E, B> {
+  return (...a) => fromEither(f(...a))
+}
+
+/**
+ * @since 0.1.10
+ */
+export function chainEitherK<E, A, B>(
+  f: (a: A) => E.Either<E, B>
+): <S>(ma: StateEither<S, E, A>) => StateEither<S, E, B> {
+  return chain<any, E, A, B>(fromEitherK(f))
+}
+
+/**
+ * @since 0.1.10
+ */
+export function StateEitherK<E, A extends Array<unknown>, B>(
+  f: (...a: A) => E.Either<E, B>
+): <S>(...a: A) => StateEither<S, E, B> {
+  return (...a) => StateEither(f(...a))
+}
+
+/**
+ * @since 0.1.10
+ */
+export function StatekEitherK<E, A, B>(
+  f: (a: A) => E.Either<E, B>
+): <S>(ma: StateEither<S, E, A>) => StateEither<S, E, B> {
+  return chain<any, E, A, B>(StateEitherK(f))
+}
+
+/**
+ * @since 0.1.0
+ */
+export const stateEither: Monad3<URI> & MonadThrow3<URI> = {
+  URI,
+  map: T.map,
+  of: right,
+  ap: T.ap,
+  chain: T.chain,
+  throwError: left
+}
+
+/**
+ * Like `stateEither` but `ap` is sequential
+ * @since 0.1.0
+ */
+export const stateEitherSeq: typeof stateEither = {
+  ...stateEither,
+  ap: (mab, ma) => T.chain(mab, f => T.map(ma, f))
+}
+
+const {
+  ap,
+  apFirst,
+  apSecond,
+  chain,
+  chainFirst,
+  flatten,
+  map,
+  filterOrElse,
+  fromEither,
+  fromOption,
+  fromPredicate
+} = pipeable(stateEither)
+
+export {
+  /**
+   * @since 0.1.0
+   */
+  ap,
+  /**
+   * @since 0.1.0
+   */
+  apFirst,
+  /**
+   * @since 0.1.0
+   */
+  apSecond,
+  /**
+   * @since 0.1.0
+   */
+  chain,
+  /**
+   * @since 0.1.0
+   */
+  chainFirst,
+  /**
+   * @since 0.1.0
+   */
+  flatten,
+  /**
+   * @since 0.1.0
+   */
+  map,
+  /**
+   * @since 0.1.0
+   */
+  filterOrElse,
+  /**
+   * @since 0.1.0
+   */
+  fromEither,
+  /**
+   * @since 0.1.0
+   */
+  fromOption,
+  /**
+   * @since 0.1.0
+   */
+  fromPredicate
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,7 @@ import * as show from './Show'
 import * as state from './State'
 import * as stateReaderTaskEither from './StateReaderTaskEither'
 import * as stateT from './StateT'
+import * as stateEither from './StateEither'
 import * as store from './Store'
 import * as strong from './Strong'
 import * as task from './Task'
@@ -405,6 +406,10 @@ export {
    * @since 2.0.0
    */
   stateT,
+  /**
+   * @since 2.4.4
+   */
+  stateEither,
   /**
    * @since 2.0.0
    */

--- a/test/StateEither.ts
+++ b/test/StateEither.ts
@@ -1,16 +1,8 @@
 import * as assert from 'assert'
 import * as E from '../src/Either'
-// import { io } from '../src/IO'
-// import * as IE from '../src/IOEither'
-// import * as O from '../src/Option'
 import { pipe } from '../src/pipeable'
-// import { reader } from '../src/Reader'
-// import * as RE from '../src/ReaderEither'
-// import * as RTE from '../src/ReaderTaskEither'
 import { State } from '../src/State'
 import * as _ from '../src/StateEither'
-// import { task } from '../src/Task'
-// import * as TE from '../src/TaskEither'
 
 describe('StateEither', () => {
   it('run', () => {

--- a/test/StateEither.ts
+++ b/test/StateEither.ts
@@ -1,0 +1,116 @@
+import * as assert from 'assert'
+import * as E from '../src/Either'
+// import { io } from '../src/IO'
+// import * as IE from '../src/IOEither'
+// import * as O from '../src/Option'
+import { pipe } from '../src/pipeable'
+// import { reader } from '../src/Reader'
+// import * as RE from '../src/ReaderEither'
+// import * as RTE from '../src/ReaderTaskEither'
+import { State } from '../src/State'
+import * as _ from '../src/StateEither'
+// import { task } from '../src/Task'
+// import * as TE from '../src/TaskEither'
+
+describe('StateEither', () => {
+  it('run', () => {
+    const ma = _.right('aaa')
+    const e = _.run(ma, {})
+    assert.deepStrictEqual(e, E.right(['aaa', {}]))
+  })
+
+  describe('Monad', () => {
+    it('map', async () => {
+      const len = (s: string): number => s.length
+      const ma = _.right('aaa')
+      const e = _.evalState(_.stateEither.map(ma, len), {})
+      assert.deepStrictEqual(e, E.right(3))
+    })
+
+    it('ap', async () => {
+      const len = (s: string): number => s.length
+      const mab = _.right(len)
+      const ma = _.right('aaa')
+      const e = _.evalState(_.stateEither.ap(mab, ma), {})
+      assert.deepStrictEqual(e, E.right(3))
+    })
+
+    it('ap (seq)', async () => {
+      const len = (s: string): number => s.length
+      const mab = _.right(len)
+      const ma = _.right('aaa')
+      const e = _.evalState(_.stateEitherSeq.ap(mab, ma), {})
+      assert.deepStrictEqual(e, E.right(3))
+    })
+
+    it('chain', async () => {
+      const f = (s: string) => (s.length > 2 ? _.right(s.length) : _.right(0))
+      const ma = _.right('aaa')
+      const e = _.evalState(_.stateEither.chain(ma, f), {})
+      assert.deepStrictEqual(e, E.right(3))
+    })
+  })
+
+  it('evalState', () => {
+    const ma = _.right('aaa')
+    const s = {}
+    const e = _.evalState(ma, s)
+    assert.deepStrictEqual(e, E.right('aaa'))
+  })
+
+  it('execState Right', () => {
+    const ma = _.right('aaa')
+    const s = {}
+    const e = _.execState(ma, s)
+    assert.deepStrictEqual(e, E.right(s))
+  })
+
+  it('execState Left', () => {
+    const ma = _.left('aaa')
+    const s = {}
+    const e = _.execState(ma, s)
+    assert.deepStrictEqual(e, E.left('aaa'))
+  })
+
+  it('rightState', () => {
+    const state: State<{}, number> = s => [1, s]
+    const e = _.evalState(_.rightState(state), {})
+    assert.deepStrictEqual(e, E.right(1))
+  })
+
+  it('leftState', () => {
+    const state: State<{}, number> = s => [1, s]
+    const e = _.evalState(_.leftState(state), {})
+    assert.deepStrictEqual(e, E.left(1))
+  })
+
+  it('fromEither', async () => {
+    const ei: E.Either<{}, number> = E.right(1)
+    const e = _.evalState(_.fromEither(ei), {})
+    assert.deepStrictEqual(e, E.right(1))
+  })
+
+  it('chainEitherK', async () => {
+    const f = (s: string) => E.right(s.length)
+    const x = _.evalState(pipe(_.right('aa'), _.chainEitherK(f)), {})
+    assert.deepStrictEqual(x, E.right(2))
+  })
+
+  it('StateEitherK', async () => {
+    const f = (s: Array<string>) => E.right(s.length)
+    const x = _.evalState(_.StateEitherK(f)(['a', 'b']), {})
+    assert.deepStrictEqual(x, E.right(2))
+  })
+
+  it('StatekEitherK', async () => {
+    const f = (s: string) => E.right(s.length)
+    const x = _.evalState(_.StatekEitherK(f)(_.right('e')), {})
+    assert.deepStrictEqual(x, E.right(1))
+  })
+
+  it('stateEitherSeq', async () => {
+    const f = (s: Array<string>) => E.right(s.length)
+    const x = _.evalState(_.StateEitherK(f)(['a', 'b']), {})
+    assert.deepStrictEqual(x, E.right(2))
+  })
+})


### PR DESCRIPTION
Adding StateEither to FP-TS, see https://github.com/sledorze/morphic-ts/issues/4
StateEither is used in morphic to parse JSON schemas
