### PR TITLE
improve performance of sequenceT and sequenceS, fix #1255

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ high state of flux, you're at risk of it changing without notice.
 - **Bug Fix**
   - `These`
     - fix `ap` implementation in `getMonad` function (@gcanti)
+- **Polish**
+  - improve performance of sequenceT and sequenceS, fix #1255 (@gcanti)
 - **New Feature**
   - `function`
     - add `hole` (type hole simulation) (@gcanti)

--- a/perf/Apply/sequenceS.ts
+++ b/perf/Apply/sequenceS.ts
@@ -1,0 +1,45 @@
+import * as Benchmark from 'benchmark'
+import * as A from '../../src/Apply'
+import * as E from '../../src/Either'
+
+/*
+sequenceS (1) x 13,783,868 ops/sec ±1.90% (82 runs sampled)
+sequenceS (2) x 8,007,962 ops/sec ±1.55% (83 runs sampled)
+sequenceS (3) x 4,969,669 ops/sec ±1.50% (86 runs sampled)
+sequenceS (4) x 3,796,491 ops/sec ±0.98% (87 runs sampled)
+sequenceS (5) x 2,973,628 ops/sec ±0.50% (89 runs sampled)
+sequenceS (6) x 1,126,226 ops/sec ±3.36% (84 runs sampled)
+*/
+
+const suite = new Benchmark.Suite()
+
+const sequenceS = A.sequenceS(E.applicativeEither)
+
+suite
+  .add('sequenceS (1)', function () {
+    sequenceS({ a: E.right(1) })
+  })
+  .add('sequenceS (2)', function () {
+    sequenceS({ a: E.right(1), b: E.right(2) })
+  })
+  .add('sequenceS (3)', function () {
+    sequenceS({ a: E.right(1), b: E.right(2), c: E.right(3) })
+  })
+  .add('sequenceS (4)', function () {
+    sequenceS({ a: E.right(1), b: E.right(2), c: E.right(3), d: E.right(4) })
+  })
+  .add('sequenceS (5)', function () {
+    sequenceS({ a: E.right(1), b: E.right(2), c: E.right(3), d: E.right(4), e: E.right(5) })
+  })
+  .add('sequenceS (6)', function () {
+    sequenceS({ a: E.right(1), b: E.right(2), c: E.right(3), d: E.right(4), e: E.right(5), f: E.right(6) })
+  })
+  .on('cycle', function (event: any) {
+    // tslint:disable-next-line: no-console
+    console.log(String(event.target))
+  })
+  .on('complete', function (this: any) {
+    // tslint:disable-next-line: no-console
+    console.log('Fastest is ' + this.filter('fastest').map('name'))
+  })
+  .run({ async: true })

--- a/perf/Apply/sequenceT.ts
+++ b/perf/Apply/sequenceT.ts
@@ -1,0 +1,45 @@
+import * as Benchmark from 'benchmark'
+import * as A from '../../src/Apply'
+import * as E from '../../src/Either'
+
+/*
+sequenceT (1) x 15,737,986 ops/sec ±0.71% (88 runs sampled)
+sequenceT (2) x 8,389,840 ops/sec ±0.65% (86 runs sampled)
+sequenceT (3) x 5,759,450 ops/sec ±0.54% (90 runs sampled)
+sequenceT (4) x 4,307,637 ops/sec ±1.44% (85 runs sampled)
+sequenceT (5) x 3,464,223 ops/sec ±1.75% (85 runs sampled)
+sequenceT (6) x 1,899,460 ops/sec ±2.75% (84 runs sampled)
+*/
+
+const suite = new Benchmark.Suite()
+
+const sequenceT = A.sequenceT(E.applicativeEither)
+
+suite
+  .add('sequenceT (1)', function () {
+    sequenceT(E.right(1))
+  })
+  .add('sequenceT (2)', function () {
+    sequenceT(E.right(1), E.right(2))
+  })
+  .add('sequenceT (3)', function () {
+    sequenceT(E.right(1), E.right(2), E.right(3))
+  })
+  .add('sequenceT (4)', function () {
+    sequenceT(E.right(1), E.right(2), E.right(3), E.right(4))
+  })
+  .add('sequenceT (5)', function () {
+    sequenceT(E.right(1), E.right(2), E.right(3), E.right(4), E.right(5))
+  })
+  .add('sequenceT (6)', function () {
+    sequenceT(E.right(1), E.right(2), E.right(3), E.right(4), E.right(5), E.right(6))
+  })
+  .on('cycle', function (event: any) {
+    // tslint:disable-next-line: no-console
+    console.log(String(event.target))
+  })
+  .on('complete', function (this: any) {
+    // tslint:disable-next-line: no-console
+    console.log('Fastest is ' + this.filter('fastest').map('name'))
+  })
+  .run({ async: true })

