### PR TITLE
Fix IO example

### DIFF
--- a/src/IO.ts
+++ b/src/IO.ts
@@ -43,7 +43,7 @@
  * const logger = (input: number | null) =>
  *  pipe(
  *    fromNullable(input),
- *    fold(log('Received null'), value => log(`Received ${value}`)),
+ *    fold(() => log('Received null'), value => log(`Received ${value}`)),
  *  );
  *
  * logger(123)() // returns undefined and outputs "Received 123" to console


### PR DESCRIPTION
In the example:
```ts
pipe(
    fromNullable(input),
    fold(log('Received null'), value => log(`Received ${value}`)),
  );
```
the left side of the fold needs to return a thunk, otherwise the resulf of the pipe isn't callable.