### PR TITLE
Add more `/*#__PURE__*/` comments to improve tree shaking

### DIFF
--- a/src/IOEither.ts
+++ b/src/IOEither.ts
@@ -807,6 +807,6 @@ export const traverseSeqArray: <A, E, B>(
 /**
  * @since 2.9.0
  */
-export const sequenceSeqArray: <E, A>(
-  arr: ReadonlyArray<IOEither<E, A>>
-) => IOEither<E, ReadonlyArray<A>> = traverseSeqArray(identity)
+export const sequenceSeqArray: <E, A>(arr: ReadonlyArray<IOEither<E, A>>) => IOEither<E, ReadonlyArray<A>> =
+  /*#__PURE__*/
+  traverseSeqArray(identity)

--- a/src/ReaderTaskEither.ts
+++ b/src/ReaderTaskEither.ts
@@ -976,4 +976,6 @@ export const traverseSeqArray: <R, E, A, B>(
  */
 export const sequenceSeqArray: <R, E, A>(
   arr: ReadonlyArray<ReaderTaskEither<R, E, A>>
-) => ReaderTaskEither<R, E, ReadonlyArray<A>> = traverseSeqArray(identity)
+) => ReaderTaskEither<R, E, ReadonlyArray<A>> =
+  /*#__PURE__*/
+  traverseSeqArray(identity)

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -526,4 +526,6 @@ export const traverseSeqArray: <A, B>(f: (a: A) => Task<B>) => (arr: ReadonlyArr
  *
  * @since 2.9.0
  */
-export const sequenceSeqArray: <A>(arr: ReadonlyArray<Task<A>>) => Task<ReadonlyArray<A>> = traverseSeqArray(identity)
+export const sequenceSeqArray: <A>(arr: ReadonlyArray<Task<A>>) => Task<ReadonlyArray<A>> =
+  /*#__PURE__*/
+  traverseSeqArray(identity)

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -1068,6 +1068,6 @@ export const traverseSeqArray: <A, B, E>(
  *
  * @since 2.9.0
  */
-export const sequenceSeqArray: <A, E>(
-  arr: ReadonlyArray<TaskEither<E, A>>
-) => TaskEither<E, ReadonlyArray<A>> = traverseSeqArray(identity)
+export const sequenceSeqArray: <A, E>(arr: ReadonlyArray<TaskEither<E, A>>) => TaskEither<E, ReadonlyArray<A>> =
+  /*#__PURE__*/
+  traverseSeqArray(identity)


### PR DESCRIPTION
More of the same (#1368)

@gcanti WDYT about using a tool which adds these automatically? Something like https://github.com/Andarist/babel-plugin-annotate-pure-calls.