### PR TITLE
tryCatch impl (rxjs parity)

### DIFF
--- a/docs/modules/TaskEither.ts.md
+++ b/docs/modules/TaskEither.ts.md
@@ -533,10 +533,9 @@ Converts a function returning a `Promise` to one returning a `TaskEither`.
 **Signature**
 
 ```ts
-export declare function tryCatchK<E, A extends ReadonlyArray<unknown>, B>(
-  f: (...a: A) => Promise<B>,
-  onRejected: (reason: unknown) => E
-): (...a: A) => TaskEither<E, B>
+export declare function tryCatchK<A extends ReadonlyArray<unknown>, B>(
+  f: (...a: A) => Promise<B>
+): (...a: A) => TaskEither<unknown, B>
 ```
 
 Added in v2.5.0
@@ -661,19 +660,26 @@ Note: `f` should never `throw` errors, they are not caught.
 **Signature**
 
 ```ts
-export declare function tryCatch<E, A>(f: Lazy<Promise<A>>, onRejected: (reason: unknown) => E): TaskEither<E, A>
+export declare function tryCatch<A>(f: Lazy<Promise<A>>): TaskEither<unknown, A>
 ```
 
 **Example**
 
 ```ts
+import { pipe } from 'fp-ts/function'
 import { left, right } from 'fp-ts/Either'
-import { tryCatch } from 'fp-ts/TaskEither'
+import { tryCatch, mapLeft } from 'fp-ts/TaskEither'
 
-tryCatch(() => Promise.resolve(1), String)().then((result) => {
+pipe(
+  tryCatch(() => Promise.resolve(1)),
+  mapLeft(String)
+)().then((result) => {
   assert.deepStrictEqual(result, right(1))
 })
-tryCatch(() => Promise.reject('error'), String)().then((result) => {
+pipe(
+  tryCatch(() => Promise.reject('error')),
+  mapLeft(String)
+)().then((result) => {
   assert.deepStrictEqual(result, left('error'))
 })
 ```

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -148,7 +148,10 @@ export const fromPredicate: {
  * @since 2.0.0
  */
 export function tryCatch<E, A>(f: Lazy<Promise<A>>, onRejected: (reason: unknown) => E): TaskEither<E, A> {
-  return () => f().then(E.right, (reason) => E.left(onRejected(reason)))
+  return () =>
+    f()
+      .then(E.right)
+      .catch((reason) => E.left(onRejected(reason)))
 }
 
 // -------------------------------------------------------------------------------------

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -135,12 +135,18 @@ export const fromPredicate: {
  *
  * @example
  * import { left, right } from 'fp-ts/Either'
- * import { tryCatch } from 'fp-ts/TaskEither'
+ * import { tryCatch, mapLeft } from 'fp-ts/TaskEither'
  *
- * tryCatch(() => Promise.resolve(1), String)().then(result => {
+ * pipe(
+ *   tryCatch(() => Promise.resolve(1)),
+ *   mapLeft(String)
+ * )().then(result => {
  *   assert.deepStrictEqual(result, right(1))
  * })
- * tryCatch(() => Promise.reject('error'), String)().then(result => {
+ * pipe(
+ *   tryCatch(() => Promise.reject('error')),
+ *   mapLeft(String)
+ * )().then(result => {
  *   assert.deepStrictEqual(result, left('error'))
  * })
  *

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -147,11 +147,9 @@ export const fromPredicate: {
  * @category constructors
  * @since 2.0.0
  */
-export function tryCatch<E, A>(f: Lazy<Promise<A>>, onRejected: (reason: unknown) => E): TaskEither<E, A> {
+export function tryCatch<A>(f: Lazy<Promise<A>>): TaskEither<unknown, A> {
   return () =>
-    f()
-      .then(E.right)
-      .catch((reason) => E.left(onRejected(reason)))
+    f().then(E.right).catch(E.left)
 }
 
 // -------------------------------------------------------------------------------------
@@ -251,11 +249,10 @@ export const filterOrElse: {
  * @category combinators
  * @since 2.5.0
  */
-export function tryCatchK<E, A extends ReadonlyArray<unknown>, B>(
+export function tryCatchK<A extends ReadonlyArray<unknown>, B>(
   f: (...a: A) => Promise<B>,
-  onRejected: (reason: unknown) => E
-): (...a: A) => TaskEither<E, B> {
-  return (...a) => tryCatch(() => f(...a), onRejected)
+): (...a: A) => TaskEither<unknown, B> {
+  return (...a) => tryCatch(() => f(...a))
 }
 
 /**

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -134,6 +134,7 @@ export const fromPredicate: {
  * Note: `f` should never `throw` errors, they are not caught.
  *
  * @example
+ * import { pipe } from 'fp-ts/function'
  * import { left, right } from 'fp-ts/Either'
  * import { tryCatch, mapLeft } from 'fp-ts/TaskEither'
  *
@@ -154,8 +155,7 @@ export const fromPredicate: {
  * @since 2.0.0
  */
 export function tryCatch<A>(f: Lazy<Promise<A>>): TaskEither<unknown, A> {
-  return () =>
-    f().then(E.right).catch(E.left)
+  return () => f().then(E.right).catch(E.left)
 }
 
 // -------------------------------------------------------------------------------------
@@ -256,7 +256,7 @@ export const filterOrElse: {
  * @since 2.5.0
  */
 export function tryCatchK<A extends ReadonlyArray<unknown>, B>(
-  f: (...a: A) => Promise<B>,
+  f: (...a: A) => Promise<B>
 ): (...a: A) => TaskEither<unknown, B> {
   return (...a) => tryCatch(() => f(...a))
 }

--- a/test/TaskEither.ts
+++ b/test/TaskEither.ts
@@ -345,22 +345,13 @@ describe('TaskEither', () => {
 
     it('resolving', async () => {
       const fOk = (n: number, s: string) => Promise.resolve(n + s.length)
-      return assert.deepStrictEqual(
-        await pipe(
-          _.tryCatchK(fOk)(2, '1'),
-          _.mapLeft(handleRejection)
-        )(),
-        E.right(3)
-      )
+      return assert.deepStrictEqual(await pipe(_.tryCatchK(fOk)(2, '1'), _.mapLeft(handleRejection))(), E.right(3))
     })
 
     it('rejecting', async () => {
       const fReject = () => Promise.reject()
       return assert.deepStrictEqual(
-        await pipe(
-          _.tryCatchK(fReject)(),
-          _.mapLeft(handleRejection)
-        )(),
+        await pipe(_.tryCatchK(fReject)(), _.mapLeft(handleRejection))(),
         E.left('rejected')
       )
     })
@@ -381,17 +372,10 @@ describe('TaskEither', () => {
   })
 
   it('tryCatch', async () => {
-    assert.deepStrictEqual(
-      await _.tryCatch(
-        () => Promise.resolve(1),
-      )(),
-      E.right(1)
-    )
+    assert.deepStrictEqual(await _.tryCatch(() => Promise.resolve(1))(), E.right(1))
     assert.deepStrictEqual(
       await pipe(
-        _.tryCatch(
-          () => Promise.reject(undefined),
-        ),
+        _.tryCatch(() => Promise.reject(undefined)),
         _.mapLeft(() => 'error')
       )(),
       E.left('error')

--- a/test/TaskEither.ts
+++ b/test/TaskEither.ts
@@ -345,12 +345,24 @@ describe('TaskEither', () => {
 
     it('resolving', async () => {
       const fOk = (n: number, s: string) => Promise.resolve(n + s.length)
-      return assert.deepStrictEqual(await _.tryCatchK(fOk, handleRejection)(2, '1')(), E.right(3))
+      return assert.deepStrictEqual(
+        await pipe(
+          _.tryCatchK(fOk)(2, '1'),
+          _.mapLeft(handleRejection)
+        )(),
+        E.right(3)
+      )
     })
 
     it('rejecting', async () => {
       const fReject = () => Promise.reject()
-      return assert.deepStrictEqual(await _.tryCatchK(fReject, handleRejection)()(), E.left('rejected'))
+      return assert.deepStrictEqual(
+        await pipe(
+          _.tryCatchK(fReject)(),
+          _.mapLeft(handleRejection)
+        )(),
+        E.left('rejected')
+      )
     })
   })
 
@@ -372,14 +384,15 @@ describe('TaskEither', () => {
     assert.deepStrictEqual(
       await _.tryCatch(
         () => Promise.resolve(1),
-        () => 'error'
       )(),
       E.right(1)
     )
     assert.deepStrictEqual(
-      await _.tryCatch(
-        () => Promise.reject(undefined),
-        () => 'error'
+      await pipe(
+        _.tryCatch(
+          () => Promise.reject(undefined),
+        ),
+        _.mapLeft(() => 'error')
       )(),
       E.left('error')
     )


### PR DESCRIPTION
Logically equivalent semantic change in the implementation of `tryCatch` for parity with the rxjs `tryCatch` https://github.com/gcanti/fp-ts-rxjs/pull/46, as per @OliverJAsh suggestion https://github.com/gcanti/fp-ts-rxjs/issues/31#issuecomment-760982846

Uses `promise.then(a).catch(e)` instead of `promise.then(a, e)`