### PR TITLE
refactor: use JSON.stringify in `toError` instead of String casting

### DIFF
--- a/src/Either.ts
+++ b/src/Either.ts
@@ -1021,7 +1021,7 @@ export const either: Monad2<URI> &
  * @since 2.0.0
  */
 export function toError(e: unknown): Error {
-  return e instanceof Error ? e : new Error(String(e))
+  return e instanceof Error ? e : new Error(JSON.stringify(e))
 }
 
 /**

--- a/test/Either.ts
+++ b/test/Either.ts
@@ -352,7 +352,14 @@ describe('Either', () => {
           // tslint:disable-next-line: no-string-throw
           throw 'string error'
         }, _.toError),
-        _.left(new Error('string error'))
+        _.left(new Error('"string error"'))
+      )
+
+      assert.deepStrictEqual(
+        _.tryCatch(() => {
+          throw { ECODE: 1 }
+        }, _.toError),
+        _.left(new Error('{"ECODE":1}'))
       )
     })
   })


### PR DESCRIPTION
A tiny improvement to `toError` in case an object is thrown. A comparison of string casting to JSON stringify:

```sh
> String({ a: "123" })
'[object Object]'
> JSON.stringify({ a: "123" })
'{"a":"123"}'
```

Motivation: sometimes there's not much to do about errors other than logging them; `[object Object]` does not provide much value in logs for debugging purposes.