### PR TITLE
doc: add type signature for `TaskEither` in module intro

### DIFF
--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -1,4 +1,8 @@
 /**
+ * ```ts
+ * interface TaskEither<E, A> extends Task<Either<E, A>> {}
+ * ```
+ *
  * `TaskEither<E, A>` represents an asynchronous computation that either yields a value of type `A` or fails yielding an
  * error of type `E`. If you want to represent an asynchronous computation that never fails, please see `Task`.
  *


### PR DESCRIPTION
Thanks for this excellent and remarkably complete library!

This adds the type signature of `TaskEither` to the introductory
paragraph on the `TaskEither` page in a way that aligns with the `Task`
docs, which also have the signature at the top.

I'm opening this because when I first used `TaskEither`, I hadn't used
`Task` yet, either, and I didn't realize how to get the promise out of
it. I started out by looking for some kind of destructor method rather
than thinking it was callable. It was only when I looked at the `Task`
documentation that I realized it should be callable.

It's possible that if the top of the file had directed me that it was
an extension of `Task`, I might have figured it out sooner. I should
have thought to look down around line 860, where the existing docs
describe the signature, but I did not. Of course, it's also possible I
wouldn't have, so no worries if you don't feel like this is worth
adding.