### PR TITLE
Add article about Do by Paul Gray

### DIFF
--- a/docs/learning-resources.md
+++ b/docs/learning-resources.md
@@ -10,6 +10,7 @@ has_toc: false
 
 - [Mostly adequate guide to FP](https://github.com/MostlyAdequate/mostly-adequate-guide) by [@DrBoolean](https://github.com/DrBoolean)
 - [The State monad](https://paulgray.net/the-state-monad/)
+- [Approximating Haskell's `do` syntax in TypeScript](https://paulgray.net/do-syntax-in-typescript/)
 
 ## Getting started with fp-ts series
 


### PR DESCRIPTION
Not sure if it belongs here though, since `Do` is in `fp-ts-contrib`, but I guess it's a good idea to have the resources in one place.