### PR TITLE
IORef this binding problems solved

### DIFF
--- a/docs/learning-resources.md
+++ b/docs/learning-resources.md
@@ -40,3 +40,7 @@ has_toc: false
 - "`fp-ts` to the max" (TypeScript port of John De Goes's ["FP to the max"](https://www.youtube.com/watch?v=sxudIMiOo68) in Scala)
   - [Part I](https://github.com/gcanti/fp-ts/blob/master/examples/fp-ts-to-the-max-I.ts)
   - [Part II](https://github.com/gcanti/fp-ts/blob/master/examples/fp-ts-to-the-max-II.ts)
+
+## Community documentation
+
+- [fp-ts recipes](https://grossbart.github.io/fp-ts-recipes/) – A collection of practical recipes for working with `fp-ts`

--- a/src/IORef.ts
+++ b/src/IORef.ts
@@ -18,6 +18,8 @@ export class IORef<A> {
   read: IO<A>
   constructor(private value: A) {
     this.read = () => this.value
+    this.write = this.write.bind(this)
+    this.modify = this.modify.bind(this)
   }
   /**
    * @since 2.0.0

--- a/test/IORef.ts
+++ b/test/IORef.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert'
 import { io } from '../src/IO'
 import { IORef, newIORef } from '../src/IORef'
+import { pipe } from '../src/pipeable'
 
 describe('IORef', () => {
   it('read', () => {
@@ -21,5 +22,13 @@ describe('IORef', () => {
 
   it('newIORef', () => {
     assert.deepStrictEqual(io.chain(newIORef(1), ref => ref.read)(), 1)
+  })
+
+  it('pipe', () => {
+    const ref = new IORef(1)
+    pipe(2, ref.write)()
+    assert.deepStrictEqual(ref.read(), 2)
+    pipe(() => 3, ref.modify)()
+    assert.deepStrictEqual(ref.read(), 3)
   })
 })


### PR DESCRIPTION
I made all attributes `readonly` and solved a problem that occurs when you try to `pipe` the functions of an `IORef` instance. The problem is that the `this` context gets lost when using the methods directly.

```ts
const ref = new IORef('hello')

pipe('world', ref.write)() // This would throw: Uncaught TypeError: Cannot set property 'value' of undefined
```