### PR TITLE
Add raise function to throw an error as an expression (to 2.x)

### DIFF
--- a/docs/modules/function.ts.md
+++ b/docs/modules/function.ts.md
@@ -30,6 +30,7 @@ Added in v2.0.0
 - [identity](#identity)
 - [increment](#increment)
 - [not](#not)
+- [raise](#raise)
 - [tuple](#tuple)
 - [tupled](#tupled)
 - [unsafeCoerce](#unsafecoerce)
@@ -323,6 +324,17 @@ export declare function not<A>(predicate: Predicate<A>): Predicate<A>
 ```
 
 Added in v2.0.0
+
+# raise
+
+**Signature**
+
+```ts
+export declare function raise<E extends Error>(e: E): never
+```
+
+Added in v2.6.1
+Throws an error more compositionally.
 
 # tuple
 

--- a/src/function.ts
+++ b/src/function.ts
@@ -269,6 +269,14 @@ export function decrement(n: number): number {
 }
 
 /**
+ * @since 2.6.1
+ * Throws an error more compositionally.
+ */
+export function raise<E extends Error>(e: E): never {
+  throw e
+}
+
+/**
  * @since 2.0.0
  */
 export function absurd<A>(_: never): A {

--- a/test/function.ts
+++ b/test/function.ts
@@ -11,6 +11,7 @@ import {
   increment,
   not,
   unsafeCoerce,
+  raise,
   absurd,
   flow,
   tupled,
@@ -63,6 +64,10 @@ describe('function', () => {
 
   it('decrement', () => {
     assert.deepStrictEqual(decrement(2), 1)
+  })
+
+  it('raise', () => {
+    assert.throws(() => raise(new Error('raise')))
   })
 
   it('absurd', () => {


### PR DESCRIPTION
The function provided is just a wrapper of `throw` *statement*.
I also add it to 1.x (see #1214).