### PR TITLE
Fix meaning of C in code conventions docs

### DIFF
--- a/docs/guides/code-conventions.md
+++ b/docs/guides/code-conventions.md
@@ -35,7 +35,7 @@ In general a module containing the definition of a data structure has the follow
 The naming convention is:
 
 - the number means the kind
-- `C` means *C*urried
+- `C` means *C*onstrained
 
 | Kind               | Type class           | Type defunctionalization | Note                                                     |
 | ------------------ | -------------------- | ------------------------ | -------------------------------------------------------- |


### PR DESCRIPTION
I was a bit confused when reading the documentation regarding the meaning of `C` in type classes names such as [`Functor2C`](https://github.com/gcanti/fp-ts/blob/21461b8c6de99620f3b127f4fbfbca915f1a6059/src/Functor.ts#L43) or [`Applicative2C`](https://github.com/gcanti/fp-ts/blob/21461b8c6de99620f3b127f4fbfbca915f1a6059/src/Applicative.ts#L61).

If I understood it correctly, the `C` doesn't mean _curried_, but rather _constrained_, e.g. the "left" parameter of the [`Writer monad`](https://github.com/gcanti/fp-ts/blob/21461b8c6de99620f3b127f4fbfbca915f1a6059/src/Writer.ts#L96) must be an instance of Monoid.

Unless I misunderstood it? 🤔 