### PR TITLE
Add alga-ts library

### DIFF
--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -27,6 +27,7 @@ has_toc: false
 - [kleisli-ts](https://github.com/YBogomolov/kleisli-ts) - Kleisli arrows for bifunctor MonadThrow (IOEither, TaskEither)
 - [@nll/datum](https://github.com/nullpub/datum) - Datum and DatumEither types, another take on RemoteData and [flow](https://medium.com/@gcanti/slaying-a-ui-antipattern-with-flow-5eed0cfb627b)
 - [fetcher-ts](https://github.com/YBogomolov/fetcher-ts) - Type-safe REST HTTP client with io-ts response validation
+- [alga-ts](https://github.com/algebraic-graphs/typescript) – Algebraic encoding for graphs, which makes invalid graphs unrepresentable
 
 ## Bindings
 


### PR DESCRIPTION
I've ported Haskell library `alga` to TypeScript, and used `fp-ts` for HKT to provide Monad & Alternative instances. I would be happy to see it as a part of awesome `fp-ts` ecosystem.