### PR TITLE
tryCatch impl (rxjs parity)

### DIFF
--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -127,7 +127,7 @@ export const fromEither: FromEither2<URI>['fromEither'] =
  * @category constructors
  * @since 3.0.0
  */
-export const tryCatch = <A>(f: Lazy<Promise<A>>): TaskEither<unknown, A> => () => f().then(E.right, E.left)
+export const tryCatch = <A>(f: Lazy<Promise<A>>): TaskEither<unknown, A> => () => f().then(E.right).catch(E.left)
 
 /**
  * @category constructors


### PR DESCRIPTION
Logically equivalent semantic change in the implementation of tryCatch for parity with the rxjs `tryCatch` https://github.com/gcanti/fp-ts-rxjs/pull/48 as per @OliverJAsh suggestion https://github.com/gcanti/fp-ts-rxjs/issues/31#issuecomment-760982846

Semantically, `promise.then(a).catch(e)` is closer to `observable.pipe(catchError(e))` than promise.then(a, e). This should have no bearing on tests or behavior, since E.right will never throw an error.

Difference btw/n `then`'s `onRejected` and `catch` documented [here](https://www.codingame.com/playgrounds/347/javascript-promises-mastering-the-asynchronous/the-catch-method), though they are logically equivalent in this case.