### PR TITLE
Safe split and join

### DIFF
--- a/docs/modules/Strong.ts.md
+++ b/docs/modules/Strong.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Strong.ts
-nav_order: 86
+nav_order: 87
 parent: Modules
 ---
 

--- a/docs/modules/Task.ts.md
+++ b/docs/modules/Task.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Task.ts
-nav_order: 87
+nav_order: 88
 parent: Modules
 ---
 

--- a/docs/modules/TaskEither.ts.md
+++ b/docs/modules/TaskEither.ts.md
@@ -1,6 +1,6 @@
 ---
 title: TaskEither.ts
-nav_order: 88
+nav_order: 89
 parent: Modules
 ---
 

--- a/docs/modules/TaskThese.ts.md
+++ b/docs/modules/TaskThese.ts.md
@@ -1,6 +1,6 @@
 ---
 title: TaskThese.ts
-nav_order: 89
+nav_order: 90
 parent: Modules
 ---
 

--- a/docs/modules/These.ts.md
+++ b/docs/modules/These.ts.md
@@ -1,6 +1,6 @@
 ---
 title: These.ts
-nav_order: 90
+nav_order: 91
 parent: Modules
 ---
 

--- a/docs/modules/TheseT.ts.md
+++ b/docs/modules/TheseT.ts.md
@@ -1,6 +1,6 @@
 ---
 title: TheseT.ts
-nav_order: 91
+nav_order: 92
 parent: Modules
 ---
 

--- a/docs/modules/Traced.ts.md
+++ b/docs/modules/Traced.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Traced.ts
-nav_order: 92
+nav_order: 93
 parent: Modules
 ---
 

--- a/docs/modules/Traversable.ts.md
+++ b/docs/modules/Traversable.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Traversable.ts
-nav_order: 93
+nav_order: 94
 parent: Modules
 ---
 

--- a/docs/modules/TraversableWithIndex.ts.md
+++ b/docs/modules/TraversableWithIndex.ts.md
@@ -1,6 +1,6 @@
 ---
 title: TraversableWithIndex.ts
-nav_order: 94
+nav_order: 95
 parent: Modules
 ---
 

--- a/docs/modules/Tree.ts.md
+++ b/docs/modules/Tree.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Tree.ts
-nav_order: 95
+nav_order: 96
 parent: Modules
 ---
 

--- a/docs/modules/Tuple.ts.md
+++ b/docs/modules/Tuple.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Tuple.ts
-nav_order: 96
+nav_order: 97
 parent: Modules
 ---
 

--- a/docs/modules/Unfoldable.ts.md
+++ b/docs/modules/Unfoldable.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Unfoldable.ts
-nav_order: 97
+nav_order: 98
 parent: Modules
 ---
 

--- a/docs/modules/ValidationT.ts.md
+++ b/docs/modules/ValidationT.ts.md
@@ -1,6 +1,6 @@
 ---
 title: ValidationT.ts
-nav_order: 98
+nav_order: 99
 parent: Modules
 ---
 

--- a/docs/modules/Witherable.ts.md
+++ b/docs/modules/Witherable.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Witherable.ts
-nav_order: 99
+nav_order: 100
 parent: Modules
 ---
 

--- a/docs/modules/Writer.ts.md
+++ b/docs/modules/Writer.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Writer.ts
-nav_order: 100
+nav_order: 101
 parent: Modules
 ---
 

--- a/docs/modules/WriterT.ts.md
+++ b/docs/modules/WriterT.ts.md
@@ -1,6 +1,6 @@
 ---
 title: WriterT.ts
