### PR TITLE
test(state): check for original state instead of undefined

### DIFF
--- a/test/State.ts
+++ b/test/State.ts
@@ -82,8 +82,8 @@ describe('State', () => {
         _.of(1),
         _.bindTo('a'),
         _.bind('b', () => _.of('b'))
-      )(undefined),
-      [{ a: 1, b: 'b' }, undefined]
+      )('state'),
+      [{ a: 1, b: 'b' }, 'state']
     )
   })
 


### PR DESCRIPTION
There's an edge case where testing the `State` monad with `Do` notation where the original state is overwritten by the chained.

By inputting the state as a real value and not `undefined`, we ensure that the input state is passed through and not overwritten by undefined in `_.of("b")`, where the state is initialized as undefined.

I discovered this when creating tests for `Do` notation for `fp-ts-rxjs/StateReaderObservableEither`. I wrote this test because I thought this was a bug with it's implementation because I copied the code from `fp-ts`, but it seems to be a different cause.

The test passes, meaning it's working as intended.