### PR TITLE
add W variants, closes #904

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,33 @@
 **Note**: Gaps between patch versions are faulty/broken releases. **Note**: A feature tagged as Experimental is in a
 high state of flux, you're at risk of it changing without notice.
 
+# 2.6.0
+
+- **New Feature**
+  - `Either`
+    - add `getOrElseW` (@gcanti)
+    - add `chainW` (@gcanti)
+  - `IOEither`
+    - add `getOrElseW` (@gcanti)
+    - add `chainW` (@gcanti)
+  - `Option`
+    - add `getOrElseW` (@gcanti)
+  - `Reader`
+    - add `chainW` (@gcanti)
+  - `ReaderEither`
+    - add `getOrElseW` (@gcanti)
+    - add `chainW` (@gcanti)
+  - `ReaderTaskEither`
+    - add `getOrElseW` (@gcanti)
+    - add `chainW` (@gcanti)
+  - `StateReaderTaskEither`
+    - add `chainW` (@gcanti)
+  - `TaskEither`
+    - add `getOrElseW` (@gcanti)
+    - add `chainW` (@gcanti)
+  - `Tree`
+    - add `fold` function (@gcanti)
+
 # 2.5.4
 
 - **Polish**

--- a/dtslint/ts3.5/Either.ts
+++ b/dtslint/ts3.5/Either.ts
@@ -1,0 +1,22 @@
+import * as _ from '../../src/Either'
+import { pipe } from '../../src/pipeable'
+
+//
+// getOrElseW
+//
+
+// $ExpectType string | null
+pipe(
+  _.right('a'),
+  _.getOrElseW(() => null)
+)
+
+//
+// chainW
+//
+
+// $ExpectType Either<string | number, number>
+pipe(
+  _.right<string, string>('a'),
+  _.chainW(() => _.right<number, number>(1))
+)

--- a/dtslint/ts3.5/IOEither.ts
+++ b/dtslint/ts3.5/IOEither.ts
@@ -1,0 +1,23 @@
+import * as _ from '../../src/IOEither'
+import * as IO from '../../src/IO'
+import { pipe } from '../../src/pipeable'
+
+//
+// getOrElseW
+//
+
+// $ExpectType IO<string | null>
+pipe(
+  _.right('a'),
+  _.getOrElseW(() => IO.of(null))
+)
+
+//
+// chainW
+//
+
+// $ExpectType IOEither<string | number, number>
+pipe(
+  _.right<string, string>('a'),
+  _.chainW(() => _.right<number, number>(1))
+)

--- a/dtslint/ts3.5/Option.ts
+++ b/dtslint/ts3.5/Option.ts
@@ -1,0 +1,12 @@
+import * as _ from '../../src/Option'
+import { pipe } from '../../src/pipeable'
+
+//
+// getOrElseW
+//
+
+// $ExpectType string | null
+pipe(
+  _.some('a'),
+  _.getOrElseW(() => null)
+)

--- a/dtslint/ts3.5/Reader.ts
+++ b/dtslint/ts3.5/Reader.ts
@@ -1,0 +1,12 @@
+import * as _ from '../../src/Reader'
+import { pipe } from '../../src/pipeable'
+
+//
+// chainW
+//
+
+// $ExpectType Reader<{ a: string; } & { b: number; }, number>
+pipe(
+  _.of<{ a: string }, string>('a'),
+  _.chainW(() => _.of<{ b: number }, number>(1))
+)

--- a/dtslint/ts3.5/ReaderEither.ts
+++ b/dtslint/ts3.5/ReaderEither.ts
@@ -1,0 +1,23 @@
+import * as _ from '../../src/ReaderEither'
+import * as R from '../../src/Reader'
+import { pipe } from '../../src/pipeable'
+
+//
+// getOrElseW
+//
+
+// $ExpectType Reader<{ a: string; } & { b: number; }, string | null>
+pipe(
+  _.right<{ a: string }, string, string>('a'),
+  _.getOrElseW(() => R.of<{ b: number }, null>(null))
+)
+
+//
+// chainW
+//
+
+// $ExpectType ReaderEither<{ a: string; } & { b: number; }, string | number, number>
+pipe(
+  _.right<{ a: string }, string, string>('a'),
+  _.chainW(() => _.right<{ b: number }, number, number>(1))
+)

