### PR TITLE
Fix documentation typos

### DIFF
--- a/docs/modules/Either.ts.md
+++ b/docs/modules/Either.ts.md
@@ -1450,7 +1450,7 @@ Added in v2.9.0
 ## sequenceArray
 
 convert an array of either to an either of array
-this function have the same behavior of `A.sequence(E.either)` but it's optimized and perform better
+this function has the same behavior of `A.sequence(E.either)` but it's optimized and perform better
 
 **Signature**
 
@@ -1487,7 +1487,7 @@ Added in v2.0.0
 ## traverseArray
 
 map an array using provided function to Either then transform to Either of the array
-this function have the same behavior of `A.traverse(E.either)` but it's optimized and perform better
+this function has the same behavior of `A.traverse(E.either)` but it's optimized and perform better
 
 **Signature**
 

--- a/docs/modules/Either.ts.md
+++ b/docs/modules/Either.ts.md
@@ -1450,7 +1450,7 @@ Added in v2.9.0
 ## sequenceArray
 
 convert an array of either to an either of array
-this function has the same behavior of `A.sequence(E.either)` but it's optimized and perform better
+this function has the same behavior of `A.sequence(E.either)` but it's optimized and performs better
 
 **Signature**
 
@@ -1487,7 +1487,7 @@ Added in v2.0.0
 ## traverseArray
 
 map an array using provided function to Either then transform to Either of the array
-this function has the same behavior of `A.traverse(E.either)` but it's optimized and perform better
+this function has the same behavior of `A.traverse(E.either)` but it's optimized and performs better
 
 **Signature**
 

--- a/docs/modules/IO.ts.md
+++ b/docs/modules/IO.ts.md
@@ -355,7 +355,7 @@ Added in v2.8.0
 
 transform Array of IO to IO of Array
 
-this function have the same behavior of `A.sequence(IO.io)` but it's stack safe
+this function has the same behavior of `A.sequence(IO.io)` but it's stack safe
 
 **Signature**
 
@@ -385,7 +385,7 @@ Added in v2.9.0
 
 runs an action for every element in array, and accumulates the results IO in the array.
 
-this function have the same behavior of `A.traverse(IO.io)` but it's stack safe
+this function has the same behavior of `A.traverse(IO.io)` but it's stack safe
 
 **Signature**
 

--- a/docs/modules/Option.ts.md
+++ b/docs/modules/Option.ts.md
@@ -1457,7 +1457,7 @@ Added in v2.0.0
 
 get an array of option and convert it to option of array
 
-this function has the same behavior of `A.sequence(O.option)` but it's optimized and perform better
+this function has the same behavior of `A.sequence(O.option)` but it's optimized and performs better
 
 **Signature**
 
@@ -1483,7 +1483,7 @@ Added in v2.9.0
 
 Runs an action for every element in array and accumulates the results in option
 
-this function has the same behavior of `A.sequence(O.option)` but it's optimized and perform better
+this function has the same behavior of `A.sequence(O.option)` but it's optimized and performs better
 
 **Signature**
 

--- a/docs/modules/Option.ts.md
+++ b/docs/modules/Option.ts.md
@@ -1457,7 +1457,7 @@ Added in v2.0.0
 
 get an array of option and convert it to option of array
 
-this function have the same behavior of `A.sequence(O.option)` but it's optimized and perform better
+this function has the same behavior of `A.sequence(O.option)` but it's optimized and perform better
 
 **Signature**
 
@@ -1483,7 +1483,7 @@ Added in v2.9.0
 
 Runs an action for every element in array and accumulates the results in option
 
-this function have the same behavior of `A.sequence(O.option)` but it's optimized and perform better
+this function has the same behavior of `A.sequence(O.option)` but it's optimized and perform better
 
 **Signature**
 

--- a/docs/modules/Reader.ts.md
+++ b/docs/modules/Reader.ts.md
@@ -494,7 +494,7 @@ Added in v2.8.0
 
 ## sequenceArray
 
-this function have the same behavior of `A.sequence(R.reader)` but it's stack safe and optimized
+this function has the same behavior of `A.sequence(R.reader)` but it's stack safe and optimized
 
 **Signature**
 
@@ -525,7 +525,7 @@ Added in v2.9.0
 
 ## traverseArray
 