--- a/test/Apply.ts
+++ b/test/Apply.ts
@@ -9,8 +9,18 @@ describe('Apply', () => {
   it('sequenceT', () => {
     const sequenceTOption = sequenceT(O.applicativeOption)
     assert.deepStrictEqual(sequenceTOption(O.some(1)), O.some([1]))
-    assert.deepStrictEqual(sequenceTOption(O.some(1), O.some('2')), O.some([1, '2']))
-    assert.deepStrictEqual(sequenceTOption(O.some(1), O.some('2'), O.none), O.none)
+    assert.deepStrictEqual(sequenceTOption(O.some(1), O.some('a')), O.some([1, 'a']))
+    assert.deepStrictEqual(sequenceTOption(O.some(1), O.some('a'), O.some(true)), O.some([1, 'a', true]))
+    assert.deepStrictEqual(sequenceTOption(O.some(1), O.some('a'), O.some(true), O.some(2)), O.some([1, 'a', true, 2]))
+    assert.deepStrictEqual(
+      sequenceTOption(O.some(1), O.some('a'), O.some(true), O.some(2), O.some('b')),
+      O.some([1, 'a', true, 2, 'b'])
+    )
+    assert.deepStrictEqual(
+      sequenceTOption(O.some(1), O.some('a'), O.some(true), O.some(2), O.some('b'), O.some(false)),
+      O.some([1, 'a', true, 2, 'b', false])
+    )
+    assert.deepStrictEqual(sequenceTOption(O.some(1), O.some('a'), O.none), O.none)
 
     // #914
     const a1: ReadonlyArray<number> = [1, 2, 3]
@@ -44,7 +54,23 @@ describe('Apply', () => {
   it('sequenceS', () => {
     const adoOption = sequenceS(O.applicativeOption)
     assert.deepStrictEqual(adoOption({ a: O.some(1) }), O.some({ a: 1 }))
-    assert.deepStrictEqual(adoOption({ a: O.some(1), b: O.some(2) }), O.some({ a: 1, b: 2 }))
+    assert.deepStrictEqual(adoOption({ a: O.some(1), b: O.some('a') }), O.some({ a: 1, b: 'a' }))
+    assert.deepStrictEqual(
+      adoOption({ a: O.some(1), b: O.some('a'), c: O.some(true) }),
+      O.some({ a: 1, b: 'a', c: true })
+    )
+    assert.deepStrictEqual(
+      adoOption({ a: O.some(1), b: O.some('a'), c: O.some(true), d: O.some(2) }),
+      O.some({ a: 1, b: 'a', c: true, d: 2 })
+    )
+    assert.deepStrictEqual(
+      adoOption({ a: O.some(1), b: O.some('a'), c: O.some(true), d: O.some(2), e: O.some('b') }),
+      O.some({ a: 1, b: 'a', c: true, d: 2, e: 'b' })
+    )
+    assert.deepStrictEqual(
+      adoOption({ a: O.some(1), b: O.some('a'), c: O.some(true), d: O.some(2), e: O.some('b'), f: O.some(false) }),
+      O.some({ a: 1, b: 'a', c: true, d: 2, e: 'b', f: false })
+    )
     assert.deepStrictEqual(adoOption({ a: O.some(1), b: O.none }), O.none)
 
     const adoEither = sequenceS(E.applicativeEither)


### PR DESCRIPTION
**Before**

`sequenceT`

```
sequenceT (1) x 3,038,314 ops/sec ±1.06% (86 runs sampled)
sequenceT (2) x 1,486,717 ops/sec ±1.80% (86 runs sampled)
sequenceT (3) x 1,033,153 ops/sec ±0.79% (85 runs sampled)
sequenceT (4) x 799,994 ops/sec ±0.81% (87 runs sampled)
sequenceT (5) x 625,985 ops/sec ±0.80% (90 runs sampled)
```

`sequenceS`

```
sequenceS (1) x 2,723,960 ops/sec ±0.78% (86 runs sampled)
sequenceS (2) x 1,266,164 ops/sec ±0.74% (89 runs sampled)
sequenceS (3) x 809,389 ops/sec ±1.03% (89 runs sampled)
sequenceS (4) x 638,330 ops/sec ±1.43% (86 runs sampled)
sequenceS (5) x 522,986 ops/sec ±1.21% (89 runs sampled)
```

**After**

`sequenceT`

```
sequenceT (1) x 15,737,986 ops/sec ±0.71% (88 runs sampled)
sequenceT (2) x 8,389,840 ops/sec ±0.65% (86 runs sampled)
sequenceT (3) x 5,759,450 ops/sec ±0.54% (90 runs sampled)
sequenceT (4) x 4,307,637 ops/sec ±1.44% (85 runs sampled)
sequenceT (5) x 3,464,223 ops/sec ±1.75% (85 runs sampled)
```

`sequenceS`

```
sequenceS (1) x 13,783,868 ops/sec ±1.90% (82 runs sampled)
sequenceS (2) x 8,007,962 ops/sec ±1.55% (83 runs sampled)
sequenceS (3) x 4,969,669 ops/sec ±1.50% (86 runs sampled)
sequenceS (4) x 3,796,491 ops/sec ±0.98% (87 runs sampled)
sequenceS (5) x 2,973,628 ops/sec ±0.50% (89 runs sampled)
```

/cc @pbadenski