### PR TITLE
Array, ReadonlyArray: change scanLeft & scanRight to return NonEmpty

### DIFF
--- a/docs/modules/Array.ts.md
+++ b/docs/modules/Array.ts.md
@@ -895,7 +895,7 @@ Same as `reduce` but it carries over the intermediate steps
 **Signature**
 
 ```ts
-export declare const scanLeft: <A, B>(b: B, f: (b: B, a: A) => B) => (as: A[]) => B[]
+export declare const scanLeft: <A, B>(b: B, f: (b: B, a: A) => B) => (as: A[]) => NonEmptyArray<B>
 ```
 
 **Example**
@@ -915,7 +915,7 @@ Fold an array from the right, keeping all intermediate results instead of only t
 **Signature**
 
 ```ts
-export declare const scanRight: <A, B>(b: B, f: (a: A, b: B) => B) => (as: A[]) => B[]
+export declare const scanRight: <A, B>(b: B, f: (a: A, b: B) => B) => (as: A[]) => NonEmptyArray<B>
 ```
 
 **Example**

--- a/docs/modules/ReadonlyArray.ts.md
+++ b/docs/modules/ReadonlyArray.ts.md
@@ -884,7 +884,7 @@ Same as `reduce` but it carries over the intermediate steps
 **Signature**
 
 ```ts
-export declare function scanLeft<A, B>(b: B, f: (b: B, a: A) => B): (as: ReadonlyArray<A>) => ReadonlyArray<B>
+export declare function scanLeft<A, B>(b: B, f: (b: B, a: A) => B): (as: ReadonlyArray<A>) => ReadonlyNonEmptyArray<B>
 ```
 
 **Example**
@@ -904,7 +904,7 @@ Fold an array from the right, keeping all intermediate results instead of only t
 **Signature**
 
 ```ts
-export declare function scanRight<A, B>(b: B, f: (a: A, b: B) => B): (as: ReadonlyArray<A>) => ReadonlyArray<B>
+export declare function scanRight<A, B>(b: B, f: (a: A, b: B) => B): (as: ReadonlyArray<A>) => ReadonlyNonEmptyArray<B>
 ```
 
 **Example**

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -189,7 +189,7 @@ export const foldRight: <A, B>(
  * @category combinators
  * @since 2.0.0
  */
-export const scanLeft: <A, B>(b: B, f: (b: B, a: A) => B) => (as: Array<A>) => Array<B> = RA.scanLeft as any
+export const scanLeft: <A, B>(b: B, f: (b: B, a: A) => B) => (as: Array<A>) => NonEmptyArray<B> = RA.scanLeft as any
 
 /**
  * Fold an array from the right, keeping all intermediate results instead of only the final result
@@ -202,7 +202,7 @@ export const scanLeft: <A, B>(b: B, f: (b: B, a: A) => B) => (as: Array<A>) => A
  * @category combinators
  * @since 2.0.0
  */
-export const scanRight: <A, B>(b: B, f: (a: A, b: B) => B) => (as: Array<A>) => Array<B> = RA.scanRight as any
+export const scanRight: <A, B>(b: B, f: (a: A, b: B) => B) => (as: Array<A>) => NonEmptyArray<B> = RA.scanRight as any
 
 /**
  * Test whether an array is empty

--- a/src/ReadonlyArray.ts
+++ b/src/ReadonlyArray.ts
@@ -25,6 +25,7 @@ import { Monad1 } from './Monad'
 import { Monoid } from './Monoid'
 import * as O from './Option'
 import { fromCompare, getMonoid as getOrdMonoid, Ord, ordNumber } from './Ord'
+import { NonEmptyArray } from './NonEmptyArray'
 import { ReadonlyNonEmptyArray } from './ReadonlyNonEmptyArray'
 import { Show } from './Show'
 import { PipeableTraverse1, Traversable1 } from './Traversable'
@@ -299,11 +300,10 @@ export function foldRight<A, B>(
  * @category combinators
  * @since 2.5.0
  */
-export function scanLeft<A, B>(b: B, f: (b: B, a: A) => B): (as: ReadonlyArray<A>) => ReadonlyArray<B> {
+export function scanLeft<A, B>(b: B, f: (b: B, a: A) => B): (as: ReadonlyArray<A>) => ReadonlyNonEmptyArray<B> {
   return (as) => {
     const l = as.length
-    // tslint:disable-next-line: readonly-array
-    const r: Array<B> = new Array(l + 1)
+    const r = new Array(l + 1) as NonEmptyArray<B>
     r[0] = b
     for (let i = 0; i < l; i++) {
       r[i + 1] = f(r[i], as[i])
@@ -323,11 +323,10 @@ export function scanLeft<A, B>(b: B, f: (b: B, a: A) => B): (as: ReadonlyArray<A
  * @category combinators
  * @since 2.5.0
  */
-export function scanRight<A, B>(b: B, f: (a: A, b: B) => B): (as: ReadonlyArray<A>) => ReadonlyArray<B> {
+export function scanRight<A, B>(b: B, f: (a: A, b: B) => B): (as: ReadonlyArray<A>) => ReadonlyNonEmptyArray<B> {
   return (as) => {
     const l = as.length
-    // tslint:disable-next-line: readonly-array
-    const r: Array<B> = new Array(l + 1)
+    const r = new Array(l + 1) as NonEmptyArray<B>
     r[l] = b
     for (let i = l - 1; i >= 0; i--) {
       r[i] = f(as[i], r[i + 1])


### PR DESCRIPTION
Given scanLeft/Right, unlike reduce, always returns an array that has at least one element (the seed),
it makes sense to me to be more specific about the result.

What do you think? Are there any unintended consequences I'm missing here?