### PR TITLE
NEA, RNEA: Add `uncons`, `unsnoc` destructors

### DIFF
--- a/docs/modules/NonEmptyArray.ts.md
+++ b/docs/modules/NonEmptyArray.ts.md
@@ -551,7 +551,7 @@ import { cons, uncons } from 'fp-ts/NonEmptyArray'
 assert.deepStrictEqual(uncons(cons(1, [2, 3, 4])), [1, [2, 3, 4]])
 ```
 
-Added in v-
+Added in v2.9.0
 
 ## unsnoc
 
@@ -571,7 +571,7 @@ import { snoc, unsnoc } from 'fp-ts/NonEmptyArray'
 assert.deepStrictEqual(unsnoc(snoc([1, 2, 3], 4)), [[1, 2, 3], 4])
 ```
 
-Added in v-
+Added in v2.9.0
 
 # instances
 

--- a/docs/modules/NonEmptyArray.ts.md
+++ b/docs/modules/NonEmptyArray.ts.md
@@ -56,6 +56,9 @@ Added in v2.0.0
   - [fromArray](#fromarray)
   - [groupBy](#groupby)
   - [snoc](#snoc)
+- [destructors](#destructors)
+  - [uncons](#uncons)
+  - [unsnoc](#unsnoc)
 - [instances](#instances)
   - [Alt](#alt-1)
   - [Applicative](#applicative-1)
@@ -527,6 +530,48 @@ assert.deepStrictEqual(snoc([1, 2, 3], 4), [1, 2, 3, 4])
 ```
 
 Added in v2.0.0
+
+# destructors
+
+## uncons
+
+Produces a couple of the first element of the array, and a new array of the remaining elements, if any
+
+**Signature**
+
+```ts
+export declare const uncons: <A>(nea: NonEmptyArray<A>) => readonly [A, A[]]
+```
+
+**Example**
+
+```ts
+import { cons, uncons } from 'fp-ts/NonEmptyArray'
+
+assert.deepStrictEqual(uncons(cons(1, [2, 3, 4])), [1, [2, 3, 4]])
+```
+
+Added in v-
+
+## unsnoc
+
+Produces a couple of a copy of the array without its last element, and that last element
+
+**Signature**
+
+```ts
+export declare const unsnoc: <A>(nea: NonEmptyArray<A>) => readonly [A[], A]
+```
+
+**Example**
+
+```ts
+import { snoc, unsnoc } from 'fp-ts/NonEmptyArray'
+
+assert.deepStrictEqual(unsnoc(snoc([1, 2, 3], 4)), [[1, 2, 3], 4])
+```
+
+Added in v-
 
 # instances
 

--- a/docs/modules/ReadonlyNonEmptyArray.ts.md
+++ b/docs/modules/ReadonlyNonEmptyArray.ts.md
@@ -560,7 +560,7 @@ import { cons, uncons } from 'fp-ts/ReadonlyNonEmptyArray'
 assert.deepStrictEqual(uncons(cons(1, [2, 3, 4])), [1, [2, 3, 4]])
 ```
 
-Added in v-
+Added in v2.9.0
 
 ## unsnoc
 
@@ -580,7 +580,7 @@ import { snoc, unsnoc } from 'fp-ts/ReadonlyNonEmptyArray'
 assert.deepStrictEqual(unsnoc(snoc([1, 2, 3], 4)), [[1, 2, 3], 4])
 ```
 
-Added in v-
+Added in v2.9.0
 
 # instances
 

--- a/docs/modules/ReadonlyNonEmptyArray.ts.md
+++ b/docs/modules/ReadonlyNonEmptyArray.ts.md
@@ -55,6 +55,9 @@ Added in v2.5.0
   - [fromReadonlyArray](#fromreadonlyarray)
   - [groupBy](#groupby)
   - [snoc](#snoc)
+- [destructors](#destructors)
+  - [uncons](#uncons)
+  - [unsnoc](#unsnoc)
 - [instances](#instances)
   - [Alt](#alt-1)
   - [Applicative](#applicative-1)
@@ -536,6 +539,48 @@ assert.deepStrictEqual(snoc([1, 2, 3], 4), [1, 2, 3, 4])
 ```
 
 Added in v2.5.0
+
+# destructors
+
+## uncons
+
+Produces a couple of the first element of the array, and a new array of the remaining elements, if any
+
+**Signature**
+
+```ts
+export declare function uncons<A>(nea: ReadonlyNonEmptyArray<A>): readonly [A, ReadonlyArray<A>]
+```
+
+**Example**
+
+```ts
+import { cons, uncons } from 'fp-ts/ReadonlyNonEmptyArray'
+
+assert.deepStrictEqual(uncons(cons(1, [2, 3, 4])), [1, [2, 3, 4]])
+```
+
+Added in v-
+
+## unsnoc
+
+Produces a couple of a copy of the array without its last element, and that last element
+
+**Signature**
+
+```ts
+export declare function unsnoc<A>(nea: ReadonlyNonEmptyArray<A>): readonly [ReadonlyArray<A>, A]
+```
+
+**Example**
+
+```ts
+import { snoc, unsnoc } from 'fp-ts/ReadonlyNonEmptyArray'
+
+assert.deepStrictEqual(unsnoc(snoc([1, 2, 3], 4)), [[1, 2, 3], 4])
+```
+
+Added in v-
 
 # instances
 

--- a/src/NonEmptyArray.ts
+++ b/src/NonEmptyArray.ts
@@ -73,6 +73,32 @@ export const snoc: <A>(init: Array<A>, end: A) => NonEmptyArray<A> = RNEA.snoc a
 export const fromArray: <A>(as: Array<A>) => Option<NonEmptyArray<A>> = RNEA.fromArray as any
 
 /**
+ * Produces a couple of the first element of the array, and a new array of the remaining elements, if any
+ *
+ * @example
+ * import { cons, uncons } from 'fp-ts/NonEmptyArray'
+ *
+ * assert.deepStrictEqual(uncons(cons(1, [2, 3, 4])), [1, [2, 3, 4]])
+ *
+ * @category destructors
+ * @since -
+ */
+export const uncons: <A>(nea: NonEmptyArray<A>) => readonly [A, Array<A>] = RNEA.uncons as any
+
+/**
+ * Produces a couple of a copy of the array without its last element, and that last element
+ *
+ * @example
+ * import { snoc, unsnoc } from 'fp-ts/NonEmptyArray'
+ *
+ * assert.deepStrictEqual(unsnoc(snoc([1, 2, 3], 4)), [[1, 2, 3], 4])
+ *
+ * @category destructors
+ * @since -
+ */
+export const unsnoc: <A>(nea: NonEmptyArray<A>) => readonly [Array<A>, A] = RNEA.unsnoc as any
+
+/**
  * @category instances
  * @since 2.0.0
  */

--- a/src/NonEmptyArray.ts
+++ b/src/NonEmptyArray.ts
@@ -81,7 +81,7 @@ export const fromArray: <A>(as: Array<A>) => Option<NonEmptyArray<A>> = RNEA.fro
  * assert.deepStrictEqual(uncons(cons(1, [2, 3, 4])), [1, [2, 3, 4]])
  *
  * @category destructors
- * @since -
+ * @since 2.9.0
  */
 export const uncons: <A>(nea: NonEmptyArray<A>) => readonly [A, Array<A>] = RNEA.uncons as any
 
@@ -94,7 +94,7 @@ export const uncons: <A>(nea: NonEmptyArray<A>) => readonly [A, Array<A>] = RNEA
  * assert.deepStrictEqual(unsnoc(snoc([1, 2, 3], 4)), [[1, 2, 3], 4])
  *
  * @category destructors
- * @since -
+ * @since 2.9.0
  */
 export const unsnoc: <A>(nea: NonEmptyArray<A>) => readonly [Array<A>, A] = RNEA.unsnoc as any
 

--- a/src/ReadonlyNonEmptyArray.ts
+++ b/src/ReadonlyNonEmptyArray.ts
@@ -91,7 +91,7 @@ export function fromArray<A>(as: Array<A>): Option<ReadonlyNonEmptyArray<A>> {
  * assert.deepStrictEqual(uncons(cons(1, [2, 3, 4])), [1, [2, 3, 4]])
  *
  * @category destructors
- * @since -
+ * @since 2.9.0
  */
 export function uncons<A>(nea: ReadonlyNonEmptyArray<A>): readonly [A, ReadonlyArray<A>] {
   return [nea[0], nea.slice(1)]
@@ -106,7 +106,7 @@ export function uncons<A>(nea: ReadonlyNonEmptyArray<A>): readonly [A, ReadonlyA
  * assert.deepStrictEqual(unsnoc(snoc([1, 2, 3], 4)), [[1, 2, 3], 4])
  *
  * @category destructors
- * @since -
+ * @since 2.9.0
  */
 export function unsnoc<A>(nea: ReadonlyNonEmptyArray<A>): readonly [ReadonlyArray<A>, A] {
   const l = nea.length - 1

--- a/src/ReadonlyNonEmptyArray.ts
+++ b/src/ReadonlyNonEmptyArray.ts
@@ -83,6 +83,37 @@ export function fromArray<A>(as: Array<A>): Option<ReadonlyNonEmptyArray<A>> {
 }
 
 /**
+ * Produces a couple of the first element of the array, and a new array of the remaining elements, if any
+ *
+ * @example
+ * import { cons, uncons } from 'fp-ts/ReadonlyNonEmptyArray'
+ *
+ * assert.deepStrictEqual(uncons(cons(1, [2, 3, 4])), [1, [2, 3, 4]])
+ *
+ * @category destructors
+ * @since -
+ */
+export function uncons<A>(nea: ReadonlyNonEmptyArray<A>): readonly [A, ReadonlyArray<A>] {
+  return [nea[0], nea.slice(1)]
+}
+
+/**
+ * Produces a couple of a copy of the array without its last element, and that last element
+ *
+ * @example
+ * import { snoc, unsnoc } from 'fp-ts/ReadonlyNonEmptyArray'
+ *
+ * assert.deepStrictEqual(unsnoc(snoc([1, 2, 3], 4)), [[1, 2, 3], 4])
+ *
+ * @category destructors
+ * @since -
+ */
+export function unsnoc<A>(nea: ReadonlyNonEmptyArray<A>): readonly [ReadonlyArray<A>, A] {
+  const l = nea.length - 1
+  return [nea.slice(0, l), nea[l]]
+}
+
+/**
  * @category instances
  * @since 2.5.0
  */

--- a/test/NonEmptyArray.ts
+++ b/test/NonEmptyArray.ts
@@ -302,6 +302,16 @@ describe('NonEmptyArray', () => {
     assert.deepStrictEqual(_.snoc([1, 2, 3], 4), [1, 2, 3, 4])
   })
 
+  it('uncons', () => {
+    assert.deepStrictEqual(_.uncons(_.cons(0, [])), [0, []])
+    assert.deepStrictEqual(_.uncons(_.cons(1, [2, 3, 4])), [1, [2, 3, 4]])
+  })
+
+  it('unsnoc', () => {
+    assert.deepStrictEqual(_.unsnoc(_.snoc([], 0)), [[], 0])
+    assert.deepStrictEqual(_.unsnoc(_.snoc([1, 2, 3], 4)), [[1, 2, 3], 4])
+  })
+
   it('getShow', () => {
     const S = _.getShow(showString)
     assert.deepStrictEqual(S.show(['a']), `["a"]`)

--- a/test/ReadonlyNonEmptyArray.ts
+++ b/test/ReadonlyNonEmptyArray.ts
@@ -295,6 +295,16 @@ describe('ReadonlyNonEmptyArray', () => {
     assert.deepStrictEqual(_.snoc([1, 2, 3], 4), [1, 2, 3, 4])
   })
 
+  it('uncons', () => {
+    assert.deepStrictEqual(_.uncons(_.cons(0, [])), [0, []])
+    assert.deepStrictEqual(_.uncons(_.cons(1, [2, 3, 4])), [1, [2, 3, 4]])
+  })
+
+  it('unsnoc', () => {
+    assert.deepStrictEqual(_.unsnoc(_.snoc([], 0)), [[], 0])
+    assert.deepStrictEqual(_.unsnoc(_.snoc([1, 2, 3], 4)), [[1, 2, 3], 4])
+  })
+
   it('getShow', () => {
     const S = _.getShow(showString)
     assert.deepStrictEqual(S.show(['a']), `["a"]`)


### PR DESCRIPTION
Added the functions under a new `destructor` category.

`Array` and `RA` versions could also be added, with optional results, if needed.