-nav_order: 101
+nav_order: 102
 parent: Modules
 ---
 

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -96,6 +96,7 @@ Added in v2.0.0
 - [stateReaderTaskEither](#statereadertaskeither)
 - [stateT](#statet)
 - [store](#store)
+- [string](#string)
 - [strong](#strong)
 - [task](#task)
 - [taskEither](#taskeither)
@@ -954,6 +955,16 @@ export declare const store: typeof store
 ```
 
 Added in v2.0.0
+
+# string
+
+**Signature**
+
+```ts
+export declare const string: typeof string
+```
+
+Added in v2.6.0
 
 # strong
 

--- a/docs/modules/string.ts.md
+++ b/docs/modules/string.ts.md
@@ -1,0 +1,61 @@
+---
+title: string.ts
+nav_order: 86
+parent: Modules
+---
+
+# string overview
+
+Added in v2.6.0
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [join](#join)
+- [split](#split)
+
+---
+
+# join
+
+Takes a `delimiter` string and joins given string values with the delimiter.
+
+**Signature**
+
+```ts
+export declare function join(delimiter: string): (values: NonEmptyArray<string>) => string
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/lib/pipeable'
+import { join } from 'fp-ts/lib/string'
+
+assert.deepStrictEqual(pipe(['foo', 'bar'], join('.')), 'foo.bar')
+```
+
+Added in v2.6.0
+
+# split
+
+Takes a `delimiter` string and splits a given string value at the delimiter
+returning one or more substrings.
+
+**Signature**
+
+```ts
+export declare function split(delimiter: string): (value: string) => NonEmptyArray<string>
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/lib/pipeable'
+import { split } from 'fp-ts/lib/string'
+
+assert.deepStrictEqual(pipe('foo.bar', split('.')), ['foo', 'bar'])
+```
+
+Added in v2.6.0

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,7 @@ import * as state from './State'
 import * as stateReaderTaskEither from './StateReaderTaskEither'
 import * as stateT from './StateT'
 import * as store from './Store'
+import * as string from './string'
 import * as strong from './Strong'
 import * as task from './Task'
 import * as taskEither from './TaskEither'
@@ -439,6 +440,10 @@ export {
    * @since 2.0.0
    */
   store,
+  /**
+   * @since 2.6.0
+   */
+  string,
   /**
    * @since 2.0.0
    */

--- a/src/string.ts
+++ b/src/string.ts
@@ -1,0 +1,50 @@
+/**
+ * @since 2.6.0
+ */
+
+import { NonEmptyArray } from './NonEmptyArray'
+
+/**
+ * Takes a `delimiter` string and splits a given string value at the delimiter
+ * returning one or more substrings.
+ *
+ *
+ * @example
+ * import { pipe } from 'fp-ts/lib/pipeable'
+ * import { split } from 'fp-ts/lib/string'
+ *
+ * assert.deepStrictEqual(
+ *  pipe(
+ *    'foo.bar',
+ *    split('.')
+ *  ),
+ *  ['foo', 'bar']
+ * )
+ *
+ * @since 2.6.0
+ */
+export function split(delimiter: string): (value: string) => NonEmptyArray<string> {
+  return (value) => value.split(delimiter) as NonEmptyArray<string>
+}
+
+/**
+ * Takes a `delimiter` string and joins given string values with the delimiter.
+ *
+ *
+ * @example
+ * import { pipe } from 'fp-ts/lib/pipeable'
+ * import { join } from 'fp-ts/lib/string'
+ *
+ * assert.deepStrictEqual(
+ *  pipe(
+ *    ['foo', 'bar'],
+ *    join('.')
+ *  ),
+ *  'foo.bar'
+ * )
+ *
+ * @since 2.6.0
+ */
+export function join(delimiter: string): (values: NonEmptyArray<string>) => string {
+  return (values) => values.join(delimiter)
+}

--- a/test/string.ts
+++ b/test/string.ts
@@ -1,0 +1,19 @@
+import * as assert from 'assert'
+import * as S from '../src/string'
+
+describe('string', () => {
+  it('split', () => {
+    assert.deepStrictEqual(S.split('.')(''), [''])
+    assert.deepStrictEqual(S.split('.')('foo'), ['foo'])
+    assert.deepStrictEqual(S.split('.')('foo.bar'), ['foo', 'bar'])
+    assert.deepStrictEqual(S.split('.')('foo..bar'), ['foo', '', 'bar'])
+    assert.deepStrictEqual(S.split('..')('foo..bar'), ['foo', 'bar'])
+  })
+  it('join', () => {
+    assert.deepStrictEqual(S.join('.')(['']), '')
+    assert.deepStrictEqual(S.join('.')(['foo']), 'foo')
+    assert.deepStrictEqual(S.join('.')(['foo', 'bar']), 'foo.bar')
+    assert.deepStrictEqual(S.join('.')(['foo', '', 'bar']), 'foo..bar')
+    assert.deepStrictEqual(S.join('..')(['foo', 'bar']), 'foo..bar')
+  })
+})


### PR DESCRIPTION
This PR adds string `split` and `join` functions that work with NonEmptyArrays.