### PR TITLE
Add raise function to throw an error as an expression (to 1.x)

### DIFF
--- a/docs/modules/function.ts.md
+++ b/docs/modules/function.ts.md
@@ -59,6 +59,7 @@ parent: Modules
 - [~~on~~ (function)](#on-function)
 - [~~or~~ (function)](#or-function)
 - [~~pipe~~ (function)](#pipe-function)
+- [raise (function)](#raise-function)
 - [~~toString~~ (function)](#tostring-function)
 - [tuple (function)](#tuple-function)
 - [~~tupleCurried~~ (function)](#tuplecurried-function)
@@ -752,6 +753,16 @@ export function pipe<A, B, C, D, E, F, G, H, I, J>(
 ```
 
 Added in v1.0.0
+
+# raise (function)
+
+**Signature**
+
+```ts
+export function raise<E extends Error>(e: E): never { ... }
+```
+
+Added in v1.19.5
 
 # ~~toString~~ (function)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fp-ts",
-  "version": "1.19.3",
+  "version": "1.19.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2808,7 +2808,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2829,12 +2830,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2849,17 +2852,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2976,7 +2982,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2988,6 +2995,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3002,6 +3010,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3009,12 +3018,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3033,6 +3044,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3113,7 +3125,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3125,6 +3138,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3210,7 +3224,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3246,6 +3261,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3265,6 +3281,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3308,12 +3325,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/function.ts
+++ b/src/function.ts
@@ -500,6 +500,13 @@ export const decrement = (n: number): number => {
 }
 
 /**
+ * @since 1.19.5
+ */
+export function raise<E extends Error>(e: E): never {
+  throw e
+}
+
+/**
  * @since 1.18.0
  */
 export function absurd<A>(_: never): A {

--- a/test/function.ts
+++ b/test/function.ts
@@ -19,6 +19,7 @@ import {
   toString,
   constVoid,
   tupleCurried,
+  raise,
   absurd,
   flow
 } from '../src/function'
@@ -360,6 +361,10 @@ describe('function', () => {
   it('tupleCurried', () => {
     // tslint:disable-next-line: deprecation
     assert.deepStrictEqual(tupleCurried(1)('a'), [1, 'a'])
+  })
+
+  it('raise', () => {
+    assert.throws(() => raise(new Error('raise')))
   })
 
   it('absurd', () => {


### PR DESCRIPTION
The function provided is just a wrapper of `throw` *statement*.