### PR TITLE
Handle bad type assertion in isLeft and isRight

### DIFF
--- a/src/Either.ts
+++ b/src/Either.ts
@@ -287,7 +287,7 @@ export function isLeft<E, A>(ma: Either<E, A>): ma is Left<E> {
   switch (ma._tag) {
     case 'Left':
       return true
-    case 'Right':
+    default:
       return false
   }
 }
@@ -298,7 +298,12 @@ export function isLeft<E, A>(ma: Either<E, A>): ma is Left<E> {
  * @since 2.0.0
  */
 export function isRight<E, A>(ma: Either<E, A>): ma is Right<A> {
-  return isLeft(ma) ? false : true
+  switch (ma._tag) {
+    case 'Right':
+      return true
+    default:
+      return false
+  }
 }
 
 /**

--- a/test/Either.ts
+++ b/test/Either.ts
@@ -91,13 +91,11 @@ describe('Either', () => {
   it('isLeft', () => {
     assert.deepStrictEqual(_.isLeft(_.right(1)), false)
     assert.deepStrictEqual(_.isLeft(_.left(1)), true)
-    assert.deepStrictEqual(_.isLeft(('Left' as unknown) as _.Either<unknown, unknown>), false)
   })
 
   it('isRight', () => {
     assert.deepStrictEqual(_.isRight(_.right(1)), true)
     assert.deepStrictEqual(_.isRight(_.left(1)), false)
-    assert.deepStrictEqual(_.isRight(('Right' as unknown) as _.Either<unknown, unknown>), false)
   })
 
   it('orElse', () => {

--- a/test/Either.ts
+++ b/test/Either.ts
@@ -91,11 +91,13 @@ describe('Either', () => {
   it('isLeft', () => {
     assert.deepStrictEqual(_.isLeft(_.right(1)), false)
     assert.deepStrictEqual(_.isLeft(_.left(1)), true)
+    assert.deepStrictEqual(_.isLeft(('Left' as unknown) as _.Either<unknown, unknown>), false)
   })
 
   it('isRight', () => {
     assert.deepStrictEqual(_.isRight(_.right(1)), true)
     assert.deepStrictEqual(_.isRight(_.left(1)), false)
+    assert.deepStrictEqual(_.isRight(('Right' as unknown) as _.Either<unknown, unknown>), false)
   })
 
   it('orElse', () => {


### PR DESCRIPTION
Supplying a non-Either value with an "as Either<unknown, unknown>"
type assertion should cause both isLeft and isRight to return false.

See issue [#1168](https://github.com/gcanti/fp-ts/issues/1168)