--- a/dtslint/ts3.5/ReaderTaskEither.ts
+++ b/dtslint/ts3.5/ReaderTaskEither.ts
@@ -1,0 +1,23 @@
+import * as _ from '../../src/ReaderTaskEither'
+import * as RT from '../../src/ReaderTask'
+import { pipe } from '../../src/pipeable'
+
+//
+// getOrElseW
+//
+
+// $ExpectType ReaderTask<{ a: string; } & { b: number; }, string | null>
+pipe(
+  _.right<{ a: string }, string, string>('a'),
+  _.getOrElseW(() => RT.of<{ b: number }, null>(null))
+)
+
+//
+// chainW
+//
+
+// $ExpectType ReaderTaskEither<{ a: string; } & { b: number; }, string | number, number>
+pipe(
+  _.right<{ a: string }, string, string>('a'),
+  _.chainW(() => _.right<{ b: number }, number, number>(1))
+)

--- a/dtslint/ts3.5/StateReaderTaskEither.ts
+++ b/dtslint/ts3.5/StateReaderTaskEither.ts
@@ -1,0 +1,12 @@
+import * as _ from '../../src/StateReaderTaskEither'
+import { pipe } from '../../src/pipeable'
+
+//
+// chainW
+//
+
+// $ExpectType StateReaderTaskEither<boolean, { a: string; } & { b: number; }, string | number, number>
+pipe(
+  _.right<boolean, { a: string }, string, string>('a'),
+  _.chainW(() => _.right<boolean, { b: number }, number, number>(1))
+)

