### PR TITLE
feat: add monoidSumBigInt and monoidProductBigInt

### DIFF
--- a/docs/modules/Monoid.ts.md
+++ b/docs/modules/Monoid.ts.md
@@ -55,8 +55,10 @@ Added in v2.0.0
   - [monoidAll](#monoidall)
   - [monoidAny](#monoidany)
   - [monoidProduct](#monoidproduct)
+  - [monoidProductBigInt](#monoidproductbigint)
   - [monoidString](#monoidstring)
   - [monoidSum](#monoidsum)
+  - [monoidSumBigInt](#monoidsumbigint)
   - [monoidVoid](#monoidvoid)
 - [type classes](#type-classes)
   - [Monoid (interface)](#monoid-interface)
@@ -310,6 +312,28 @@ assert.deepStrictEqual(M.monoidProduct.concat(2, 3), 6)
 
 Added in v2.0.0
 
+## monoidProductBigInt
+
+`bigint` monoid under multiplication.
+
+The `empty` value is `BigInt(1)`.
+
+**Signature**
+
+```ts
+export declare const monoidProductBigInt: Monoid<bigint>
+```
+
+**Example**
+
+```ts
+import * as M from 'fp-ts/Monoid'
+
+assert.deepStrictEqual(M.monoidProductBigInt.concat(BigInt(2), BigInt(3)), BigInt(6))
+```
+
+Added in v2.10.0
+
 ## monoidString
 
 `string` monoid under concatenation.
@@ -353,6 +377,28 @@ assert.deepStrictEqual(M.monoidSum.concat(2, 3), 5)
 ```
 
 Added in v2.0.0
+
+## monoidSumBigInt
+
+`bigint` monoid under addition.
+
+The `empty` value is `BigInt(0)`.
+
+**Signature**
+
+```ts
+export declare const monoidSumBigInt: Monoid<bigint>
+```
+
+**Example**
+
+```ts
+import * as M from 'fp-ts/Monoid'
+
+assert.deepStrictEqual(M.monoidSumBigInt.concat(BigInt(2), BigInt(3)), BigInt(5))
+```
+
+Added in v2.10.0
 
 ## monoidVoid
 

--- a/docs/modules/Semigroup.ts.md
+++ b/docs/modules/Semigroup.ts.md
@@ -62,8 +62,10 @@ Added in v2.0.0
   - [semigroupAll](#semigroupall)
   - [semigroupAny](#semigroupany)
   - [semigroupProduct](#semigroupproduct)
+  - [semigroupProductBigInt](#semigroupproductbigint)
   - [semigroupString](#semigroupstring)
   - [semigroupSum](#semigroupsum)
+  - [semigroupSumBigInt](#semigroupsumbigint)
   - [semigroupVoid](#semigroupvoid)
 - [type classes](#type-classes)
   - [Semigroup (interface)](#semigroup-interface)
@@ -382,6 +384,26 @@ assert.deepStrictEqual(S.semigroupProduct.concat(2, 3), 6)
 
 Added in v2.0.0
 
+## semigroupProductBigInt
+
+`bigint` semigroup under multiplication.
+
+**Signature**
+
+```ts
+export declare const semigroupProductBigInt: Semigroup<bigint>
+```
+
+**Example**
+
+```ts
+import * as S from 'fp-ts/Semigroup'
+
+assert.deepStrictEqual(S.semigroupProductBigInt.concat(BigInt(2), BigInt(3)), BigInt(6))
+```
+
+Added in v2.10.0
+
 ## semigroupString
 
 `string` semigroup under concatenation.
@@ -421,6 +443,26 @@ assert.deepStrictEqual(S.semigroupSum.concat(2, 3), 5)
 ```
 
 Added in v2.0.0
+
+## semigroupSumBigInt
+
+`bigint` semigroup under addition.
+
+**Signature**
+
+```ts
+export declare const semigroupSumBigInt: Semigroup<bigint>
+```
+
+**Example**
+
+```ts
+import * as S from 'fp-ts/Semigroup'
+
+assert.deepStrictEqual(S.semigroupSumBigInt.concat(BigInt(2), BigInt(3)), BigInt(5))
+```
+
+Added in v2.10.0
 
 ## semigroupVoid
 

--- a/src/Monoid.ts
+++ b/src/Monoid.ts
@@ -121,6 +121,42 @@ export const monoidProduct: Monoid<number> = {
 }
 
 /**
+ * `bigint` monoid under addition.
+ *
+ * The `empty` value is `BigInt(0)`.
+ *
+ * @example
+ * import * as M from 'fp-ts/Monoid'
+ *
+ * assert.deepStrictEqual(M.monoidSumBigInt.concat(BigInt(2), BigInt(3)), BigInt(5))
+ *
+ * @category instances
+ * @since 2.10.0
+ */
+export const monoidSumBigInt: Monoid<bigint> = {
+  concat: S.semigroupSumBigInt.concat,
+  empty: BigInt(0)
+}
+
+/**
+ * `bigint` monoid under multiplication.
+ *
+ * The `empty` value is `BigInt(1)`.
+ *
+ * @example
+ * import * as M from 'fp-ts/Monoid'
+ *
+ * assert.deepStrictEqual(M.monoidProductBigInt.concat(BigInt(2), BigInt(3)), BigInt(6))
+ *
+ * @category instances
+ * @since 2.10.0
+ */
+export const monoidProductBigInt: Monoid<bigint> = {
+  concat: S.semigroupProductBigInt.concat,
+  empty: BigInt(1)
+}
+
+/**
  * `string` monoid under concatenation.
  *
  * The `empty` value is `''`.

--- a/src/Semigroup.ts
+++ b/src/Semigroup.ts
@@ -341,6 +341,36 @@ export const semigroupProduct: Semigroup<number> = {
 }
 
 /**
+ * `bigint` semigroup under addition.
+ *
+ * @example
+ * import * as S from 'fp-ts/Semigroup'
+ *
+ * assert.deepStrictEqual(S.semigroupSumBigInt.concat(BigInt(2), BigInt(3)), BigInt(5))
+ *
+ * @category instances
+ * @since 2.10.0
+ */
+export const semigroupSumBigInt: Semigroup<bigint> = {
+  concat: (x, y) => x + y
+}
+
+/**
+ * `bigint` semigroup under multiplication.
+ *
+ * @example
+ * import * as S from 'fp-ts/Semigroup'
+ *
+ * assert.deepStrictEqual(S.semigroupProductBigInt.concat(BigInt(2), BigInt(3)), BigInt(6))
+ *
+ * @category instances
+ * @since 2.10.0
+ */
+export const semigroupProductBigInt: Semigroup<bigint> = {
+  concat: (x, y) => x * y
+}
+
+/**
  * `string` semigroup under concatenation.
  *
  * @example

--- a/test/Semigroup.ts
+++ b/test/Semigroup.ts
@@ -47,6 +47,14 @@ describe('Semigroup', () => {
     assert.deepStrictEqual(_.semigroupProduct.concat(2, 3), 6)
   })
 
+  it('semigroupSumBigInt', () => {
+    assert.deepStrictEqual(_.semigroupSumBigInt.concat(BigInt(2), BigInt(3)), BigInt(5))
+  })
+
+  it('semigroupSumBigInt', () => {
+    assert.deepStrictEqual(_.semigroupProductBigInt.concat(BigInt(2), BigInt(3)), BigInt(6))
+  })
+
   it('getFirstSemigroup', () => {
     assert.deepStrictEqual(_.getFirstSemigroup<number>().concat(1, 2), 1)
   })


### PR DESCRIPTION
The added monoids and semigroups behave the same as monoidSum
and monoidProduct for numbers.