### PR TITLE
Feature/docs

### DIFF
--- a/docs/modules/Either.ts.md
+++ b/docs/modules/Either.ts.md
@@ -286,10 +286,26 @@ Added in v2.0.0
 
 ## reduce
 
+Left-associative fold of a structure.
+
 **Signature**
 
 ```ts
 export declare const reduce: <A, B>(b: B, f: (b: B, a: A) => B) => <E>(fa: Either<E, A>) => B
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/function'
+import * as E from 'fp-ts/Either'
+
+const empty = 'prefix'
+const concat = (a: string, b: string) => `${a}:${b}`
+
+assert.deepStrictEqual(pipe(E.right('a'), E.reduce(empty, concat)), 'prefix:a')
+
+assert.deepStrictEqual(pipe(E.left('e'), E.reduce(empty, concat)), 'prefix')
 ```
 
 Added in v2.0.0

--- a/docs/modules/Either.ts.md
+++ b/docs/modules/Either.ts.md
@@ -404,10 +404,22 @@ Added in v2.6.0
 
 ## flatten
 
+The `flatten` function is the conventional monad join operator. It is used to remove one level of monadic structure, projecting its bound argument into the outer level.
+
 **Signature**
 
 ```ts
 export declare const flatten: <E, A>(mma: Either<E, Either<E, A>>) => Either<E, A>
+```
+
+**Example**
+
+```ts
+import * as E from 'fp-ts/Either'
+
+assert.deepStrictEqual(E.flatten(E.right(E.right('a'))), E.right('a'))
+assert.deepStrictEqual(E.flatten(E.right(E.left('e'))), E.left('e'))
+assert.deepStrictEqual(E.flatten(E.left('e')), E.left('e'))
 ```
 
 Added in v2.0.0

--- a/docs/modules/Either.ts.md
+++ b/docs/modules/Either.ts.md
@@ -464,10 +464,25 @@ Added in v2.6.3
 
 ## traverse
 
+Map each element of a structure to an action, evaluate these actions from left to right, and collect the results.
+
 **Signature**
 
 ```ts
 export declare const traverse: PipeableTraverse2<'Either'>
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/function'
+import * as A from 'fp-ts/Array'
+import * as E from 'fp-ts/Either'
+import * as O from 'fp-ts/Option'
+
+assert.deepStrictEqual(pipe(E.right(['a']), E.traverse(O.option)(A.head)), O.some(E.right('a')))
+
+assert.deepStrictEqual(pipe(E.right([]), E.traverse(O.option)(A.head)), O.none)
 ```
 
 Added in v2.6.3

--- a/docs/modules/Either.ts.md
+++ b/docs/modules/Either.ts.md
@@ -140,10 +140,20 @@ Added in v2.0.0
 
 ## of
 
+Lift a value.
+
 **Signature**
 
 ```ts
 export declare const of: <E, A>(a: A) => Either<E, A>
+```
+
+**Example**
+
+```ts
+import * as E from 'fp-ts/Either'
+
+assert.deepStrictEqual(E.of('a'), E.right('a'))
 ```
 
 Added in v2.7.0

--- a/docs/modules/Either.ts.md
+++ b/docs/modules/Either.ts.md
@@ -312,10 +312,26 @@ Added in v2.0.0
 
 ## reduceRight
 
+Right-associative fold of a structure.
+
 **Signature**
 
 ```ts
 export declare const reduceRight: <A, B>(b: B, f: (a: A, b: B) => B) => <E>(fa: Either<E, A>) => B
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/function'
+import * as E from 'fp-ts/Either'
+
+const empty = 'postfix'
+const concat = (a: string, b: string) => `${a}:${b}`
+
+assert.deepStrictEqual(pipe(E.right('a'), E.reduceRight(empty, concat)), 'a:postfix')
+
+assert.deepStrictEqual(pipe(E.left('e'), E.reduceRight(empty, concat)), 'postfix')
 ```
 
 Added in v2.0.0