--- a/dtslint/ts3.5/TaskEither.ts
+++ b/dtslint/ts3.5/TaskEither.ts
@@ -1,0 +1,23 @@
+import * as _ from '../../src/TaskEither'
+import * as T from '../../src/Task'
+import { pipe } from '../../src/pipeable'
+
+//
+// getOrElseW
+//
+
+// $ExpectType Task<string | null>
+pipe(
+  _.right('a'),
+  _.getOrElseW(() => T.of(null))
+)
+
+//
+// chainW
+//
+
+// $ExpectType TaskEither<string | number, number>
+pipe(
+  _.right<string, string>('a'),
+  _.chainW(() => _.right<number, number>(1))
+)

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -323,6 +323,11 @@ export function getOrElse<E, A>(onLeft: (e: E) => A): (ma: Either<E, A>) => A {
 }
 
 /**
+ * @since 2.6.0
+ */
+export const getOrElseW: <E, B>(onLeft: (e: E) => B) => <A>(ma: Either<E, A>) => A | B = getOrElse as any
+
+/**
  * @since 2.0.0
  */
 export function elem<A>(E: Eq<A>): <E>(a: A, ma: Either<E, A>) => boolean {
@@ -589,6 +594,11 @@ const {
   fromPredicate,
   filterOrElse
 } = pipeable(either)
+
+/**
+ * @since 2.6.0
+ */
+export const chainW: <D, A, B>(f: (a: A) => Either<D, B>) => <E>(ma: Either<E, A>) => Either<E | D, B> = chain as any
 
 export {
   /**

--- a/src/IOEither.ts
+++ b/src/IOEither.ts
@@ -79,6 +79,11 @@ export function getOrElse<E, A>(onLeft: (e: E) => IO<A>): (ma: IOEither<E, A>) =
 }
 
 /**
+ * @since 2.6.0
+ */
+export const getOrElseW: <E, B>(onLeft: (e: E) => IO<B>) => <A>(ma: IOEither<E, A>) => IO<A | B> = getOrElse as any
+
+/**
  * @since 2.0.0
  */
 export function orElse<E, A, M>(onLeft: (e: E) => IOEither<M, A>): (ma: IOEither<E, A>) => IOEither<M, A> {
@@ -218,6 +223,13 @@ const {
   fromPredicate,
   filterOrElse
 } = pipeable(ioEither)
+
+/**
+ * @since 2.6.0
+ */
+export const chainW: <D, A, B>(
+  f: (a: A) => IOEither<D, B>
+) => <E>(ma: IOEither<E, A>) => IOEither<E | D, B> = chain as any
 
 export {
   /**

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -258,6 +258,11 @@ export function getOrElse<A>(onNone: () => A): (ma: Option<A>) => A {
 }
 
 /**
+ * @since 2.6.0
+ */
+export const getOrElseW: <B>(onNone: () => B) => <A>(ma: Option<A>) => A | B = getOrElse as any
+
+/**
  * Returns `true` if `ma` contains `a`
  *
  * @example

--- a/src/Reader.ts
+++ b/src/Reader.ts
@@ -109,6 +109,11 @@ export const reader: Monad2<URI> & Profunctor2<URI> & Category2<URI> & Strong2<U
 
 const { ap, apFirst, apSecond, chain, chainFirst, compose, flatten, map, promap } = pipeable(reader)
 
+/**
+ * @since 2.6.0
+ */
+export const chainW: <Q, A, B>(f: (a: A) => Reader<Q, B>) => <R>(ma: Reader<R, A>) => Reader<R & Q, B> = chain as any
+
 export {
   /**
    * @since 2.0.0

--- a/src/ReaderEither.ts
+++ b/src/ReaderEither.ts
@@ -76,6 +76,13 @@ export function getOrElse<R, E, A>(onLeft: (e: E) => Reader<R, A>): (ma: ReaderE
 }
 
 /**
+ * @since 2.6.0
+ */
+export const getOrElseW: <Q, E, B>(
+  onLeft: (e: E) => Reader<Q, B>
+) => <R, A>(ma: ReaderEither<R, E, A>) => Reader<R & Q, A | B> = getOrElse as any
+
+/**
  * @since 2.0.0
  */
 export function orElse<R, E, A, M>(
@@ -197,6 +204,13 @@ const {
   fromPredicate,
   filterOrElse
 } = pipeable(readerEither)
+
+/**
+ * @since 2.6.0
+ */
+export const chainW: <Q, D, A, B>(
+  f: (a: A) => ReaderEither<Q, D, B>
+) => <R, E>(ma: ReaderEither<R, E, A>) => ReaderEither<R & Q, E | D, B> = chain as any
 
 export {
   /**

--- a/src/ReaderTaskEither.ts
+++ b/src/ReaderTaskEither.ts
@@ -166,6 +166,13 @@ export function getOrElse<R, E, A>(
 }
 
 /**
+ * @since 2.6.0
+ */
+export const getOrElseW: <Q, E, B>(
+  onLeft: (e: E) => ReaderTask<Q, B>
+) => <R, A>(ma: ReaderTaskEither<R, E, A>) => ReaderTask<R & Q, A | B> = getOrElse as any
+
+/**
  * @since 2.0.0
  */
 export function orElse<R, E, A, M>(
@@ -353,6 +360,13 @@ const {
   fromPredicate,
   filterOrElse
 } = pipeable(readerTaskEither)
+
+/**
+ * @since 2.6.0
+ */
+export const chainW: <Q, D, A, B>(
+  f: (a: A) => ReaderTaskEither<Q, D, B>
+) => <R, E>(ma: ReaderTaskEither<R, E, A>) => ReaderTaskEither<R & Q, E | D, B> = chain as any
 
 export {
   /**

--- a/src/StateReaderTaskEither.ts
+++ b/src/StateReaderTaskEither.ts
@@ -306,6 +306,13 @@ const {
   fromPredicate
 } = pipeable(stateReaderTaskEither)
 
+/**
+ * @since 2.6.0
+ */
+export const chainW: <S, Q, D, A, B>(
+  f: (a: A) => StateReaderTaskEither<S, Q, D, B>
+) => <R, E>(ma: StateReaderTaskEither<S, R, E, A>) => StateReaderTaskEither<S, R & Q, E | D, B> = chain as any
+
 export {
   /**
    * @since 2.0.0

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -103,6 +103,13 @@ export function getOrElse<E, A>(onLeft: (e: E) => Task<A>): (ma: TaskEither<E, A
 }
 
 /**
+ * @since 2.6.0
+ */
+export const getOrElseW: <E, B>(
+  onLeft: (e: E) => Task<B>
+) => <A>(ma: TaskEither<E, A>) => Task<A | B> = getOrElse as any
+
+/**
  * @since 2.0.0
  */
 export function orElse<E, A, M>(onLeft: (e: E) => TaskEither<M, A>): (ma: TaskEither<E, A>) => TaskEither<M, A> {
@@ -348,6 +355,13 @@ const {
   fromPredicate,
   filterOrElse
 } = pipeable(taskEither)
+
+/**
+ * @since 2.6.0
+ */
+export const chainW: <D, A, B>(
+  f: (a: A) => TaskEither<D, B>
+) => <E>(ma: TaskEither<E, A>) => TaskEither<E | D, B> = chain as any
 
 export {
   /**


### PR DESCRIPTION
- **New Feature**
  - `Either`
    - add `getOrElseW`
    - add `chainW`
  - `IOEither`
    - add `getOrElseW`
    - add `chainW`
  - `Option`
    - add `getOrElseW`
  - `Reader`
    - add `chainW`
  - `ReaderEither`
    - add `getOrElseW`
    - add `chainW`
  - `ReaderTaskEither`
    - add `getOrElseW`
    - add `chainW`
  - `StateReaderTaskEither`
    - add `chainW`
  - `TaskEither`
    - add `getOrElseW`
    - add `chainW`