-this function have the same behavior of `A.traverse(R.reader)` but it's stack safe and optimized
+this function has the same behavior of `A.traverse(R.reader)` but it's stack safe and optimized
 
 **Signature**
 

--- a/docs/modules/Task.ts.md
+++ b/docs/modules/Task.ts.md
@@ -483,7 +483,7 @@ Added in v2.0.0
 
 this function works like `Promise.all` it will get an array of tasks and return a task of array.
 
-this function have the same behavior of `A.sequence(T.task)` but it's stack safe.
+this function has the same behavior of `A.sequence(T.task)` but it's stack safe.
 
 > **This function run all task in parallel for sequential use `sequenceSeqArray` **
 
@@ -514,7 +514,7 @@ Added in v2.9.0
 
 run tasks in array sequential and give a task of array
 
-this function have the same behavior of `A.sequence(T.taskSeq)` but it's stack safe.
+this function has the same behavior of `A.sequence(T.taskSeq)` but it's stack safe.
 
 > **This function run all task sequentially for parallel use `sequenceArray` **
 
@@ -530,7 +530,7 @@ Added in v2.9.0
 
 this function map array to task using provided function and transform it to a task of array.
 
-this function have the same behavior of `A.traverse(T.task)` but it's stack safe.
+this function has the same behavior of `A.traverse(T.task)` but it's stack safe.
 
 > **This function run all task in parallel for sequential use `traverseSeqArray` **
 
@@ -572,7 +572,7 @@ Added in v2.9.0
 
 runs an action for every element in array then run task sequential, and accumulates the results in the array.
 
-this function have the same behavior of `A.traverse(T.taskSeq)` but it's stack safe.
+this function has the same behavior of `A.traverse(T.taskSeq)` but it's stack safe.
 
 > **This function run all task sequentially for parallel use `traverseArray` **
 

--- a/docs/modules/TaskEither.ts.md
+++ b/docs/modules/TaskEither.ts.md
@@ -1025,7 +1025,7 @@ Added in v2.9.0
 
 ## sequenceArray
 
-this function have the same behavior of `A.sequence(TE.taskEither)` but it's stack safe and perform better
+this function has the same behavior of `A.sequence(TE.taskEither)` but it's stack safe and perform better
 
 _this function run all tasks in parallel and does not bail out, for sequential version use `sequenceSeqArray`_
 
@@ -1070,7 +1070,7 @@ Added in v2.9.0
 
 ## sequenceSeqArray
 
-this function have the same behavior of `A.sequence(TE.taskEitherSeq)` but it's stack safe and perform better
+this function has the same behavior of `A.sequence(TE.taskEitherSeq)` but it's stack safe and perform better
 
 _this function run all tasks in sequential order and bails out on left side of either, for parallel version use `sequenceArray`_
 
@@ -1136,7 +1136,7 @@ Added in v2.0.0
 
 ## traverseArray
 
-this function have the same behavior of `A.traverse(TE.taskEither)` but it's stack safe and perform better
+this function has the same behavior of `A.traverse(TE.taskEither)` but it's stack safe and perform better
 
 _this function run all tasks in parallel and does not bail out, for sequential version use `traverseSeqArray`_
 
@@ -1195,7 +1195,7 @@ Added in v2.9.0
 
 ## traverseSeqArray
 
-this function have the same behavior of `A.traverse(TE.taskEitherSeq)` but it's stack safe and perform better
+this function has the same behavior of `A.traverse(TE.taskEitherSeq)` but it's stack safe and perform better
 
 _this function run all tasks in sequential order and bails out on left side of either, for parallel version use `traverseArray`_
 

--- a/docs/modules/TaskEither.ts.md
+++ b/docs/modules/TaskEither.ts.md
@@ -1025,7 +1025,7 @@ Added in v2.9.0
 
 ## sequenceArray
 
-this function has the same behavior of `A.sequence(TE.taskEither)` but it's stack safe and perform better
+this function has the same behavior of `A.sequence(TE.taskEither)` but it's stack safe and performs better
 
 _this function run all tasks in parallel and does not bail out, for sequential version use `sequenceSeqArray`_
 
@@ -1070,7 +1070,7 @@ Added in v2.9.0
 
 ## sequenceSeqArray
 
