### PR TITLE
Fix TaskEither getApplyMonoid test

### DIFF
--- a/test/TaskEither.ts
+++ b/test/TaskEither.ts
@@ -225,8 +225,8 @@ describe('TaskEither', () => {
     })
 
     it('empty (left)', async () => {
-      const x = await M.concat(M.empty, _.right('a'))()
-      return assert.deepStrictEqual(x, E.right('a'))
+      const x = await M.concat(M.empty, _.left('a'))()
+      return assert.deepStrictEqual(x, E.left('a'))
     })
   })
 


### PR DESCRIPTION
TaskEither's getApplyMonoid test was testing twice concatting empty with right.
This PR fixes it so that it concats once with empty and right and once with empty and left.