### PR TITLE
Foldable: add `toArray`

### DIFF
--- a/docs/modules/Foldable.ts.md
+++ b/docs/modules/Foldable.ts.md
@@ -32,6 +32,7 @@ Added in v2.0.0
   - [foldM](#foldm)
   - [getFoldableComposition](#getfoldablecomposition)
   - [intercalate](#intercalate)
+  - [toArray](#toArray)
   - [traverse\_](#traverse_)
 
 ---
@@ -398,6 +399,40 @@ assert.strictEqual(intercalate(monoidString, tree)('|', t), 'a|b|c|d')
 ```
 
 Added in v2.0.0
+
+## toArray
+
+Transforms a foldable into an array.
+
+**Signature**
+
+```ts
+export function toArray<F extends URIS4>(F: Foldable4<F>): <S, R, E, A>(fa: Kind4<F, S, R, E, A>) => Array<A>
+export function toArray<F extends URIS3>(F: Foldable3<F>): <R, E, A>(fa: Kind3<F, R, E, A>) => Array<A>
+export function toArray<F extends URIS3, E>(F: Foldable3C<F, E>): <R, A>(fa: Kind3<F, R, E, A>) => Array<A>
+export function toArray<F extends URIS2>(F: Foldable2<F>): <E, A>(fa: Kind2<F, E, A>) => Array<A>
+export function toArray<F extends URIS2, E>(F: Foldable2C<F, E>): <A>(fa: Kind2<F, E, A>) => Array<A>
+export function toArray<F extends URIS>(F: Foldable1<F>): <A>(fa: Kind<F, A>) => Array<A>
+export function toArray<F>(F: Foldable<F>): <A>(fa: HKT<F, A>) => Array<A>
+export function toArray<F>(F: Foldable<F>): <A>(fa: HKT<F, A>) => Array<A> { ... }
+```
+
+**Example**
+
+```ts
+import { toArray } from 'fp-ts/lib/Foldable2v'
+import { option, some, none } from 'fp-ts/lib/Option'
+import { Tree, tree } from 'fp-ts/lib/Tree'
+
+const optionToArray = toArray(option)
+assert.deepStrictEqual(optionToArray(some(1)), [1])
+assert.deepStrictEqual(optionToArray(none), [])
+
+const t = new Tree(1, [new Tree(2, []), new Tree(3, []), new Tree(4, [])])
+assert.deepStrictEqual(toArray(tree)(t), [1, 2, 3, 4])
+```
+
+Added in v2.7.1
 
 ## traverse\_
 

--- a/docs/modules/Foldable.ts.md
+++ b/docs/modules/Foldable.ts.md
@@ -33,6 +33,7 @@ Added in v2.0.0
   - [getFoldableComposition](#getfoldablecomposition)
   - [intercalate](#intercalate)
   - [toArray](#toArray)
+  - [toReadOnlyArray](#toReadOnlyArray)
   - [traverse\_](#traverse_)
 
 ---

--- a/docs/modules/Foldable.ts.md
+++ b/docs/modules/Foldable.ts.md
@@ -32,8 +32,7 @@ Added in v2.0.0
   - [foldM](#foldm)
   - [getFoldableComposition](#getfoldablecomposition)
   - [intercalate](#intercalate)
-  - [toArray](#toArray)
-  - [toReadOnlyArray](#toReadOnlyArray)
+  - [toArray](#toarray)
   - [traverse\_](#traverse_)
 
 ---
@@ -403,71 +402,35 @@ Added in v2.0.0
 
 ## toArray
 
-Transforms a foldable into an array.
+Transforms a `Foldable` into a read-only array.
 
 **Signature**
 
 ```ts
-export function toArray<F extends URIS4>(F: Foldable4<F>): <S, R, E, A>(fa: Kind4<F, S, R, E, A>) => Array<A>
-export function toArray<F extends URIS3>(F: Foldable3<F>): <R, E, A>(fa: Kind3<F, R, E, A>) => Array<A>
-export function toArray<F extends URIS3, E>(F: Foldable3C<F, E>): <R, A>(fa: Kind3<F, R, E, A>) => Array<A>
-export function toArray<F extends URIS2>(F: Foldable2<F>): <E, A>(fa: Kind2<F, E, A>) => Array<A>
-export function toArray<F extends URIS2, E>(F: Foldable2C<F, E>): <A>(fa: Kind2<F, E, A>) => Array<A>
-export function toArray<F extends URIS>(F: Foldable1<F>): <A>(fa: Kind<F, A>) => Array<A>
-export function toArray<F>(F: Foldable<F>): <A>(fa: HKT<F, A>) => Array<A>
-export function toArray<F>(F: Foldable<F>): <A>(fa: HKT<F, A>) => Array<A> { ... }
+export declare function toArray<F extends URIS4>(
+  F: Foldable4<F>
+): <S, R, E, A>(fa: Kind4<F, S, R, E, A>) => ReadonlyArray<A>
+export declare function toArray<F extends URIS3>(F: Foldable3<F>): <R, E, A>(fa: Kind3<F, R, E, A>) => ReadonlyArray<A>
+export declare function toArray<F extends URIS3, E>(
+  F: Foldable3C<F, E>
+): <R, A>(fa: Kind3<F, R, E, A>) => ReadonlyArray<A>
+export declare function toArray<F extends URIS2>(F: Foldable2<F>): <E, A>(fa: Kind2<F, E, A>) => ReadonlyArray<A>
+export declare function toArray<F extends URIS2, E>(F: Foldable2C<F, E>): <A>(fa: Kind2<F, E, A>) => ReadonlyArray<A>
+export declare function toArray<F extends URIS>(F: Foldable1<F>): <A>(fa: Kind<F, A>) => ReadonlyArray<A>
+export declare function toArray<F>(F: Foldable<F>): <A>(fa: HKT<F, A>) => ReadonlyArray<A>
 ```
 
 **Example**
 
 ```ts
 import { toArray } from 'fp-ts/lib/Foldable'
-import { option, some, none } from 'fp-ts/lib/Option'
-import { Tree, tree } from 'fp-ts/lib/Tree'
+import { tree, make } from 'fp-ts/lib/Tree'
 
-const optionToArray = toArray(option)
-assert.deepStrictEqual(optionToArray(some(1)), [1])
-assert.deepStrictEqual(optionToArray(none), [])
-
-const t = new Tree(1, [new Tree(2, []), new Tree(3, []), new Tree(4, [])])
+const t = make(1, [make(2, []), make(3, []), make(4, [])])
 assert.deepStrictEqual(toArray(tree)(t), [1, 2, 3, 4])
 ```
 
-Added in v2.7.1
-
-## toReadOnlyArray
-
-Transforms a foldable into a read-only array.
-
-**Signature**
-
-```ts
-export function toReadOnlyArray<F extends URIS4>(F: Foldable4<F>): <S, R, E, A>(fa: Kind4<F, S, R, E, A>) => ReadOnlyArray<A>
-export function toReadOnlyArray<F extends URIS3>(F: Foldable3<F>): <R, E, A>(fa: Kind3<F, R, E, A>) => ReadOnlyArray<A>
-export function toReadOnlyArray<F extends URIS3, E>(F: Foldable3C<F, E>): <R, A>(fa: Kind3<F, R, E, A>) => ReadOnlyArray<A>
-export function toReadOnlyArray<F extends URIS2>(F: Foldable2<F>): <E, A>(fa: Kind2<F, E, A>) => ReadOnlyArray<A>
-export function toReadOnlyArray<F extends URIS2, E>(F: Foldable2C<F, E>): <A>(fa: Kind2<F, E, A>) => ReadOnlyArray<A>
-export function toReadOnlyArray<F extends URIS>(F: Foldable1<F>): <A>(fa: Kind<F, A>) => ReadOnlyArray<A>
-export function toReadOnlyArray<F>(F: Foldable<F>): <A>(fa: HKT<F, A>) => ReadOnlyArray<A>
-export function toReadOnlyArray<F>(F: Foldable<F>): <A>(fa: HKT<F, A>) => ReadOnlyArray<A> { ... }
-```
-
-**Example**
-
-```ts
-import { toReadOnlyArray } from 'fp-ts/lib/Foldable'
-import { option, some, none } from 'fp-ts/lib/Option'
-import { Tree, tree } from 'fp-ts/lib/Tree'
-
-const optionToRA = toReadOnlyArray(option)
-assert.deepStrictEqual(optionToRA(some(1)), [1])
-assert.deepStrictEqual(optionToRA(none), [])
-
-const t = new Tree(1, [new Tree(2, []), new Tree(3, []), new Tree(4, [])])
-assert.deepStrictEqual(optionToRA(tree)(t), [1, 2, 3, 4])
-```
-
-Added in v2.7.1
+Added in v2.8.0
 
 ## traverse\_
 

--- a/docs/modules/Foldable.ts.md
+++ b/docs/modules/Foldable.ts.md
@@ -436,7 +436,7 @@ Added in v2.7.1
 
 ## toReadOnlyArray
 
-Transforms a foldable into an read-only array.
+Transforms a foldable into a read-only array.
 
 **Signature**
 

--- a/docs/modules/Foldable.ts.md
+++ b/docs/modules/Foldable.ts.md
@@ -420,7 +420,7 @@ export function toArray<F>(F: Foldable<F>): <A>(fa: HKT<F, A>) => Array<A> { ...
 **Example**
 
 ```ts
-import { toArray } from 'fp-ts/lib/Foldable2v'
+import { toArray } from 'fp-ts/lib/Foldable'
 import { option, some, none } from 'fp-ts/lib/Option'
 import { Tree, tree } from 'fp-ts/lib/Tree'
 
@@ -430,6 +430,40 @@ assert.deepStrictEqual(optionToArray(none), [])
 
 const t = new Tree(1, [new Tree(2, []), new Tree(3, []), new Tree(4, [])])
 assert.deepStrictEqual(toArray(tree)(t), [1, 2, 3, 4])
+```
+
+Added in v2.7.1
+
+## toReadOnlyArray
+
+Transforms a foldable into an read-only array.
+
+**Signature**
+
+```ts
+export function toReadOnlyArray<F extends URIS4>(F: Foldable4<F>): <S, R, E, A>(fa: Kind4<F, S, R, E, A>) => ReadOnlyArray<A>
+export function toReadOnlyArray<F extends URIS3>(F: Foldable3<F>): <R, E, A>(fa: Kind3<F, R, E, A>) => ReadOnlyArray<A>
+export function toReadOnlyArray<F extends URIS3, E>(F: Foldable3C<F, E>): <R, A>(fa: Kind3<F, R, E, A>) => ReadOnlyArray<A>
+export function toReadOnlyArray<F extends URIS2>(F: Foldable2<F>): <E, A>(fa: Kind2<F, E, A>) => ReadOnlyArray<A>
+export function toReadOnlyArray<F extends URIS2, E>(F: Foldable2C<F, E>): <A>(fa: Kind2<F, E, A>) => ReadOnlyArray<A>
+export function toReadOnlyArray<F extends URIS>(F: Foldable1<F>): <A>(fa: Kind<F, A>) => ReadOnlyArray<A>
+export function toReadOnlyArray<F>(F: Foldable<F>): <A>(fa: HKT<F, A>) => ReadOnlyArray<A>
+export function toReadOnlyArray<F>(F: Foldable<F>): <A>(fa: HKT<F, A>) => ReadOnlyArray<A> { ... }
+```
+
+**Example**
+
+```ts
+import { toReadOnlyArray } from 'fp-ts/lib/Foldable'
+import { option, some, none } from 'fp-ts/lib/Option'
+import { Tree, tree } from 'fp-ts/lib/Tree'
+
+const optionToRA = toReadOnlyArray(option)
+assert.deepStrictEqual(optionToRA(some(1)), [1])
+assert.deepStrictEqual(optionToRA(none), [])
+
+const t = new Tree(1, [new Tree(2, []), new Tree(3, []), new Tree(4, [])])
+assert.deepStrictEqual(optionToRA(tree)(t), [1, 2, 3, 4])
 ```
 
 Added in v2.7.1

--- a/src/Foldable.ts
+++ b/src/Foldable.ts
@@ -298,7 +298,7 @@ export function intercalate<M, F>(M: Monoid<M>, F: Foldable<F>): (sep: M, fm: HK
 
 // tslint:disable: readonly-array
 /**
- * Transforms a foldable into an array
+ * Transforms a foldable into an array.
  *
  * @example
  * import { toArray } from 'fp-ts/lib/Foldable'
@@ -326,7 +326,7 @@ export function toArray<F>(F: Foldable<F>): <A>(fa: HKT<F, A>) => Array<A> {
 // tslint:enable: readonly-array
 
 /**
- * Transforms a foldable into an array
+ * Transforms a foldable into a read-only array.
  *
  * @example
  * import { toReadOnlyArray } from 'fp-ts/lib/Foldable'

--- a/src/Foldable.ts
+++ b/src/Foldable.ts
@@ -6,7 +6,6 @@ import { constant } from './function'
 import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3, URIS4, Kind4 } from './HKT'
 import { Monad, Monad1, Monad2, Monad2C, Monad3, Monad3C } from './Monad'
 import { Monoid } from './Monoid'
-import { getMonoid } from './ReadonlyArray'
 
 /**
  * @category type classes
@@ -296,9 +295,8 @@ export function intercalate<M, F>(M: Monoid<M>, F: Foldable<F>): (sep: M, fm: HK
   }
 }
 
-// tslint:disable: readonly-array
 /**
- * Transforms a foldable into an array.
+ * Transforms a `Foldable` into a read-only array.
  *
  * @example
  * import { toArray } from 'fp-ts/lib/Foldable'
@@ -307,49 +305,22 @@ export function intercalate<M, F>(M: Monoid<M>, F: Foldable<F>): (sep: M, fm: HK
  * const t = make(1, [make(2, []), make(3, []), make(4, [])])
  * assert.deepStrictEqual(toArray(tree)(t), [1, 2, 3, 4])
  *
- * @since 2.7.1
+ * @since 2.8.0
  */
-export function toArray<F extends URIS4>(F: Foldable4<F>): <S, R, E, A>(fa: Kind4<F, S, R, E, A>) => Array<A>
-export function toArray<F extends URIS3>(F: Foldable3<F>): <R, E, A>(fa: Kind3<F, R, E, A>) => Array<A>
-export function toArray<F extends URIS3, E>(F: Foldable3C<F, E>): <R, A>(fa: Kind3<F, R, E, A>) => Array<A>
-export function toArray<F extends URIS2>(F: Foldable2<F>): <E, A>(fa: Kind2<F, E, A>) => Array<A>
-export function toArray<F extends URIS2, E>(F: Foldable2C<F, E>): <A>(fa: Kind2<F, E, A>) => Array<A>
-export function toArray<F extends URIS>(F: Foldable1<F>): <A>(fa: Kind<F, A>) => Array<A>
-export function toArray<F>(F: Foldable<F>): <A>(fa: HKT<F, A>) => Array<A>
-export function toArray<F>(F: Foldable<F>): <A>(fa: HKT<F, A>) => Array<A> {
+export function toArray<F extends URIS4>(F: Foldable4<F>): <S, R, E, A>(fa: Kind4<F, S, R, E, A>) => ReadonlyArray<A>
+export function toArray<F extends URIS3>(F: Foldable3<F>): <R, E, A>(fa: Kind3<F, R, E, A>) => ReadonlyArray<A>
+export function toArray<F extends URIS3, E>(F: Foldable3C<F, E>): <R, A>(fa: Kind3<F, R, E, A>) => ReadonlyArray<A>
+export function toArray<F extends URIS2>(F: Foldable2<F>): <E, A>(fa: Kind2<F, E, A>) => ReadonlyArray<A>
+export function toArray<F extends URIS2, E>(F: Foldable2C<F, E>): <A>(fa: Kind2<F, E, A>) => ReadonlyArray<A>
+export function toArray<F extends URIS>(F: Foldable1<F>): <A>(fa: Kind<F, A>) => ReadonlyArray<A>
+export function toArray<F>(F: Foldable<F>): <A>(fa: HKT<F, A>) => ReadonlyArray<A>
+export function toArray<F>(F: Foldable<F>): <A>(fa: HKT<F, A>) => ReadonlyArray<A> {
   return <A>(fa: HKT<F, A>) =>
-    F.reduce<A, Array<A>>(fa, [], (acc, a) => {
+    // tslint:disable-next-line: readonly-array
+    F.reduce(fa, [], (acc: Array<A>, a) => {
       acc.push(a)
       return acc
     })
-}
-// tslint:enable: readonly-array
-
-/**
- * Transforms a foldable into a read-only array.
- *
- * @example
- * import { toReadOnlyArray } from 'fp-ts/lib/Foldable'
- * import { tree, make } from 'fp-ts/lib/Tree'
- *
- * const t = make(1, [make(2, []), make(3, []), make(4, [])])
- * assert.deepStrictEqual(toReadOnlyArray(tree)(t), [1, 2, 3, 4])
- *
- * @since 2.7.1
- */
-export function toReadOnlyArray<F extends URIS4>(
-  F: Foldable4<F>
-): <S, R, E, A>(fa: Kind4<F, S, R, E, A>) => ReadonlyArray<A>
-export function toReadOnlyArray<F extends URIS3>(F: Foldable3<F>): <R, E, A>(fa: Kind3<F, R, E, A>) => ReadonlyArray<A>
-export function toReadOnlyArray<F extends URIS3, E>(
-  F: Foldable3C<F, E>
-): <R, A>(fa: Kind3<F, R, E, A>) => ReadonlyArray<A>
-export function toReadOnlyArray<F extends URIS2>(F: Foldable2<F>): <E, A>(fa: Kind2<F, E, A>) => ReadonlyArray<A>
-export function toReadOnlyArray<F extends URIS2, E>(F: Foldable2C<F, E>): <A>(fa: Kind2<F, E, A>) => ReadonlyArray<A>
-export function toReadOnlyArray<F extends URIS>(F: Foldable1<F>): <A>(fa: Kind<F, A>) => ReadonlyArray<A>
-export function toReadOnlyArray<F>(F: Foldable<F>): <A>(fa: HKT<F, A>) => ReadonlyArray<A>
-export function toReadOnlyArray<F>(F: Foldable<F>): <A>(fa: HKT<F, A>) => ReadonlyArray<A> {
-  return <A>(fa: HKT<F, A>) => F.foldMap(getMonoid<A>())(fa, (a) => [a])
 }
 
 // TODO: remove in v3

--- a/src/Foldable.ts
+++ b/src/Foldable.ts
@@ -295,6 +295,35 @@ export function intercalate<M, F>(M: Monoid<M>, F: Foldable<F>): (sep: M, fm: HK
   }
 }
 
+// tslint:disable: readonly-array
+/**
+ * Transforms a foldable into an array
+ *
+ * @example
+ * import { toArray } from 'fp-ts/lib/Foldable'
+ * import { tree, make } from 'fp-ts/lib/Tree'
+ *
+ * const t = make(1, [make(2, []), make(3, []), make(4, [])])
+ * assert.deepStrictEqual(toArray(tree)(t), [1, 2, 3, 4])
+ *
+ * @since 2.7.1
+ */
+export function toArray<F extends URIS4>(F: Foldable4<F>): <S, R, E, A>(fa: Kind4<F, S, R, E, A>) => Array<A>
+export function toArray<F extends URIS3>(F: Foldable3<F>): <R, E, A>(fa: Kind3<F, R, E, A>) => Array<A>
+export function toArray<F extends URIS3, E>(F: Foldable3C<F, E>): <R, A>(fa: Kind3<F, R, E, A>) => Array<A>
+export function toArray<F extends URIS2>(F: Foldable2<F>): <E, A>(fa: Kind2<F, E, A>) => Array<A>
+export function toArray<F extends URIS2, E>(F: Foldable2C<F, E>): <A>(fa: Kind2<F, E, A>) => Array<A>
+export function toArray<F extends URIS>(F: Foldable1<F>): <A>(fa: Kind<F, A>) => Array<A>
+export function toArray<F>(F: Foldable<F>): <A>(fa: HKT<F, A>) => Array<A>
+export function toArray<F>(F: Foldable<F>): <A>(fa: HKT<F, A>) => Array<A> {
+  return <A>(fa: HKT<F, A>) =>
+    F.reduce<A, Array<A>>(fa, [], (acc, a) => {
+      acc.push(a)
+      return acc
+    })
+}
+// tslint:enable: readonly-array
+
 // TODO: remove in v3
 /**
  * Traverse a data structure, performing some effects encoded by an `Applicative` functor at each value, ignoring the

--- a/src/Foldable.ts
+++ b/src/Foldable.ts
@@ -6,6 +6,7 @@ import { constant } from './function'
 import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3, URIS4, Kind4 } from './HKT'
 import { Monad, Monad1, Monad2, Monad2C, Monad3, Monad3C } from './Monad'
 import { Monoid } from './Monoid'
+import { getMonoid } from './ReadonlyArray'
 
 /**
  * @category type classes
@@ -323,6 +324,33 @@ export function toArray<F>(F: Foldable<F>): <A>(fa: HKT<F, A>) => Array<A> {
     })
 }
 // tslint:enable: readonly-array
+
+/**
+ * Transforms a foldable into an array
+ *
+ * @example
+ * import { toReadOnlyArray } from 'fp-ts/lib/Foldable'
+ * import { tree, make } from 'fp-ts/lib/Tree'
+ *
+ * const t = make(1, [make(2, []), make(3, []), make(4, [])])
+ * assert.deepStrictEqual(toReadOnlyArray(tree)(t), [1, 2, 3, 4])
+ *
+ * @since 2.7.1
+ */
+export function toReadOnlyArray<F extends URIS4>(
+  F: Foldable4<F>
+): <S, R, E, A>(fa: Kind4<F, S, R, E, A>) => ReadonlyArray<A>
+export function toReadOnlyArray<F extends URIS3>(F: Foldable3<F>): <R, E, A>(fa: Kind3<F, R, E, A>) => ReadonlyArray<A>
+export function toReadOnlyArray<F extends URIS3, E>(
+  F: Foldable3C<F, E>
+): <R, A>(fa: Kind3<F, R, E, A>) => ReadonlyArray<A>
+export function toReadOnlyArray<F extends URIS2>(F: Foldable2<F>): <E, A>(fa: Kind2<F, E, A>) => ReadonlyArray<A>
+export function toReadOnlyArray<F extends URIS2, E>(F: Foldable2C<F, E>): <A>(fa: Kind2<F, E, A>) => ReadonlyArray<A>
+export function toReadOnlyArray<F extends URIS>(F: Foldable1<F>): <A>(fa: Kind<F, A>) => ReadonlyArray<A>
+export function toReadOnlyArray<F>(F: Foldable<F>): <A>(fa: HKT<F, A>) => ReadonlyArray<A>
+export function toReadOnlyArray<F>(F: Foldable<F>): <A>(fa: HKT<F, A>) => ReadonlyArray<A> {
+  return <A>(fa: HKT<F, A>) => F.foldMap(getMonoid<A>())(fa, (a) => [a])
+}
 
 // TODO: remove in v3
 /**

--- a/test/Foldable.ts
+++ b/test/Foldable.ts
@@ -4,7 +4,7 @@ import * as I from '../src/IO'
 import * as O from '../src/Option'
 import * as T from '../src/Tree'
 import { monoidString } from '../src/Monoid'
-import { foldM, getFoldableComposition, intercalate, traverse_, toArray, toReadOnlyArray } from '../src/Foldable'
+import { foldM, getFoldableComposition, intercalate, traverse_, toArray } from '../src/Foldable'
 
 export const ArrayOptionURI = 'ArrayOption'
 
@@ -54,17 +54,6 @@ describe('Foldable', () => {
 
     // Tree
     const treeToArray = toArray(T.tree)
-    assert.deepStrictEqual(treeToArray(T.make(1, [T.make(2, []), T.make(3, []), T.make(4, [])])), [1, 2, 3, 4])
-  })
-
-  it('toReadOnlyArray', () => {
-    // Option
-    const optionToRA = toReadOnlyArray(O.option)
-    assert.deepStrictEqual(optionToRA(O.some(1)), [1])
-    assert.deepStrictEqual(optionToRA(O.none), [])
-
-    // Tree
-    const treeToArray = toReadOnlyArray(T.tree)
     assert.deepStrictEqual(treeToArray(T.make(1, [T.make(2, []), T.make(3, []), T.make(4, [])])), [1, 2, 3, 4])
   })
 

--- a/test/Foldable.ts
+++ b/test/Foldable.ts
@@ -1,9 +1,10 @@
 import * as assert from 'assert'
 import * as A from '../src/ReadonlyArray'
-import { foldM, getFoldableComposition, intercalate, traverse_ } from '../src/Foldable'
 import * as I from '../src/IO'
-import { monoidString } from '../src/Monoid'
 import * as O from '../src/Option'
+import * as T from '../src/Tree'
+import { monoidString } from '../src/Monoid'
+import { foldM, getFoldableComposition, intercalate, traverse_, toArray } from '../src/Foldable'
 
 export const ArrayOptionURI = 'ArrayOption'
 
@@ -43,6 +44,17 @@ describe('Foldable', () => {
 
   it('intercalate', () => {
     assert.deepStrictEqual(intercalate(monoidString, A.Foldable)(',', ['a', 'b', 'c']), 'a,b,c')
+  })
+
+  it('toArray', () => {
+    // Option
+    const optionToArray = toArray(O.option)
+    assert.deepStrictEqual(optionToArray(O.some(1)), [1])
+    assert.deepStrictEqual(optionToArray(O.none), [])
+
+    // Tree
+    const treeToArray = toArray(T.tree)
+    assert.deepStrictEqual(treeToArray(T.make(1, [T.make(2, []), T.make(3, []), T.make(4, [])])), [1, 2, 3, 4])
   })
 
   it('traverse_', () => {

--- a/test/Foldable.ts
+++ b/test/Foldable.ts
@@ -4,7 +4,7 @@ import * as I from '../src/IO'
 import * as O from '../src/Option'
 import * as T from '../src/Tree'
 import { monoidString } from '../src/Monoid'
-import { foldM, getFoldableComposition, intercalate, traverse_, toArray } from '../src/Foldable'
+import { foldM, getFoldableComposition, intercalate, traverse_, toArray, toReadOnlyArray } from '../src/Foldable'
 
 export const ArrayOptionURI = 'ArrayOption'
 
@@ -54,6 +54,17 @@ describe('Foldable', () => {
 
     // Tree
     const treeToArray = toArray(T.tree)
+    assert.deepStrictEqual(treeToArray(T.make(1, [T.make(2, []), T.make(3, []), T.make(4, [])])), [1, 2, 3, 4])
+  })
+
+  it('toReadOnlyArray', () => {
+    // Option
+    const optionToRA = toReadOnlyArray(O.option)
+    assert.deepStrictEqual(optionToRA(O.some(1)), [1])
+    assert.deepStrictEqual(optionToRA(O.none), [])
+
+    // Tree
+    const treeToArray = toReadOnlyArray(T.tree)
     assert.deepStrictEqual(treeToArray(T.make(1, [T.make(2, []), T.make(3, []), T.make(4, [])])), [1, 2, 3, 4])
   })
 


### PR DESCRIPTION
👋 

I saw an open PR, "Added Option.toArray" (https://github.com/gcanti/fp-ts/pull/1155), and noticed @gcanti recommended instead adding `toArray` to Foldable.

I went ahead and added it. However, I'm not 100% sure about the implementation.

In 2.x+, `Array` is deprecated in favor of `ReadOnlyArray`, but the original implementation of `toArray` uses a combination of `reduce` and `arr.push`.

**Possible problem**: `.push` does not exist on `ReadOnlyArray` since it mutates the array in place. This method is probably faster, but it might not desirable in the 2.x+ world.

Would it make sense to add another instance, `toReadOnlyArray`?

**Update**: I went ahead and also added a `toReadOnlyArray` instance. There appeared to be some prior art in the Map, Set, and Record modules.

I'm open to feedback and/or edits.

---
- [x] Fork [the repository](https://github.com/gcanti/fp-ts) and create your branch from `master`.
- [x] Run `npm install` in the repository root.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Ensure the test suite passes (`npm test`).