### PR TITLE
Add flatZip and transpose

### DIFF
--- a/docs/modules/Array.ts.md
+++ b/docs/modules/Array.ts.md
@@ -71,6 +71,7 @@ Added in v2.0.0
   - [dropLeftWhile](#dropleftwhile)
   - [dropRight](#dropright)
   - [duplicate](#duplicate)
+  - [flatZip](#flatzip)
   - [flatten](#flatten)
   - [intersection](#intersection)
   - [intersperse](#intersperse)
@@ -721,6 +722,32 @@ export declare const duplicate: <A>(wa: A[]) => A[][]
 ```
 
 Added in v2.0.0
+
+## flatZip
+
+Merge several arrays into one by alternating elements from each array
+
+**Signature**
+
+```ts
+export declare const flatZip: <A>(aas: A[][]) => A[]
+```
+
+**Example**
+
+```ts
+import { flatZip } from 'fp-ts/Array'
+
+assert.deepStrictEqual(
+  flatZip([
+    [1, 2, 3],
+    [4, 5, 6, 7],
+  ]),
+  [1, 4, 2, 5, 3, 6, 7]
+)
+```
+
+Added in v2.10.0
 
 ## flatten
 

--- a/docs/modules/Array.ts.md
+++ b/docs/modules/Array.ts.md
@@ -86,6 +86,7 @@ Added in v2.0.0
   - [takeLeft](#takeleft)
   - [takeLeftWhile](#takeleftwhile)
   - [takeRight](#takeright)
+  - [transpose](#transpose)
   - [union](#union)
   - [uniq](#uniq)
   - [zip](#zip)
@@ -1053,6 +1054,32 @@ assert.deepStrictEqual(takeRight(2)([1, 2, 3, 4, 5]), [4, 5])
 ```
 
 Added in v2.0.0
+
+## transpose
+
+Switches rows and columns of a two dimensional array
+
+**Signature**
+
+```ts
+export declare const transpose: <A>(xy: A[][]) => NonEmptyArray<A>[]
+```
+
+**Example**
+
+```ts
+import { transpose } from 'fp-ts/Array'
+
+assert.deepStrictEqual(
+  transpose([
+    [1, 2, 3],
+    [4, 5, 6, 7],
+  ]),
+  [[1, 4], [2, 5], [3, 6], [7]]
+)
+```
+
+Added in v2.10.0
 
 ## union
 

--- a/docs/modules/NonEmptyArray.ts.md
+++ b/docs/modules/NonEmptyArray.ts.md
@@ -44,6 +44,7 @@ Added in v2.0.0
   - [copy](#copy)
   - [duplicate](#duplicate)
   - [filter](#filter)
+  - [flatZip](#flatzip)
   - [flatten](#flatten)
   - [group](#group)
   - [groupSort](#groupsort)
@@ -359,6 +360,32 @@ export declare function filter<A>(predicate: Predicate<A>): (nea: NonEmptyArray<
 ```
 
 Added in v2.0.0
+
+## flatZip
+
+Merge several arrays into one by alternating elements from each array
+
+**Signature**
+
+```ts
+export declare const flatZip: <A>(aas: NonEmptyArray<NonEmptyArray<A>>) => NonEmptyArray<A>
+```
+
+**Example**
+
+```ts
+import { flatZip } from 'fp-ts/NonEmptyArray'
+
+assert.deepStrictEqual(
+  flatZip([
+    [1, 2, 3],
+    [4, 5, 6, 7],
+  ]),
+  [1, 4, 2, 5, 3, 6, 7]
+)
+```
+
+Added in v2.10.0
 
 ## flatten
 

--- a/docs/modules/NonEmptyArray.ts.md
+++ b/docs/modules/NonEmptyArray.ts.md
@@ -51,6 +51,7 @@ Added in v2.0.0
   - [prependToAll](#prependtoall)
   - [reverse](#reverse)
   - [sort](#sort)
+  - [transpose](#transpose)
   - [zip](#zip)
   - [zipWith](#zipwith)
 - [constructors](#constructors)
@@ -482,6 +483,32 @@ export declare const sort: <B>(O: Ord<B>) => <A extends B>(nea: NonEmptyArray<A>
 ```
 
 Added in v2.0.0
+
+## transpose
+
+Switches rows and columns of a two dimensional array
+
+**Signature**
+
+```ts
+export declare const transpose: <A>(xy: NonEmptyArray<NonEmptyArray<A>>) => NonEmptyArray<NonEmptyArray<A>>
+```
+
+**Example**
+
+```ts
+import { transpose } from 'fp-ts/NonEmptyArray'
+
+assert.deepStrictEqual(
+  transpose([
+    [1, 2, 3],
+    [4, 5, 6, 7],
+  ]),
+  [[1, 4], [2, 5], [3, 6], [7]]
+)
+```
+
+Added in v2.10.0
 
 ## zip
 

--- a/docs/modules/ReadonlyArray.ts.md
+++ b/docs/modules/ReadonlyArray.ts.md
@@ -83,6 +83,7 @@ Added in v2.5.0
   - [sortBy](#sortby)
   - [takeLeft](#takeleft)
   - [takeLeftWhile](#takeleftwhile)
+  - [transpose](#transpose)
   - [union](#union)
   - [uniq](#uniq)
   - [zip](#zip)
@@ -1023,6 +1024,32 @@ assert.deepStrictEqual(takeLeftWhile((n: number) => n % 2 === 0)([2, 4, 3, 6]), 
 ```
 
 Added in v2.5.0
+
+## transpose
+
+Switches rows and columns of a two dimensional array
+
+**Signature**
+
+```ts
+export declare function transpose<A>(xy: ReadonlyArray<ReadonlyArray<A>>): ReadonlyArray<ReadonlyNonEmptyArray<A>>
+```
+
+**Example**
+
+```ts
+import { transpose } from 'fp-ts/ReadonlyArray'
+
+assert.deepStrictEqual(
+  transpose([
+    [1, 2, 3],
+    [4, 5, 6, 7],
+  ]),
+  [[1, 4], [2, 5], [3, 6], [7]]
+)
+```
+
+Added in v2.10.0
 
 ## union
 

--- a/docs/modules/ReadonlyArray.ts.md
+++ b/docs/modules/ReadonlyArray.ts.md
@@ -70,6 +70,7 @@ Added in v2.5.0
   - [dropLeftWhile](#dropleftwhile)
   - [dropRight](#dropright)
   - [duplicate](#duplicate)
+  - [flatZip](#flatzip)
   - [flatten](#flatten)
   - [intersection](#intersection)
   - [intersperse](#intersperse)
@@ -726,6 +727,32 @@ export declare const duplicate: <A>(wa: readonly A[]) => readonly (readonly A[])
 ```
 
 Added in v2.5.0
+
+## flatZip
+
+Merge several arrays into one by alternating elements from each array
+
+**Signature**
+
+```ts
+export declare const flatZip: <A>(aas: readonly (readonly A[])[]) => readonly A[]
+```
+
+**Example**
+
+```ts
+import { flatZip } from 'fp-ts/ReadonlyArray'
+
+assert.deepStrictEqual(
+  flatZip([
+    [1, 2, 3],
+    [4, 5, 6, 7],
+  ]),
+  [1, 4, 2, 5, 3, 6, 7]
+)
+```
+
+Added in v2.10.0
 
 ## flatten
 

--- a/docs/modules/ReadonlyNonEmptyArray.ts.md
+++ b/docs/modules/ReadonlyNonEmptyArray.ts.md
@@ -49,6 +49,7 @@ Added in v2.5.0
   - [prependToAll](#prependtoall)
   - [reverse](#reverse)
   - [sort](#sort)
+  - [transpose](#transpose)
   - [zip](#zip)
   - [zipWith](#zipwith)
 - [constructors](#constructors)
@@ -481,6 +482,34 @@ export declare function sort<B>(O: Ord<B>): <A extends B>(nea: ReadonlyNonEmptyA
 ```
 
 Added in v2.5.0
+
+## transpose
+
+Switches rows and columns of a two dimensional array
+
+**Signature**
+
+```ts
+export declare const transpose: <A>(
+  xy: ReadonlyNonEmptyArray<ReadonlyNonEmptyArray<A>>
+) => ReadonlyNonEmptyArray<ReadonlyNonEmptyArray<A>>
+```
+
+**Example**
+
+```ts
+import { transpose } from 'fp-ts/ReadonlyNonEmptyArray'
+
+assert.deepStrictEqual(
+  transpose([
+    [1, 2, 3],
+    [4, 5, 6, 7],
+  ]),
+  [[1, 4], [2, 5], [3, 6], [7]]
+)
+```
+
+Added in v2.10.0
 
 ## zip
 

--- a/docs/modules/ReadonlyNonEmptyArray.ts.md
+++ b/docs/modules/ReadonlyNonEmptyArray.ts.md
@@ -42,6 +42,7 @@ Added in v2.5.0
   - [apSecond](#apsecond)
   - [chainFirst](#chainfirst)
   - [duplicate](#duplicate)
+  - [flatZip](#flatzip)
   - [flatten](#flatten)
   - [group](#group)
   - [groupSort](#groupsort)
@@ -358,6 +359,32 @@ export declare const duplicate: <A>(ma: ReadonlyNonEmptyArray<A>) => ReadonlyNon
 ```
 
 Added in v2.5.0
+
+## flatZip
+
+Merge several arrays into one by alternating elements from each array
+
+**Signature**
+
+```ts
+export declare const flatZip: <A>(aas: ReadonlyNonEmptyArray<ReadonlyNonEmptyArray<A>>) => ReadonlyNonEmptyArray<A>
+```
+
+**Example**
+
+```ts
+import { flatZip } from 'fp-ts/ReadonlyNonEmptyArray'
+
+assert.deepStrictEqual(
+  flatZip([
+    [1, 2, 3],
+    [4, 5, 6, 7],
+  ]),
+  [1, 4, 2, 5, 3, 6, 7]
+)
+```
+
+Added in v2.10.0
 
 ## flatten
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fp-ts",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -765,6 +765,19 @@ export const intersperse: <A>(e: A) => (as: Array<A>) => Array<A> = RA.intersper
 export const transpose: <A>(xy: Array<Array<A>>) => Array<NonEmptyArray<A>> = RA.transpose as any
 
 /**
+ * Merge several arrays into one by alternating elements from each array
+ *
+ * @example
+ * import { flatZip } from 'fp-ts/Array'
+ *
+ * assert.deepStrictEqual(flatZip([[1, 2, 3], [4, 5, 6, 7]]), [1, 4, 2, 5, 3, 6, 7])
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flatZip: <A>(aas: Array<Array<A>>) => Array<A> = RA.flatZip as any
+
+/**
  * Rotate an array to the right by `n` steps
  *
  * @example

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -752,6 +752,19 @@ export const prependToAll: <A>(e: A) => (xs: Array<A>) => Array<A> = RA.prependT
 export const intersperse: <A>(e: A) => (as: Array<A>) => Array<A> = RA.intersperse as any
 
 /**
+ * Switches rows and columns of a two dimensional array
+ *
+ * @example
+ * import { transpose } from 'fp-ts/Array'
+ *
+ * assert.deepStrictEqual(transpose([[1, 2, 3], [4, 5, 6, 7]]), [[1, 4], [2, 5], [3, 6], [7]])
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const transpose: <A>(xy: Array<Array<A>>) => Array<NonEmptyArray<A>> = RA.transpose as any
+
+/**
  * Rotate an array to the right by `n` steps
  *
  * @example

--- a/src/NonEmptyArray.ts
+++ b/src/NonEmptyArray.ts
@@ -385,6 +385,19 @@ export const transpose: <A>(
   xy: NonEmptyArray<NonEmptyArray<A>>
 ) => NonEmptyArray<NonEmptyArray<A>> = RNEA.transpose as any
 
+/**
+ * Merge several arrays into one by alternating elements from each array
+ *
+ * @example
+ * import { flatZip } from 'fp-ts/NonEmptyArray'
+ *
+ * assert.deepStrictEqual(flatZip([[1, 2, 3], [4, 5, 6, 7]]), [1, 4, 2, 5, 3, 6, 7])
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flatZip: <A>(aas: NonEmptyArray<NonEmptyArray<A>>) => NonEmptyArray<A> = RNEA.flatZip as any
+
 // -------------------------------------------------------------------------------------
 // non-pipeables
 // -------------------------------------------------------------------------------------

--- a/src/NonEmptyArray.ts
+++ b/src/NonEmptyArray.ts
@@ -370,6 +370,21 @@ export const prependToAll: <A>(e: A) => (xs: NonEmptyArray<A>) => NonEmptyArray<
  */
 export const intersperse: <A>(e: A) => (as: NonEmptyArray<A>) => NonEmptyArray<A> = RNEA.intersperse as any
 
+/**
+ * Switches rows and columns of a two dimensional array
+ *
+ * @example
+ * import { transpose } from 'fp-ts/NonEmptyArray'
+ *
+ * assert.deepStrictEqual(transpose([[1, 2, 3], [4, 5, 6, 7]]), [[1, 4], [2, 5], [3, 6], [7]])
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const transpose: <A>(
+  xy: NonEmptyArray<NonEmptyArray<A>>
+) => NonEmptyArray<NonEmptyArray<A>> = RNEA.transpose as any
+
 // -------------------------------------------------------------------------------------
 // non-pipeables
 // -------------------------------------------------------------------------------------

--- a/src/ReadonlyArray.ts
+++ b/src/ReadonlyArray.ts
@@ -1094,6 +1094,38 @@ export function intersperse<A>(e: A): (as: ReadonlyArray<A>) => ReadonlyArray<A>
 }
 
 /**
+ * Switches rows and columns of a two dimensional array
+ *
+ * @example
+ * import { transpose } from 'fp-ts/ReadonlyArray'
+ *
+ * assert.deepStrictEqual(transpose([[1, 2, 3], [4, 5, 6, 7]]), [[1, 4], [2, 5], [3, 6], [7]])
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export function transpose<A>(xy: ReadonlyArray<ReadonlyArray<A>>): ReadonlyArray<ReadonlyNonEmptyArray<A>> {
+  const maxX = xy.length
+  const maxY = Math.max(...xy.map((y) => y.length))
+  // tslint:disable-next-line: readonly-array
+  const yx: Array<Array<A>> = []
+  let yi = 0
+  for (; yi < maxY; yi++) {
+    let xi = 0
+    // tslint:disable-next-line: readonly-array
+    let x: Array<A> = []
+    for (; xi < maxX; xi++) {
+      const y = xy[xi]
+      if (yi < y.length) {
+        x.push(y[yi])
+      }
+    }
+    yx.push(x)
+  }
+  return (yx as unknown) as ReadonlyArray<ReadonlyNonEmptyArray<A>>
+}
+
+/**
  * Rotate an array to the right by `n` steps
  *
  * @example

--- a/src/ReadonlyArray.ts
+++ b/src/ReadonlyArray.ts
@@ -1126,6 +1126,19 @@ export function transpose<A>(xy: ReadonlyArray<ReadonlyArray<A>>): ReadonlyArray
 }
 
 /**
+ * Merge several arrays into one by alternating elements from each array
+ *
+ * @example
+ * import { flatZip } from 'fp-ts/ReadonlyArray'
+ *
+ * assert.deepStrictEqual(flatZip([[1, 2, 3], [4, 5, 6, 7]]), [1, 4, 2, 5, 3, 6, 7])
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flatZip: <A>(aas: ReadonlyArray<ReadonlyArray<A>>) => ReadonlyArray<A> = flow(transpose, flatten)
+
+/**
  * Rotate an array to the right by `n` steps
  *
  * @example

--- a/src/ReadonlyNonEmptyArray.ts
+++ b/src/ReadonlyNonEmptyArray.ts
@@ -441,6 +441,21 @@ export const intersperse: <A>(
   e: A
 ) => (as: ReadonlyNonEmptyArray<A>) => ReadonlyNonEmptyArray<A> = RA.intersperse as any
 
+/**
+ * Switches rows and columns of a two dimensional array
+ *
+ * @example
+ * import { transpose } from 'fp-ts/ReadonlyNonEmptyArray'
+ *
+ * assert.deepStrictEqual(transpose([[1, 2, 3], [4, 5, 6, 7]]), [[1, 4], [2, 5], [3, 6], [7]])
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const transpose: <A>(
+  xy: ReadonlyNonEmptyArray<ReadonlyNonEmptyArray<A>>
+) => ReadonlyNonEmptyArray<ReadonlyNonEmptyArray<A>> = RA.transpose as any
+
 // -------------------------------------------------------------------------------------
 // non-pipeables
 // -------------------------------------------------------------------------------------

--- a/src/ReadonlyNonEmptyArray.ts
+++ b/src/ReadonlyNonEmptyArray.ts
@@ -456,6 +456,21 @@ export const transpose: <A>(
   xy: ReadonlyNonEmptyArray<ReadonlyNonEmptyArray<A>>
 ) => ReadonlyNonEmptyArray<ReadonlyNonEmptyArray<A>> = RA.transpose as any
 
+/**
+ * Merge several arrays into one by alternating elements from each array
+ *
+ * @example
+ * import { flatZip } from 'fp-ts/ReadonlyNonEmptyArray'
+ *
+ * assert.deepStrictEqual(flatZip([[1, 2, 3], [4, 5, 6, 7]]), [1, 4, 2, 5, 3, 6, 7])
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flatZip: <A>(
+  aas: ReadonlyNonEmptyArray<ReadonlyNonEmptyArray<A>>
+) => ReadonlyNonEmptyArray<A> = RA.flatZip as any
+
 // -------------------------------------------------------------------------------------
 // non-pipeables
 // -------------------------------------------------------------------------------------

--- a/test/Array.ts
+++ b/test/Array.ts
@@ -669,6 +669,39 @@ describe('Array', () => {
     assert.deepStrictEqual(_.transpose([[1, 2, 3], [4], [5, 6]]), [[1, 4, 5], [2, 6], [3]])
   })
 
+  it('flatZip', () => {
+    assert.deepStrictEqual(
+      _.flatZip([
+        [1, 2, 3],
+        [4, 5, 6, 7]
+      ]),
+      [1, 4, 2, 5, 3, 6, 7]
+    )
+    assert.deepStrictEqual(_.flatZip([[]]), [])
+    assert.deepStrictEqual(_.flatZip([[1]]), [1])
+    assert.deepStrictEqual(_.flatZip([[1, 2, 3]]), [1, 2, 3])
+    assert.deepStrictEqual(_.flatZip([[1], [2], [3]]), [1, 2, 3])
+    assert.deepStrictEqual(_.flatZip([[], []]), [])
+    assert.deepStrictEqual(_.flatZip([[1], []]), [1])
+    assert.deepStrictEqual(_.flatZip([[], [1]]), [1])
+    assert.deepStrictEqual(_.flatZip([[1], [2]]), [1, 2])
+    assert.deepStrictEqual(_.flatZip([[1], [2, 3]]), [1, 2, 3])
+    assert.deepStrictEqual(_.flatZip([[1, 2], [3]]), [1, 3, 2])
+    assert.deepStrictEqual(
+      _.flatZip([
+        [1, 2],
+        [3, 4]
+      ]),
+      [1, 3, 2, 4]
+    )
+    assert.deepStrictEqual(_.flatZip([[1, 2, 3], [4]]), [1, 4, 2, 3])
+    assert.deepStrictEqual(_.flatZip([[1], [2, 3, 4]]), [1, 2, 3, 4])
+    assert.deepStrictEqual(_.flatZip([[1], [2, 3], [4, 5, 6]]), [1, 2, 4, 3, 5, 6])
+    assert.deepStrictEqual(_.flatZip([[1, 2, 3], [4, 5], [6]]), [1, 4, 6, 2, 5, 3])
+    assert.deepStrictEqual(_.flatZip([[1, 2], [3], [4, 5, 6]]), [1, 3, 4, 2, 5, 6])
+    assert.deepStrictEqual(_.flatZip([[1, 2, 3], [4], [5, 6]]), [1, 4, 5, 2, 6, 3])
+  })
+
   it('zipWith', () => {
     assert.deepStrictEqual(
       _.zipWith([1, 2, 3], ['a', 'b', 'c', 'd'], (n, s) => s + n),

--- a/test/Array.ts
+++ b/test/Array.ts
@@ -633,6 +633,42 @@ describe('Array', () => {
     assert.deepStrictEqual(_.intersperse(0)([1, 2, 3, 4]), [1, 0, 2, 0, 3, 0, 4])
   })
 
+  it('transpose', () => {
+    assert.deepStrictEqual(
+      _.transpose([
+        [1, 2, 3],
+        [4, 5, 6, 7]
+      ]),
+      [[1, 4], [2, 5], [3, 6], [7]]
+    )
+    assert.deepStrictEqual(_.transpose([[]]), [])
+    assert.deepStrictEqual(_.transpose([[1]]), [[1]])
+    assert.deepStrictEqual(_.transpose([[1, 2, 3]]), [[1], [2], [3]])
+    assert.deepStrictEqual(_.transpose([[1], [2], [3]]), [[1, 2, 3]])
+    assert.deepStrictEqual(_.transpose([[], []]), [])
+    assert.deepStrictEqual(_.transpose([[1], []]), [[1]])
+    assert.deepStrictEqual(_.transpose([[], [1]]), [[1]])
+    assert.deepStrictEqual(_.transpose([[1], [2]]), [[1, 2]])
+    assert.deepStrictEqual(_.transpose([[1], [2, 3]]), [[1, 2], [3]])
+    assert.deepStrictEqual(_.transpose([[1, 2], [3]]), [[1, 3], [2]])
+    assert.deepStrictEqual(
+      _.transpose([
+        [1, 2],
+        [3, 4]
+      ]),
+      [
+        [1, 3],
+        [2, 4]
+      ]
+    )
+    assert.deepStrictEqual(_.transpose([[1, 2, 3], [4]]), [[1, 4], [2], [3]])
+    assert.deepStrictEqual(_.transpose([[1], [2, 3, 4]]), [[1, 2], [3], [4]])
+    assert.deepStrictEqual(_.transpose([[1], [2, 3], [4, 5, 6]]), [[1, 2, 4], [3, 5], [6]])
+    assert.deepStrictEqual(_.transpose([[1, 2, 3], [4, 5], [6]]), [[1, 4, 6], [2, 5], [3]])
+    assert.deepStrictEqual(_.transpose([[1, 2], [3], [4, 5, 6]]), [[1, 3, 4], [2, 5], [6]])
+    assert.deepStrictEqual(_.transpose([[1, 2, 3], [4], [5, 6]]), [[1, 4, 5], [2, 6], [3]])
+  })
+
   it('zipWith', () => {
     assert.deepStrictEqual(
       _.zipWith([1, 2, 3], ['a', 'b', 'c', 'd'], (n, s) => s + n),

--- a/test/NonEmptyArray.ts
+++ b/test/NonEmptyArray.ts
@@ -217,6 +217,35 @@ describe('NonEmptyArray', () => {
     assert.deepStrictEqual(_.transpose([[1, 2, 3], [4], [5, 6]]), [[1, 4, 5], [2, 6], [3]])
   })
 
+  it('flatZip', () => {
+    assert.deepStrictEqual(
+      _.flatZip([
+        [1, 2, 3],
+        [4, 5, 6, 7]
+      ]),
+      [1, 4, 2, 5, 3, 6, 7]
+    )
+    assert.deepStrictEqual(_.flatZip([[1]]), [1])
+    assert.deepStrictEqual(_.flatZip([[1, 2, 3]]), [1, 2, 3])
+    assert.deepStrictEqual(_.flatZip([[1], [2], [3]]), [1, 2, 3])
+    assert.deepStrictEqual(_.flatZip([[1], [2]]), [1, 2])
+    assert.deepStrictEqual(_.flatZip([[1], [2, 3]]), [1, 2, 3])
+    assert.deepStrictEqual(_.flatZip([[1, 2], [3]]), [1, 3, 2])
+    assert.deepStrictEqual(
+      _.flatZip([
+        [1, 2],
+        [3, 4]
+      ]),
+      [1, 3, 2, 4]
+    )
+    assert.deepStrictEqual(_.flatZip([[1, 2, 3], [4]]), [1, 4, 2, 3])
+    assert.deepStrictEqual(_.flatZip([[1], [2, 3, 4]]), [1, 2, 3, 4])
+    assert.deepStrictEqual(_.flatZip([[1], [2, 3], [4, 5, 6]]), [1, 2, 4, 3, 5, 6])
+    assert.deepStrictEqual(_.flatZip([[1, 2, 3], [4, 5], [6]]), [1, 4, 6, 2, 5, 3])
+    assert.deepStrictEqual(_.flatZip([[1, 2], [3], [4, 5, 6]]), [1, 3, 4, 2, 5, 6])
+    assert.deepStrictEqual(_.flatZip([[1, 2, 3], [4], [5, 6]]), [1, 4, 5, 2, 6, 3])
+  })
+
   it('reverse', () => {
     assert.deepStrictEqual(_.reverse([1, 2, 3]), [3, 2, 1])
   })

--- a/test/NonEmptyArray.ts
+++ b/test/NonEmptyArray.ts
@@ -185,6 +185,38 @@ describe('NonEmptyArray', () => {
     assert.deepStrictEqual(_.intersperse(0)(_.cons(1, [2, 3, 4])), _.cons(1, [0, 2, 0, 3, 0, 4]))
   })
 
+  it('transpose', () => {
+    assert.deepStrictEqual(
+      _.transpose([
+        [1, 2, 3],
+        [4, 5, 6, 7]
+      ]),
+      [[1, 4], [2, 5], [3, 6], [7]]
+    )
+    assert.deepStrictEqual(_.transpose([[1]]), [[1]])
+    assert.deepStrictEqual(_.transpose([[1, 2, 3]]), [[1], [2], [3]])
+    assert.deepStrictEqual(_.transpose([[1], [2], [3]]), [[1, 2, 3]])
+    assert.deepStrictEqual(_.transpose([[1], [2]]), [[1, 2]])
+    assert.deepStrictEqual(_.transpose([[1], [2, 3]]), [[1, 2], [3]])
+    assert.deepStrictEqual(_.transpose([[1, 2], [3]]), [[1, 3], [2]])
+    assert.deepStrictEqual(
+      _.transpose([
+        [1, 2],
+        [3, 4]
+      ]),
+      [
+        [1, 3],
+        [2, 4]
+      ]
+    )
+    assert.deepStrictEqual(_.transpose([[1, 2, 3], [4]]), [[1, 4], [2], [3]])
+    assert.deepStrictEqual(_.transpose([[1], [2, 3, 4]]), [[1, 2], [3], [4]])
+    assert.deepStrictEqual(_.transpose([[1], [2, 3], [4, 5, 6]]), [[1, 2, 4], [3, 5], [6]])
+    assert.deepStrictEqual(_.transpose([[1, 2, 3], [4, 5], [6]]), [[1, 4, 6], [2, 5], [3]])
+    assert.deepStrictEqual(_.transpose([[1, 2], [3], [4, 5, 6]]), [[1, 3, 4], [2, 5], [6]])
+    assert.deepStrictEqual(_.transpose([[1, 2, 3], [4], [5, 6]]), [[1, 4, 5], [2, 6], [3]])
+  })
+
   it('reverse', () => {
     assert.deepStrictEqual(_.reverse([1, 2, 3]), [3, 2, 1])
   })

--- a/test/ReadonlyArray.ts
+++ b/test/ReadonlyArray.ts
@@ -717,6 +717,39 @@ describe('ReadonlyArray', () => {
     assert.deepStrictEqual(_.transpose([[1, 2, 3], [4], [5, 6]]), [[1, 4, 5], [2, 6], [3]])
   })
 
+  it('flatZip', () => {
+    assert.deepStrictEqual(
+      _.flatZip([
+        [1, 2, 3],
+        [4, 5, 6, 7]
+      ]),
+      [1, 4, 2, 5, 3, 6, 7]
+    )
+    assert.deepStrictEqual(_.flatZip([[]]), [])
+    assert.deepStrictEqual(_.flatZip([[1]]), [1])
+    assert.deepStrictEqual(_.flatZip([[1, 2, 3]]), [1, 2, 3])
+    assert.deepStrictEqual(_.flatZip([[1], [2], [3]]), [1, 2, 3])
+    assert.deepStrictEqual(_.flatZip([[], []]), [])
+    assert.deepStrictEqual(_.flatZip([[1], []]), [1])
+    assert.deepStrictEqual(_.flatZip([[], [1]]), [1])
+    assert.deepStrictEqual(_.flatZip([[1], [2]]), [1, 2])
+    assert.deepStrictEqual(_.flatZip([[1], [2, 3]]), [1, 2, 3])
+    assert.deepStrictEqual(_.flatZip([[1, 2], [3]]), [1, 3, 2])
+    assert.deepStrictEqual(
+      _.flatZip([
+        [1, 2],
+        [3, 4]
+      ]),
+      [1, 3, 2, 4]
+    )
+    assert.deepStrictEqual(_.flatZip([[1, 2, 3], [4]]), [1, 4, 2, 3])
+    assert.deepStrictEqual(_.flatZip([[1], [2, 3, 4]]), [1, 2, 3, 4])
+    assert.deepStrictEqual(_.flatZip([[1], [2, 3], [4, 5, 6]]), [1, 2, 4, 3, 5, 6])
+    assert.deepStrictEqual(_.flatZip([[1, 2, 3], [4, 5], [6]]), [1, 4, 6, 2, 5, 3])
+    assert.deepStrictEqual(_.flatZip([[1, 2], [3], [4, 5, 6]]), [1, 3, 4, 2, 5, 6])
+    assert.deepStrictEqual(_.flatZip([[1, 2, 3], [4], [5, 6]]), [1, 4, 5, 2, 6, 3])
+  })
+
   it('rotate', () => {
     assert.deepStrictEqual(_.rotate(1)([]), [])
     assert.deepStrictEqual(_.rotate(1)([1]), [1])

--- a/test/ReadonlyArray.ts
+++ b/test/ReadonlyArray.ts
@@ -681,6 +681,42 @@ describe('ReadonlyArray', () => {
     assert.deepStrictEqual(_.intersperse(0)([1, 2, 3, 4]), [1, 0, 2, 0, 3, 0, 4])
   })
 
+  it('transpose', () => {
+    assert.deepStrictEqual(
+      _.transpose([
+        [1, 2, 3],
+        [4, 5, 6, 7]
+      ]),
+      [[1, 4], [2, 5], [3, 6], [7]]
+    )
+    assert.deepStrictEqual(_.transpose([[]]), [])
+    assert.deepStrictEqual(_.transpose([[1]]), [[1]])
+    assert.deepStrictEqual(_.transpose([[1, 2, 3]]), [[1], [2], [3]])
+    assert.deepStrictEqual(_.transpose([[1], [2], [3]]), [[1, 2, 3]])
+    assert.deepStrictEqual(_.transpose([[], []]), [])
+    assert.deepStrictEqual(_.transpose([[1], []]), [[1]])
+    assert.deepStrictEqual(_.transpose([[], [1]]), [[1]])
+    assert.deepStrictEqual(_.transpose([[1], [2]]), [[1, 2]])
+    assert.deepStrictEqual(_.transpose([[1], [2, 3]]), [[1, 2], [3]])
+    assert.deepStrictEqual(_.transpose([[1, 2], [3]]), [[1, 3], [2]])
+    assert.deepStrictEqual(
+      _.transpose([
+        [1, 2],
+        [3, 4]
+      ]),
+      [
+        [1, 3],
+        [2, 4]
+      ]
+    )
+    assert.deepStrictEqual(_.transpose([[1, 2, 3], [4]]), [[1, 4], [2], [3]])
+    assert.deepStrictEqual(_.transpose([[1], [2, 3, 4]]), [[1, 2], [3], [4]])
+    assert.deepStrictEqual(_.transpose([[1], [2, 3], [4, 5, 6]]), [[1, 2, 4], [3, 5], [6]])
+    assert.deepStrictEqual(_.transpose([[1, 2, 3], [4, 5], [6]]), [[1, 4, 6], [2, 5], [3]])
+    assert.deepStrictEqual(_.transpose([[1, 2], [3], [4, 5, 6]]), [[1, 3, 4], [2, 5], [6]])
+    assert.deepStrictEqual(_.transpose([[1, 2, 3], [4], [5, 6]]), [[1, 4, 5], [2, 6], [3]])
+  })
+
   it('rotate', () => {
     assert.deepStrictEqual(_.rotate(1)([]), [])
     assert.deepStrictEqual(_.rotate(1)([1]), [1])

--- a/test/ReadonlyNonEmptyArray.ts
+++ b/test/ReadonlyNonEmptyArray.ts
@@ -185,6 +185,38 @@ describe('ReadonlyNonEmptyArray', () => {
     assert.deepStrictEqual(_.intersperse(0)(_.cons(1, [2, 3, 4])), _.cons(1, [0, 2, 0, 3, 0, 4]))
   })
 
+  it('transpose', () => {
+    assert.deepStrictEqual(
+      _.transpose([
+        [1, 2, 3],
+        [4, 5, 6, 7]
+      ]),
+      [[1, 4], [2, 5], [3, 6], [7]]
+    )
+    assert.deepStrictEqual(_.transpose([[1]]), [[1]])
+    assert.deepStrictEqual(_.transpose([[1, 2, 3]]), [[1], [2], [3]])
+    assert.deepStrictEqual(_.transpose([[1], [2], [3]]), [[1, 2, 3]])
+    assert.deepStrictEqual(_.transpose([[1], [2]]), [[1, 2]])
+    assert.deepStrictEqual(_.transpose([[1], [2, 3]]), [[1, 2], [3]])
+    assert.deepStrictEqual(_.transpose([[1, 2], [3]]), [[1, 3], [2]])
+    assert.deepStrictEqual(
+      _.transpose([
+        [1, 2],
+        [3, 4]
+      ]),
+      [
+        [1, 3],
+        [2, 4]
+      ]
+    )
+    assert.deepStrictEqual(_.transpose([[1, 2, 3], [4]]), [[1, 4], [2], [3]])
+    assert.deepStrictEqual(_.transpose([[1], [2, 3, 4]]), [[1, 2], [3], [4]])
+    assert.deepStrictEqual(_.transpose([[1], [2, 3], [4, 5, 6]]), [[1, 2, 4], [3, 5], [6]])
+    assert.deepStrictEqual(_.transpose([[1, 2, 3], [4, 5], [6]]), [[1, 4, 6], [2, 5], [3]])
+    assert.deepStrictEqual(_.transpose([[1, 2], [3], [4, 5, 6]]), [[1, 3, 4], [2, 5], [6]])
+    assert.deepStrictEqual(_.transpose([[1, 2, 3], [4], [5, 6]]), [[1, 4, 5], [2, 6], [3]])
+  })
+
   it('reverse', () => {
     assert.deepStrictEqual(_.reverse([1, 2, 3]), [3, 2, 1])
   })

--- a/test/ReadonlyNonEmptyArray.ts
+++ b/test/ReadonlyNonEmptyArray.ts
@@ -217,6 +217,35 @@ describe('ReadonlyNonEmptyArray', () => {
     assert.deepStrictEqual(_.transpose([[1, 2, 3], [4], [5, 6]]), [[1, 4, 5], [2, 6], [3]])
   })
 
+  it('flatZip', () => {
+    assert.deepStrictEqual(
+      _.flatZip([
+        [1, 2, 3],
+        [4, 5, 6, 7]
+      ]),
+      [1, 4, 2, 5, 3, 6, 7]
+    )
+    assert.deepStrictEqual(_.flatZip([[1]]), [1])
+    assert.deepStrictEqual(_.flatZip([[1, 2, 3]]), [1, 2, 3])
+    assert.deepStrictEqual(_.flatZip([[1], [2], [3]]), [1, 2, 3])
+    assert.deepStrictEqual(_.flatZip([[1], [2]]), [1, 2])
+    assert.deepStrictEqual(_.flatZip([[1], [2, 3]]), [1, 2, 3])
+    assert.deepStrictEqual(_.flatZip([[1, 2], [3]]), [1, 3, 2])
+    assert.deepStrictEqual(
+      _.flatZip([
+        [1, 2],
+        [3, 4]
+      ]),
+      [1, 3, 2, 4]
+    )
+    assert.deepStrictEqual(_.flatZip([[1, 2, 3], [4]]), [1, 4, 2, 3])
+    assert.deepStrictEqual(_.flatZip([[1], [2, 3, 4]]), [1, 2, 3, 4])
+    assert.deepStrictEqual(_.flatZip([[1], [2, 3], [4, 5, 6]]), [1, 2, 4, 3, 5, 6])
+    assert.deepStrictEqual(_.flatZip([[1, 2, 3], [4, 5], [6]]), [1, 4, 6, 2, 5, 3])
+    assert.deepStrictEqual(_.flatZip([[1, 2], [3], [4, 5, 6]]), [1, 3, 4, 2, 5, 6])
+    assert.deepStrictEqual(_.flatZip([[1, 2, 3], [4], [5, 6]]), [1, 4, 5, 2, 6, 3])
+  })
+
   it('reverse', () => {
     assert.deepStrictEqual(_.reverse([1, 2, 3]), [3, 2, 1])
   })


### PR DESCRIPTION
This PR adds two new functions `flatZip`  and `transpose`, that operate on arrays. The `flatZip` function is used for merging several arrays into one by alternating elements from each array. The `transpose` function flips the x and y axis of a two dimensional array. See the [flat-zip](https://github.com/fregante/flat-zip) npm package and Haskell [transpose](http://zvon.org/other/haskell/Outputlist/transpose_f.html) function for a more detailed explanation.