### PR TITLE
Add a description and example for Option.alt

### DIFF
--- a/docs/modules/Option.ts.md
+++ b/docs/modules/Option.ts.md
@@ -150,10 +150,46 @@ Added in v2.0.0
 
 # alt
 
+Similar to [Option.orElse](<https://www.scala-lang.org/api/current/scala/Option.html#orElse[B%3E:A](alternative:=%3EOption[B]):Option[B]>) from Scala,
+`alt` provides an alternative value of type `Option<A>` as a fallback when `fa` is `None`.
+
 **Signature**
 
 ```ts
 <A>(that: () => Option<A>) => (fa: Option<A>) => Option<A>
+```
+
+**Example**
+
+```ts
+import { Option, fromNullable, filter, alt } from 'fp-ts/lib/Option'
+import { pipe } from 'fp-ts/lib/pipeable'
+
+interface Store {
+  a?: {
+    b?: unknown
+  }
+}
+
+const isNumber = (value: unknown): value is number => typeof value === 'number'
+
+const getFromStore = (store: Store) => pipe(fromNullable(store.a?.b), filter(isNumber))
+
+const getValue = ([mainStore, secondStore]: [Store, Store]) =>
+  pipe(
+    getFromStore(mainStore),
+    alt(() => getFromStore(secondStore))
+  )
+
+assert.deepStrictEqual(getValue([{ a: { b: 1 } }, {}]), some(1))
+assert.deepStrictEqual(getValue([{}, { a: { b: 2 } }]), some(2))
+assert.deepStrictEqual(getValue([{ a: { b: 1 } }, { a: { b: 2 } }]), some(1))
+assert.deepStrictEqual(getValue([{ a: { b: 'corrupted data' } }, { a: { b: 2 } }]), some(2))
+assert.deepStrictEqual(getValue([{ a: { b: 'corrupted data' } }, {}]), none)
+assert.deepStrictEqual(getValue([{}, { a: { b: 'corrupted data' } }]), none)
+assert.deepStrictEqual(getValue([{ a: {} }, {}]), none)
+assert.deepStrictEqual(getValue([{}, { a: {} }]), none)
+assert.deepStrictEqual(getValue([{}, {}]), none)
 ```
 
 Added in v2.0.0

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -718,6 +718,43 @@ const {
 
 export {
   /**
+   * Similar to [Option.orElse](https://www.scala-lang.org/api/current/scala/Option.html#orElse[B%3E:A](alternative:=%3EOption[B]):Option[B]) from Scala,
+   * `alt` provides an alternative value of type `Option<A>` as a fallback when `fa` is `None`.
+   *
+   * @example
+   * import { Option, fromNullable, filter, alt } from 'fp-ts/lib/Option'
+   * import { pipe } from 'fp-ts/lib/pipeable'
+   *
+   * interface Store {
+   *   a?: {
+   *     b?: unknown
+   *   }
+   * }
+   *
+   * const isNumber = (value: unknown): value is number => typeof value === 'number'
+   *
+   * const getFromStore = (store: Store) =>
+   *   pipe(
+   *     fromNullable(store.a?.b),
+   *     filter(isNumber)
+   *   )
+   *
+   * const getValue = ([mainStore, secondStore]: [Store, Store]) =>
+   *   pipe(
+   *     getFromStore(mainStore),
+   *     alt(() => getFromStore(secondStore))
+   *   )
+   *
+   * assert.deepStrictEqual(getValue([{ a: { b: 1 } }, {}]), some(1))
+   * assert.deepStrictEqual(getValue([{}, { a: { b: 2 } }]), some(2))
+   * assert.deepStrictEqual(getValue([{ a: { b: 1 } }, { a: { b: 2 } }]), some(1))
+   * assert.deepStrictEqual(getValue([{ a: { b: 'corrupted data' } }, { a: { b: 2 } }]), some(2))
+   * assert.deepStrictEqual(getValue([{ a: { b: 'corrupted data' } }, {}]), none)
+   * assert.deepStrictEqual(getValue([{}, { a: { b: 'corrupted data' } }]), none)
+   * assert.deepStrictEqual(getValue([{ a: {} }, {}]), none)
+   * assert.deepStrictEqual(getValue([{}, { a: {} }]), none)
+   * assert.deepStrictEqual(getValue([{}, {}]), none)
+   *
    * @since 2.0.0
    */
   alt,


### PR DESCRIPTION
Hello, based on the comments from the https://github.com/gcanti/fp-ts/issues/1103 issue, I'm assuming we can still improve the documentation from the `src` files. This is my first attempt at this task, please let me know if the changes proposed on this branch are OK. I'd like to contribute more on this matter, but first I want to make sure these kinds of changes are acceptable for such an amazing code base!

- I'm using the [optional chaining](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#optional-chaining) from TS 3.7 in the example, I hope that's fine.
- I had to use [markserv](https://github.com/markserv/markserv) to serve the Markdown files from the `docs` directory as HTML pages. Is there a "better" way to check the changes regarding the documentation on local?
- Do we have some guidelines somewhere regarding the size/complexity of descriptions and examples?