--- a/docs/modules/Either.ts.md
+++ b/docs/modules/Either.ts.md
@@ -440,10 +440,24 @@ Added in v2.6.3
 
 ## sequence
 
+Evaluate each monadic action in the structure from left to right, and collect the results.
+
 **Signature**
 
 ```ts
 export declare const sequence: Sequence2<'Either'>
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/function'
+import * as E from 'fp-ts/Either'
+import * as O from 'fp-ts/Option'
+
+assert.deepStrictEqual(pipe(E.right(O.some('a')), E.sequence(O.option)), O.some(E.right('a')))
+
+assert.deepStrictEqual(pipe(E.right(O.none), E.sequence(O.option)), O.none)
 ```
 
 Added in v2.6.3

--- a/docs/modules/Either.ts.md
+++ b/docs/modules/Either.ts.md
@@ -260,10 +260,26 @@ Added in v2.0.0
 
 ## foldMap
 
+Map each element of the structure to a monoid, and combine the results.
+
 **Signature**
 
 ```ts
 export declare const foldMap: <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => <E>(fa: Either<E, A>) => M
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/function'
+import * as E from 'fp-ts/Either'
+import { monoidString } from 'fp-ts/Monoid'
+
+const yell = (a: string) => `${a}!`
+
+assert.deepStrictEqual(pipe(E.right('a'), E.foldMap(monoidString)(yell)), 'a!')
+
+assert.deepStrictEqual(pipe(E.left('e'), E.foldMap(monoidString)(yell)), monoidString.empty)
 ```
 
 Added in v2.0.0

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -609,6 +609,24 @@ export const reduceRight: <A, B>(b: B, f: (a: A, b: B) => B) => <E>(fa: Either<E
   isLeft(fa) ? b : f(fa.right, b)
 
 /**
+ * Map each element of a structure to an action, evaluate these actions from left to right, and collect the results.
+ *
+ * @example
+ * import { pipe } from 'fp-ts/function'
+ * import * as A from 'fp-ts/Array'
+ * import * as E from 'fp-ts/Either'
+ * import * as O from 'fp-ts/Option'
+ *
+ * assert.deepStrictEqual(
+ *   pipe(E.right(['a']), E.traverse(O.option)(A.head)),
+ *   O.some(E.right('a')),
+ *  )
+ *
+ * assert.deepStrictEqual(
+ *   pipe(E.right([]), E.traverse(O.option)(A.head)),
+ *   O.none,
+ * )
+ *
  * @category Traversable
  * @since 2.6.3
  */

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -431,6 +431,13 @@ export const apSecond = <E, B>(fb: Either<E, B>): (<A>(fa: Either<E, A>) => Eith
   )
 
 /**
+ * Lift a value.
+ *
+ * @example
+ * import * as E from 'fp-ts/Either'
+ *
+ * assert.deepStrictEqual(E.of('a'), E.right('a'))
+ *
  * @category Applicative
  * @since 2.7.0
  */

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -522,6 +522,25 @@ export const duplicate: <E, A>(ma: Either<E, A>) => Either<E, Either<E, A>> =
   extend(identity)
 
 /**
+ * Left-associative fold of a structure.
+ *
+ * @example
+ * import { pipe } from 'fp-ts/function'
+ * import * as E from 'fp-ts/Either'
+ *
+ * const empty = 'prefix'
+ * const concat = (a: string, b: string) => `${a}:${b}`
+ *
+ * assert.deepStrictEqual(
+ *   pipe(E.right('a'), E.reduce(empty, concat)),
+ *   'prefix:a',
+ * )
+ *
+ * assert.deepStrictEqual(
+ *   pipe(E.left('e'), E.reduce(empty, concat)),
+ *   'prefix',
+ * )
+ *
  * @category Foldable
  * @since 2.0.0
  */

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -574,6 +574,25 @@ export const foldMap: <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => <E>(fa: Either
   isLeft(fa) ? M.empty : f(fa.right)
 
 /**
+ * Right-associative fold of a structure.
+ *
+ * @example
+ * import { pipe } from 'fp-ts/function'
+ * import * as E from 'fp-ts/Either'
+ *
+ * const empty = 'postfix'
+ * const concat = (a: string, b: string) => `${a}:${b}`
+ *
+ * assert.deepStrictEqual(
+ *   pipe(E.right('a'), E.reduceRight(empty, concat)),
+ *   'a:postfix',
+ * )
+ *
+ * assert.deepStrictEqual(
+ *   pipe(E.left('e'), E.reduceRight(empty, concat)),
+ *   'postfix',
+ * )
+ *
  * @category Foldable
  * @since 2.0.0
  */

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -489,6 +489,15 @@ export const chainFirstW: <D, A, B>(f: (a: A) => Either<D, B>) => <E>(ma: Either
 export const chainFirst: <E, A, B>(f: (a: A) => Either<E, B>) => (ma: Either<E, A>) => Either<E, A> = chainFirstW
 
 /**
+ * The `flatten` function is the conventional monad join operator. It is used to remove one level of monadic structure, projecting its bound argument into the outer level.
+ *
+ * @example
+ * import * as E from 'fp-ts/Either'
+ *
+ * assert.deepStrictEqual(E.flatten(E.right(E.right('a'))), E.right('a'))
+ * assert.deepStrictEqual(E.flatten(E.right(E.left('e'))), E.left('e'))
+ * assert.deepStrictEqual(E.flatten(E.left('e')), E.left('e'))
+ *
  * @category Monad
  * @since 2.0.0
  */

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -617,6 +617,23 @@ export const traverse: PipeableTraverse2<URI> = <F>(F: ApplicativeHKT<F>) => <A,
 ): HKT<F, Either<E, B>> => (isLeft(ta) ? F.of(left(ta.left)) : F.map<B, Either<E, B>>(f(ta.right), right))
 
 /**
+ * Evaluate each monadic action in the structure from left to right, and collect the results.
+ *
+ * @example
+ * import { pipe } from 'fp-ts/function'
+ * import * as E from 'fp-ts/Either'
+ * import * as O from 'fp-ts/Option'
+ *
+ * assert.deepStrictEqual(
+ *   pipe(E.right(O.some('a')), E.sequence(O.option)),
+ *   O.some(E.right('a')),
+ *  )
+ *
+ * assert.deepStrictEqual(
+ *   pipe(E.right(O.none), E.sequence(O.option)),
+ *   O.none
+ * )
+ *
  * @category Traversable
  * @since 2.6.3
  */

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -529,6 +529,25 @@ export const reduce: <A, B>(b: B, f: (b: B, a: A) => B) => <E>(fa: Either<E, A>)
   isLeft(fa) ? b : f(b, fa.right)
 
 /**
+ * Map each element of the structure to a monoid, and combine the results.
+ *
+ * @example
+ * import { pipe } from 'fp-ts/function';
+ * import * as E from 'fp-ts/Either'
+ * import { monoidString } from 'fp-ts/Monoid'
+ *
+ * const yell = (a: string) => `${a}!`
+ *
+ * assert.deepStrictEqual(
+ *   pipe(E.right('a'), E.foldMap(monoidString)(yell)),
+ *   'a!',
+ * )
+ *
+ * assert.deepStrictEqual(
+ *   pipe(E.left('e'), E.foldMap(monoidString)(yell)),
+ *   monoidString.empty,
+ * )
+ *
  * @category Foldable
  * @since 2.0.0
  */


### PR DESCRIPTION
Add descriptions and examples to each of the following functions in `Either`:

- `of`
- `foldMap`
- `reduce`
- `reduceRight`
- `flatten`
- `sequence`
- `traverse` 