-this function has the same behavior of `A.sequence(TE.taskEitherSeq)` but it's stack safe and perform better
+this function has the same behavior of `A.sequence(TE.taskEitherSeq)` but it's stack safe and performs better
 
 _this function run all tasks in sequential order and bails out on left side of either, for parallel version use `sequenceArray`_
 
@@ -1136,7 +1136,7 @@ Added in v2.0.0
 
 ## traverseArray
 
-this function has the same behavior of `A.traverse(TE.taskEither)` but it's stack safe and perform better
+this function has the same behavior of `A.traverse(TE.taskEither)` but it's stack safe and performs better
 
 _this function run all tasks in parallel and does not bail out, for sequential version use `traverseSeqArray`_
 
@@ -1195,7 +1195,7 @@ Added in v2.9.0
 
 ## traverseSeqArray
 
-this function has the same behavior of `A.traverse(TE.taskEitherSeq)` but it's stack safe and perform better
+this function has the same behavior of `A.traverse(TE.taskEitherSeq)` but it's stack safe and performs better
 
 _this function run all tasks in sequential order and bails out on left side of either, for parallel version use `traverseArray`_
 

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -1415,7 +1415,7 @@ export const traverseArrayWithIndex = <E, A, B>(f: (index: number, a: A) => Eith
 
 /**
  * map an array using provided function to Either then transform to Either of the array
- * this function have the same behavior of `A.traverse(E.either)` but it's optimized and perform better
+ * this function has the same behavior of `A.traverse(E.either)` but it's optimized and perform better
  *
  * @example
  *
@@ -1452,7 +1452,7 @@ export const traverseArray: <E, A, B>(
 
 /**
  * convert an array of either to an either of array
- * this function have the same behavior of `A.sequence(E.either)` but it's optimized and perform better
+ * this function has the same behavior of `A.sequence(E.either)` but it's optimized and perform better
  *
  * @example
  *

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -1415,7 +1415,7 @@ export const traverseArrayWithIndex = <E, A, B>(f: (index: number, a: A) => Eith
 
 /**
  * map an array using provided function to Either then transform to Either of the array
- * this function has the same behavior of `A.traverse(E.either)` but it's optimized and perform better
+ * this function has the same behavior of `A.traverse(E.either)` but it's optimized and performs better
  *
  * @example
  *
@@ -1452,7 +1452,7 @@ export const traverseArray: <E, A, B>(
 
 /**
  * convert an array of either to an either of array
- * this function has the same behavior of `A.sequence(E.either)` but it's optimized and perform better
+ * this function has the same behavior of `A.sequence(E.either)` but it's optimized and performs better
  *
  * @example
  *

--- a/src/IO.ts
+++ b/src/IO.ts
@@ -320,7 +320,7 @@ export const traverseArrayWithIndex: <A, B>(
 /**
  * runs an action for every element in array, and accumulates the results IO in the array.
  *
- * this function have the same behavior of `A.traverse(IO.io)` but it's stack safe
+ * this function has the same behavior of `A.traverse(IO.io)` but it's stack safe
  *
  * @example
  * import * as RA from 'fp-ts/ReadonlyArray'
@@ -341,7 +341,7 @@ export const traverseArray: <A, B>(f: (a: A) => IO<B>) => (arr: ReadonlyArray<A>
 /**
  * transform Array of IO to IO of Array
  *
- * this function have the same behavior of `A.sequence(IO.io)` but it's stack safe
+ * this function has the same behavior of `A.sequence(IO.io)` but it's stack safe
  *
  * @example
  * import * as RA from 'fp-ts/ReadonlyArray'

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -1314,7 +1314,7 @@ export const traverseArrayWithIndex = <A, B>(f: (index: number, a: A) => Option<
 /**
  * Runs an action for every element in array and accumulates the results in option
  *
- * this function has the same behavior of `A.sequence(O.option)` but it's optimized and perform better
+ * this function has the same behavior of `A.sequence(O.option)` but it's optimized and performs better
  *
  * @example
  *
@@ -1335,7 +1335,7 @@ export const traverseArray: <A, B>(f: (a: A) => Option<B>) => (arr: ReadonlyArra
 /**
  * get an array of option and convert it to option of array
  *
- * this function has the same behavior of `A.sequence(O.option)` but it's optimized and perform better
+ * this function has the same behavior of `A.sequence(O.option)` but it's optimized and performs better
  *
  * @example
  *

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -1314,7 +1314,7 @@ export const traverseArrayWithIndex = <A, B>(f: (index: number, a: A) => Option<
 /**
  * Runs an action for every element in array and accumulates the results in option
  *
- * this function have the same behavior of `A.sequence(O.option)` but it's optimized and perform better
+ * this function has the same behavior of `A.sequence(O.option)` but it's optimized and perform better
  *
  * @example
  *
@@ -1335,7 +1335,7 @@ export const traverseArray: <A, B>(f: (a: A) => Option<B>) => (arr: ReadonlyArra
 /**
  * get an array of option and convert it to option of array
  *
- * this function have the same behavior of `A.sequence(O.option)` but it's optimized and perform better
+ * this function has the same behavior of `A.sequence(O.option)` but it's optimized and perform better
  *
  * @example
  *

--- a/src/Reader.ts
+++ b/src/Reader.ts
@@ -424,7 +424,7 @@ export const traverseArrayWithIndex: <R, A, B>(
 ) => (arr: ReadonlyArray<A>) => Reader<R, ReadonlyArray<B>> = (f) => (arr) => (r) => arr.map((x, i) => f(i, x)(r))
 
 /**
- * this function have the same behavior of `A.traverse(R.reader)` but it's stack safe and optimized
+ * this function has the same behavior of `A.traverse(R.reader)` but it's stack safe and optimized
  *
  * @example
  * import * as RA from 'fp-ts/ReadonlyArray'
@@ -443,7 +443,7 @@ export const traverseArray: <R, A, B>(
 ) => (arr: ReadonlyArray<A>) => Reader<R, ReadonlyArray<B>> = (f) => traverseArrayWithIndex((_, a) => f(a))
 
 /**
- * this function have the same behavior of `A.sequence(R.reader)` but it's stack safe and optimized
+ * this function has the same behavior of `A.sequence(R.reader)` but it's stack safe and optimized
  *
  * @example
  * import * as RA from 'fp-ts/ReadonlyArray'

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -444,7 +444,7 @@ export const traverseArrayWithIndex: <A, B>(
 /**
  * this function map array to task using provided function and transform it to a task of array.
  *
- * this function have the same behavior of `A.traverse(T.task)` but it's stack safe.
+ * this function has the same behavior of `A.traverse(T.task)` but it's stack safe.
  *
  * > **This function run all task in parallel for sequential use `traverseSeqArray` **
  *
@@ -467,7 +467,7 @@ export const traverseArray: <A, B>(f: (a: A) => Task<B>) => (arr: ReadonlyArray<
 /**
  * this function works like `Promise.all` it will get an array of tasks and return a task of array.
  *
- * this function have the same behavior of `A.sequence(T.task)` but it's stack safe.
+ * this function has the same behavior of `A.sequence(T.task)` but it's stack safe.
  *
  * > **This function run all task in parallel for sequential use `sequenceSeqArray` **
  *
@@ -506,7 +506,7 @@ export const traverseSeqArrayWithIndex: <A, B>(
 /**
  * runs an action for every element in array then run task sequential, and accumulates the results in the array.
  *
- * this function have the same behavior of `A.traverse(T.taskSeq)` but it's stack safe.
+ * this function has the same behavior of `A.traverse(T.taskSeq)` but it's stack safe.
  *
  * > **This function run all task sequentially for parallel use `traverseArray` **
  *
@@ -520,7 +520,7 @@ export const traverseSeqArray: <A, B>(f: (a: A) => Task<B>) => (arr: ReadonlyArr
 /**
  * run tasks in array sequential and give a task of array
  *
- * this function have the same behavior of `A.sequence(T.taskSeq)` but it's stack safe.
+ * this function has the same behavior of `A.sequence(T.taskSeq)` but it's stack safe.
  *
  * > **This function run all task sequentially for parallel use `sequenceArray` **
  *

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -952,7 +952,7 @@ export const traverseArrayWithIndex: <A, B, E>(
   pipe(arr, T.traverseArrayWithIndex(f), T.map(E.sequenceArray))
 
 /**
- * this function has the same behavior of `A.traverse(TE.taskEither)` but it's stack safe and perform better
+ * this function has the same behavior of `A.traverse(TE.taskEither)` but it's stack safe and performs better
  *
  * *this function run all tasks in parallel and does not bail out, for sequential version use `traverseSeqArray`*
  *
@@ -992,7 +992,7 @@ export const traverseArray: <A, B, E>(
 ) => (arr: ReadonlyArray<A>) => TaskEither<E, ReadonlyArray<B>> = (f) => traverseArrayWithIndex((_, a) => f(a))
 
 /**
- * this function has the same behavior of `A.sequence(TE.taskEither)` but it's stack safe and perform better
+ * this function has the same behavior of `A.sequence(TE.taskEither)` but it's stack safe and performs better
  *
  * *this function run all tasks in parallel and does not bail out, for sequential version use `sequenceSeqArray`*
  *
@@ -1051,7 +1051,7 @@ export const traverseSeqArrayWithIndex: <A, B, E>(
 }
 
 /**
- * this function has the same behavior of `A.traverse(TE.taskEitherSeq)` but it's stack safe and perform better
+ * this function has the same behavior of `A.traverse(TE.taskEitherSeq)` but it's stack safe and performs better
  *
  * *this function run all tasks in sequential order and bails out on left side of either, for parallel version use `traverseArray`*
  *
@@ -1062,7 +1062,7 @@ export const traverseSeqArray: <A, B, E>(
 ) => (arr: ReadonlyArray<A>) => TaskEither<E, ReadonlyArray<B>> = (f) => traverseSeqArrayWithIndex((_, a) => f(a))
 
 /**
- * this function has the same behavior of `A.sequence(TE.taskEitherSeq)` but it's stack safe and perform better
+ * this function has the same behavior of `A.sequence(TE.taskEitherSeq)` but it's stack safe and performs better
  *
  * *this function run all tasks in sequential order and bails out on left side of either, for parallel version use `sequenceArray`*
  *

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -952,7 +952,7 @@ export const traverseArrayWithIndex: <A, B, E>(
   pipe(arr, T.traverseArrayWithIndex(f), T.map(E.sequenceArray))
 
 /**
- * this function have the same behavior of `A.traverse(TE.taskEither)` but it's stack safe and perform better
+ * this function has the same behavior of `A.traverse(TE.taskEither)` but it's stack safe and perform better
  *
  * *this function run all tasks in parallel and does not bail out, for sequential version use `traverseSeqArray`*
  *
@@ -992,7 +992,7 @@ export const traverseArray: <A, B, E>(
 ) => (arr: ReadonlyArray<A>) => TaskEither<E, ReadonlyArray<B>> = (f) => traverseArrayWithIndex((_, a) => f(a))
 
 /**
- * this function have the same behavior of `A.sequence(TE.taskEither)` but it's stack safe and perform better
+ * this function has the same behavior of `A.sequence(TE.taskEither)` but it's stack safe and perform better
  *
  * *this function run all tasks in parallel and does not bail out, for sequential version use `sequenceSeqArray`*
  *
@@ -1051,7 +1051,7 @@ export const traverseSeqArrayWithIndex: <A, B, E>(
 }
 
 /**
- * this function have the same behavior of `A.traverse(TE.taskEitherSeq)` but it's stack safe and perform better
+ * this function has the same behavior of `A.traverse(TE.taskEitherSeq)` but it's stack safe and perform better
  *
  * *this function run all tasks in sequential order and bails out on left side of either, for parallel version use `traverseArray`*
  *
@@ -1062,7 +1062,7 @@ export const traverseSeqArray: <A, B, E>(
 ) => (arr: ReadonlyArray<A>) => TaskEither<E, ReadonlyArray<B>> = (f) => traverseSeqArrayWithIndex((_, a) => f(a))
 
 /**
- * this function have the same behavior of `A.sequence(TE.taskEitherSeq)` but it's stack safe and perform better
+ * this function has the same behavior of `A.sequence(TE.taskEitherSeq)` but it's stack safe and perform better
  *
  * *this function run all tasks in sequential order and bails out on left side of either, for parallel version use `sequenceArray`*
  *


### PR DESCRIPTION
Fix two small typos

`this function have` -> `this function has`
`and perform better` -> `and performs better`