### PR TITLE
Add the `flap` function

### DIFF
--- a/docs/modules/Array.ts.md
+++ b/docs/modules/Array.ts.md
@@ -71,6 +71,7 @@ Added in v2.0.0
   - [dropLeftWhile](#dropleftwhile)
   - [dropRight](#dropright)
   - [duplicate](#duplicate)
+  - [flap](#flap)
   - [flatten](#flatten)
   - [intersection](#intersection)
   - [intersperse](#intersperse)
@@ -715,6 +716,16 @@ export declare const duplicate: <A>(wa: A[]) => A[][]
 ```
 
 Added in v2.0.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <B>(fab: ((a: A) => B)[]) => B[]
+```
+
+Added in v2.10.0
 
 ## flatten
 

--- a/docs/modules/Const.ts.md
+++ b/docs/modules/Const.ts.md
@@ -25,6 +25,8 @@ Added in v2.0.0
   - [contramap](#contramap)
 - [Functor](#functor)
   - [map](#map)
+- [combinators](#combinators)
+  - [flap](#flap)
 - [constructors](#constructors)
   - [make](#make)
 - [instances](#instances)
@@ -103,6 +105,18 @@ export declare const map: <A, B>(f: (a: A) => B) => <E>(fa: Const<E, A>) => Cons
 ```
 
 Added in v2.0.0
+
+# combinators
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <E, B>(fab: Const<E, (a: A) => B>) => Const<E, B>
+```
+
+Added in v2.10.0
 
 # constructors
 

--- a/docs/modules/Either.ts.md
+++ b/docs/modules/Either.ts.md
@@ -61,6 +61,7 @@ Added in v2.0.0
   - [duplicate](#duplicate)
   - [filterOrElse](#filterorelse)
   - [filterOrElseW](#filterorelsew)
+  - [flap](#flap)
   - [flatten](#flatten)
   - [fromNullableK](#fromnullablek)
   - [fromOptionK](#fromoptionk)
@@ -590,6 +591,16 @@ export declare const filterOrElseW: {
 ```
 
 Added in v2.9.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <E, B>(fab: Either<E, (a: A) => B>) => Either<E, B>
+```
+
+Added in v2.10.0
 
 ## flatten
 

--- a/docs/modules/Functor.ts.md
+++ b/docs/modules/Functor.ts.md
@@ -24,6 +24,8 @@ Added in v2.0.0
 
 - [combinators](#combinators)
   - [map](#map)
+- [derivables](#derivables)
+  - [flap](#flap)
 - [type classes](#type-classes)
   - [Functor (interface)](#functor-interface)
   - [Functor1 (interface)](#functor1-interface)
@@ -72,6 +74,28 @@ export declare function map<F, G>(
   F: Functor<F>,
   G: Functor<G>
 ): <A, B>(f: (a: A) => B) => (fa: HKT<F, HKT<G, A>>) => HKT<F, HKT<G, B>>
+```
+
+Added in v2.10.0
+
+# derivables
+
+## flap
+
+**Signature**
+
+```ts
+export declare function flap<F extends URIS4>(
+  F: Functor4<F>
+): <A>(a: A) => <S, R, E, B>(fab: Kind4<F, S, R, E, (a: A) => B>) => Kind4<F, S, R, E, B>
+export declare function flap<F extends URIS3>(
+  F: Functor3<F>
+): <A>(a: A) => <R, E, B>(fab: Kind3<F, R, E, (a: A) => B>) => Kind3<F, R, E, B>
+export declare function flap<F extends URIS2>(
+  F: Functor2<F>
+): <A>(a: A) => <E, B>(fab: Kind2<F, E, (a: A) => B>) => Kind2<F, E, B>
+export declare function flap<F extends URIS>(F: Functor1<F>): <A>(a: A) => <B>(fab: Kind<F, (a: A) => B>) => Kind<F, B>
+export declare function flap<F>(F: Functor<F>): <A>(a: A) => <B>(fab: HKT<F, (a: A) => B>) => HKT<F, B>
 ```
 
 Added in v2.10.0

--- a/docs/modules/IO.ts.md
+++ b/docs/modules/IO.ts.md
@@ -34,6 +34,7 @@ Added in v2.0.0
   - [apFirst](#apfirst)
   - [apSecond](#apsecond)
   - [chainFirst](#chainfirst)
+  - [flap](#flap)
   - [flatten](#flatten)
 - [constructors](#constructors)
   - [~~fromIO~~](#fromio)
@@ -163,6 +164,16 @@ export declare const chainFirst: <A, B>(f: (a: A) => IO<B>) => (first: IO<A>) =>
 ```
 
 Added in v2.0.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <B>(fab: IO<(a: A) => B>) => IO<B>
+```
+
+Added in v2.10.0
 
 ## flatten
 

--- a/docs/modules/IOEither.ts.md
+++ b/docs/modules/IOEither.ts.md
@@ -43,6 +43,7 @@ Added in v2.0.0
   - [chainOptionK](#chainoptionk)
   - [filterOrElse](#filterorelse)
   - [filterOrElseW](#filterorelsew)
+  - [flap](#flap)
   - [flatten](#flatten)
   - [fromEitherK](#fromeitherk)
   - [fromOptionK](#fromoptionk)
@@ -386,6 +387,16 @@ export declare const filterOrElseW: {
 ```
 
 Added in v2.9.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <E, B>(fab: IOEither<E, (a: A) => B>) => IOEither<E, B>
+```
+
+Added in v2.10.0
 
 ## flatten
 

--- a/docs/modules/Identity.ts.md
+++ b/docs/modules/Identity.ts.md
@@ -36,6 +36,7 @@ Added in v2.0.0
   - [apSecond](#apsecond)
   - [chainFirst](#chainfirst)
   - [duplicate](#duplicate)
+  - [flap](#flap)
   - [flatten](#flatten)
 - [instances](#instances)
   - [Alt](#alt-1)
@@ -259,6 +260,16 @@ export declare const duplicate: <A>(ma: A) => A
 ```
 
 Added in v2.0.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <B>(fab: (a: A) => B) => B
+```
+
+Added in v2.10.0
 
 ## flatten
 

--- a/docs/modules/Map.ts.md
+++ b/docs/modules/Map.ts.md
@@ -26,6 +26,7 @@ Added in v2.0.0
   - [mapWithIndex](#mapwithindex)
 - [combinators](#combinators)
   - [deleteAt](#deleteat)
+  - [flap](#flap)
   - [insertAt](#insertat)
 - [constructors](#constructors)
   - [fromFoldable](#fromfoldable)
@@ -174,6 +175,16 @@ export declare const deleteAt: <K>(E: Eq<K>) => (k: K) => <A>(m: Map<K, A>) => M
 ```
 
 Added in v2.0.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <E, B>(fab: Map<E, (a: A) => B>) => Map<E, B>
+```
+
+Added in v2.10.0
 
 ## insertAt
 

--- a/docs/modules/NonEmptyArray.ts.md
+++ b/docs/modules/NonEmptyArray.ts.md
@@ -44,6 +44,7 @@ Added in v2.0.0
   - [copy](#copy)
   - [duplicate](#duplicate)
   - [filter](#filter)
+  - [flap](#flap)
   - [flatten](#flatten)
   - [group](#group)
   - [groupSort](#groupsort)
@@ -358,6 +359,16 @@ export declare function filter<A>(predicate: Predicate<A>): (nea: NonEmptyArray<
 ```
 
 Added in v2.0.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <B>(fab: NonEmptyArray<(a: A) => B>) => NonEmptyArray<B>
+```
+
+Added in v2.10.0
 
 ## flatten
 

--- a/docs/modules/Option.ts.md
+++ b/docs/modules/Option.ts.md
@@ -64,6 +64,7 @@ Added in v2.0.0
   - [chainFirst](#chainfirst)
   - [chainNullableK](#chainnullablek)
   - [duplicate](#duplicate)
+  - [flap](#flap)
   - [flatten](#flatten)
   - [fromNullableK](#fromnullablek)
   - [tryCatchK](#trycatchk)
@@ -530,6 +531,16 @@ export declare const duplicate: <A>(ma: Option<A>) => Option<Option<A>>
 ```
 
 Added in v2.0.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <B>(fab: Option<(a: A) => B>) => Option<B>
+```
+
+Added in v2.10.0
 
 ## flatten
 

--- a/docs/modules/Reader.ts.md
+++ b/docs/modules/Reader.ts.md
@@ -32,6 +32,7 @@ Added in v2.0.0
   - [apFirst](#apfirst)
   - [apSecond](#apsecond)
   - [chainFirst](#chainfirst)
+  - [flap](#flap)
   - [flatten](#flatten)
   - [local](#local)
 - [constructors](#constructors)
@@ -226,6 +227,16 @@ export declare const chainFirst: <A, E, B>(f: (a: A) => Reader<E, B>) => (first:
 ```
 
 Added in v2.0.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <E, B>(fab: Reader<E, (a: A) => B>) => Reader<E, B>
+```
+
+Added in v2.10.0
 
 ## flatten
 

--- a/docs/modules/ReaderEither.ts.md
+++ b/docs/modules/ReaderEither.ts.md
@@ -40,6 +40,7 @@ Added in v2.0.0
   - [chainOptionK](#chainoptionk)
   - [filterOrElse](#filterorelse)
   - [filterOrElseW](#filterorelsew)
+  - [flap](#flap)
   - [flatten](#flatten)
   - [fromEitherK](#fromeitherk)
   - [fromOptionK](#fromoptionk)
@@ -394,6 +395,16 @@ export declare const filterOrElseW: {
 ```
 
 Added in v2.9.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <R, E, B>(fab: ReaderEither<R, E, (a: A) => B>) => ReaderEither<R, E, B>
+```
+
+Added in v2.10.0
 
 ## flatten
 

--- a/docs/modules/ReaderTask.ts.md
+++ b/docs/modules/ReaderTask.ts.md
@@ -28,6 +28,7 @@ Added in v2.3.0
   - [chainFirst](#chainfirst)
   - [chainIOK](#chainiok)
   - [chainTaskK](#chaintaskk)
+  - [flap](#flap)
   - [flatten](#flatten)
   - [fromIOK](#fromiok)
   - [fromTaskK](#fromtaskk)
@@ -221,6 +222,16 @@ export declare const chainTaskK: <A, B>(f: (a: A) => T.Task<B>) => <R>(ma: Reade
 ```
 
 Added in v2.4.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <E, B>(fab: ReaderTask<E, (a: A) => B>) => ReaderTask<E, B>
+```
+
+Added in v2.10.0
 
 ## flatten
 

--- a/docs/modules/ReaderTaskEither.ts.md
+++ b/docs/modules/ReaderTaskEither.ts.md
@@ -44,6 +44,7 @@ Added in v2.0.0
   - [chainTaskEitherKW](#chaintaskeitherkw)
   - [filterOrElse](#filterorelse)
   - [filterOrElseW](#filterorelsew)
+  - [flap](#flap)
   - [flatten](#flatten)
   - [fromEitherK](#fromeitherk)
   - [fromIOEitherK](#fromioeitherk)
@@ -475,6 +476,16 @@ export declare const filterOrElseW: {
 ```
 
 Added in v2.9.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <R, E, B>(fab: ReaderTaskEither<R, E, (a: A) => B>) => ReaderTaskEither<R, E, B>
+```
+
+Added in v2.10.0
 
 ## flatten
 

--- a/docs/modules/ReadonlyArray.ts.md
+++ b/docs/modules/ReadonlyArray.ts.md
@@ -70,6 +70,7 @@ Added in v2.5.0
   - [dropLeftWhile](#dropleftwhile)
   - [dropRight](#dropright)
   - [duplicate](#duplicate)
+  - [flap](#flap)
   - [flatten](#flatten)
   - [intersection](#intersection)
   - [intersperse](#intersperse)
@@ -720,6 +721,16 @@ export declare const duplicate: <A>(wa: readonly A[]) => readonly (readonly A[])
 ```
 
 Added in v2.5.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <B>(fab: readonly ((a: A) => B)[]) => readonly B[]
+```
+
+Added in v2.10.0
 
 ## flatten
 

--- a/docs/modules/ReadonlyMap.ts.md
+++ b/docs/modules/ReadonlyMap.ts.md
@@ -28,6 +28,7 @@ Added in v2.5.0
   - [deleteAt](#deleteat)
   - [filterMapWithIndex](#filtermapwithindex)
   - [filterWithIndex](#filterwithindex)
+  - [flap](#flap)
   - [insertAt](#insertat)
   - [partitionMapWithIndex](#partitionmapwithindex)
   - [partitionWithIndex](#partitionwithindex)
@@ -209,6 +210,16 @@ Added in v2.10.0
 
 ```ts
 export declare const filterWithIndex: <K, A>(p: (k: K, a: A) => boolean) => (m: ReadonlyMap<K, A>) => ReadonlyMap<K, A>
+```
+
+Added in v2.10.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <E, B>(fab: ReadonlyMap<E, (a: A) => B>) => ReadonlyMap<E, B>
 ```
 
 Added in v2.10.0

--- a/docs/modules/ReadonlyNonEmptyArray.ts.md
+++ b/docs/modules/ReadonlyNonEmptyArray.ts.md
@@ -42,6 +42,7 @@ Added in v2.5.0
   - [apSecond](#apsecond)
   - [chainFirst](#chainfirst)
   - [duplicate](#duplicate)
+  - [flap](#flap)
   - [flatten](#flatten)
   - [group](#group)
   - [groupSort](#groupsort)
@@ -357,6 +358,16 @@ export declare const duplicate: <A>(ma: ReadonlyNonEmptyArray<A>) => ReadonlyNon
 ```
 
 Added in v2.5.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <B>(fab: ReadonlyNonEmptyArray<(a: A) => B>) => ReadonlyNonEmptyArray<B>
+```
+
+Added in v2.10.0
 
 ## flatten
 

--- a/docs/modules/ReadonlyRecord.ts.md
+++ b/docs/modules/ReadonlyRecord.ts.md
@@ -30,6 +30,7 @@ Added in v2.5.0
 - [combinators](#combinators)
   - [deleteAt](#deleteat)
   - [filterMapWithIndex](#filtermapwithindex)
+  - [flap](#flap)
   - [insertAt](#insertat)
   - [map](#map)
   - [mapWithIndex](#mapwithindex)
@@ -249,6 +250,16 @@ export declare function filterMapWithIndex<K extends string, A, B>(
 ```
 
 Added in v2.5.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <B>(fab: Readonly<Record<string, (a: A) => B>>) => Readonly<Record<string, B>>
+```
+
+Added in v2.10.0
 
 ## insertAt
 

--- a/docs/modules/ReadonlyTuple.ts.md
+++ b/docs/modules/ReadonlyTuple.ts.md
@@ -29,6 +29,7 @@ Added in v2.5.0
   - [compose](#compose)
 - [combinators](#combinators)
   - [duplicate](#duplicate)
+  - [flap](#flap)
   - [swap](#swap)
 - [destructors](#destructors)
   - [fst](#fst)
@@ -176,6 +177,16 @@ export declare const duplicate: <E, A>(wa: readonly [A, E]) => readonly [readonl
 ```
 
 Added in v2.5.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <E, B>(fab: readonly [(a: A) => B, E]) => readonly [B, E]
+```
+
+Added in v2.10.0
 
 ## swap
 

--- a/docs/modules/Record.ts.md
+++ b/docs/modules/Record.ts.md
@@ -27,6 +27,8 @@ Added in v2.0.0
 - [Witherable](#witherable)
   - [wilt](#wilt)
   - [wither](#wither)
+- [combinators](#combinators)
+  - [flap](#flap)
 - [instances](#instances)
   - [Compactable](#compactable-1)
   - [Filterable](#filterable-1)
@@ -210,6 +212,18 @@ export declare const wither: PipeableWither1<'Record'>
 ```
 
 Added in v2.6.5
+
+# combinators
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <B>(fab: Record<string, (a: A) => B>) => Record<string, B>
+```
+
+Added in v2.10.0
 
 # instances
 

--- a/docs/modules/Separated.ts.md
+++ b/docs/modules/Separated.ts.md
@@ -26,6 +26,8 @@ Added in v2.10.0
   - [mapLeft](#mapleft)
 - [Functor](#functor)
   - [map](#map)
+- [combinators](#combinators)
+  - [flap](#flap)
 - [constructors](#constructors)
   - [separated](#separated)
 - [instances](#instances)
@@ -75,6 +77,18 @@ use the type constructor `F` to represent some computational context.
 
 ```ts
 export declare const map: <A, B>(f: (a: A) => B) => <E>(fa: Separated<E, A>) => Separated<E, B>
+```
+
+Added in v2.10.0
+
+# combinators
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <E, B>(fab: Separated<E, (a: A) => B>) => Separated<E, B>
 ```
 
 Added in v2.10.0

--- a/docs/modules/State.ts.md
+++ b/docs/modules/State.ts.md
@@ -24,6 +24,7 @@ Added in v2.0.0
   - [apFirst](#apfirst)
   - [apSecond](#apsecond)
   - [chainFirst](#chainfirst)
+  - [flap](#flap)
   - [flatten](#flatten)
 - [constructors](#constructors)
   - [get](#get)
@@ -154,6 +155,16 @@ export declare const chainFirst: <S, A, B>(f: (a: A) => State<S, B>) => (ma: Sta
 ```
 
 Added in v2.0.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <E, B>(fab: State<E, (a: A) => B>) => State<E, B>
+```
+
+Added in v2.10.0
 
 ## flatten
 

--- a/docs/modules/StateReaderTaskEither.ts.md
+++ b/docs/modules/StateReaderTaskEither.ts.md
@@ -46,6 +46,7 @@ Added in v2.0.0
   - [chainTaskEitherKW](#chaintaskeitherkw)
   - [filterOrElse](#filterorelse)
   - [filterOrElseW](#filterorelsew)
+  - [flap](#flap)
   - [flatten](#flatten)
   - [fromEitherK](#fromeitherk)
   - [fromIOEitherK](#fromioeitherk)
@@ -494,6 +495,18 @@ export declare const filterOrElseW: {
 ```
 
 Added in v2.9.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(
+  a: A
+) => <S, R, E, B>(fab: StateReaderTaskEither<S, R, E, (a: A) => B>) => StateReaderTaskEither<S, R, E, B>
+```
+
+Added in v2.10.0
 
 ## flatten
 

--- a/docs/modules/Store.ts.md
+++ b/docs/modules/Store.ts.md
@@ -20,6 +20,7 @@ Added in v2.0.0
   - [map](#map)
 - [combinators](#combinators)
   - [duplicate](#duplicate)
+  - [flap](#flap)
 - [instances](#instances)
   - [Comonad](#comonad)
   - [Functor](#functor-1)
@@ -88,6 +89,16 @@ export declare const duplicate: <E, A>(wa: Store<E, A>) => Store<E, Store<E, A>>
 ```
 
 Added in v2.0.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <E, B>(fab: Store<E, (a: A) => B>) => Store<E, B>
+```
+
+Added in v2.10.0
 
 # instances
 

--- a/docs/modules/Task.ts.md
+++ b/docs/modules/Task.ts.md
@@ -37,6 +37,7 @@ Added in v2.0.0
   - [chainFirst](#chainfirst)
   - [chainIOK](#chainiok)
   - [delay](#delay)
+  - [flap](#flap)
   - [flatten](#flatten)
   - [fromIOK](#fromiok)
 - [constructors](#constructors)
@@ -230,6 +231,16 @@ test()
 ```
 
 Added in v2.0.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <B>(fab: Task<(a: A) => B>) => Task<B>
+```
+
+Added in v2.10.0
 
 ## flatten
 

--- a/docs/modules/TaskEither.ts.md
+++ b/docs/modules/TaskEither.ts.md
@@ -49,6 +49,7 @@ Added in v2.0.0
   - [chainOptionK](#chainoptionk)
   - [filterOrElse](#filterorelse)
   - [filterOrElseW](#filterorelsew)
+  - [flap](#flap)
   - [flatten](#flatten)
   - [fromEitherK](#fromeitherk)
   - [fromIOEitherK](#fromioeitherk)
@@ -461,6 +462,16 @@ export declare const filterOrElseW: {
 ```
 
 Added in v2.9.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <E, B>(fab: TaskEither<E, (a: A) => B>) => TaskEither<E, B>
+```
+
+Added in v2.10.0
 
 ## flatten
 

--- a/docs/modules/TaskOption.ts.md
+++ b/docs/modules/TaskOption.ts.md
@@ -36,6 +36,7 @@ Added in v2.10.0
 - [combinators](#combinators)
   - [chainNullableK](#chainnullablek)
   - [chainOptionK](#chainoptionk)
+  - [flap](#flap)
   - [fromNullableK](#fromnullablek)
   - [fromOptionK](#fromoptionk)
   - [tryCatchK](#trycatchk)
@@ -267,6 +268,16 @@ Added in v2.10.0
 
 ```ts
 export declare const chainOptionK: <A, B>(f: (a: A) => O.Option<B>) => (ma: T.Task<O.Option<A>>) => T.Task<O.Option<B>>
+```
+
+Added in v2.10.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <B>(fab: TaskOption<(a: A) => B>) => TaskOption<B>
 ```
 
 Added in v2.10.0

--- a/docs/modules/TaskThese.ts.md
+++ b/docs/modules/TaskThese.ts.md
@@ -20,6 +20,7 @@ Added in v2.4.0
 - [Pointed](#pointed)
   - [of](#of)
 - [combinators](#combinators)
+  - [flap](#flap)
   - [fromOptionK](#fromoptionk)
   - [swap](#swap)
 - [constructors](#constructors)
@@ -117,6 +118,16 @@ export declare const of: <E, A>(a: A) => TaskThese<E, A>
 Added in v2.7.0
 
 # combinators
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <E, B>(fab: TaskThese<E, (a: A) => B>) => TaskThese<E, B>
+```
+
+Added in v2.10.0
 
 ## fromOptionK
 

--- a/docs/modules/These.ts.md
+++ b/docs/modules/These.ts.md
@@ -42,6 +42,7 @@ Added in v2.0.0
 - [Pointed](#pointed)
   - [of](#of)
 - [combinators](#combinators)
+  - [flap](#flap)
   - [fromOptionK](#fromoptionk)
   - [swap](#swap)
 - [constructors](#constructors)
@@ -176,6 +177,16 @@ export declare const of: <E, A>(a: A) => These<E, A>
 Added in v2.0.0
 
 # combinators
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <E, B>(fab: These<E, (a: A) => B>) => These<E, B>
+```
+
+Added in v2.10.0
 
 ## fromOptionK
 

--- a/docs/modules/Traced.ts.md
+++ b/docs/modules/Traced.ts.md
@@ -14,6 +14,8 @@ Added in v2.0.0
 
 - [Functor](#functor)
   - [map](#map)
+- [combinators](#combinators)
+  - [flap](#flap)
 - [instances](#instances)
   - [Functor](#functor-1)
   - [URI](#uri)
@@ -44,6 +46,18 @@ export declare const map: <A, B>(f: (a: A) => B) => <E>(fa: Traced<E, A>) => Tra
 ```
 
 Added in v2.0.0
+
+# combinators
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <E, B>(fab: Traced<E, (a: A) => B>) => Traced<E, B>
+```
+
+Added in v2.10.0
 
 # instances
 

--- a/docs/modules/Tree.ts.md
+++ b/docs/modules/Tree.ts.md
@@ -39,6 +39,7 @@ Added in v2.0.0
   - [apSecond](#apsecond)
   - [chainFirst](#chainfirst)
   - [duplicate](#duplicate)
+  - [flap](#flap)
   - [flatten](#flatten)
 - [constructors](#constructors)
   - [make](#make)
@@ -245,6 +246,16 @@ export declare const duplicate: <A>(wa: Tree<A>) => Tree<Tree<A>>
 ```
 
 Added in v2.0.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <B>(fab: Tree<(a: A) => B>) => Tree<B>
+```
+
+Added in v2.10.0
 
 ## flatten
 

--- a/docs/modules/Tuple.ts.md
+++ b/docs/modules/Tuple.ts.md
@@ -29,6 +29,7 @@ Added in v2.0.0
   - [compose](#compose)
 - [combinators](#combinators)
   - [duplicate](#duplicate)
+  - [flap](#flap)
   - [swap](#swap)
 - [destructors](#destructors)
   - [fst](#fst)
@@ -176,6 +177,16 @@ export declare const duplicate: <E, A>(wa: [A, E]) => [[A, E], E]
 ```
 
 Added in v2.0.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <E, B>(fab: [(a: A) => B, E]) => [B, E]
+```
+
+Added in v2.10.0
 
 ## swap
 

--- a/docs/modules/Writer.ts.md
+++ b/docs/modules/Writer.ts.md
@@ -16,6 +16,7 @@ Added in v2.0.0
   - [map](#map)
 - [combinators](#combinators)
   - [censor](#censor)
+  - [flap](#flap)
   - [listen](#listen)
   - [listens](#listens)
   - [pass](#pass)
@@ -67,6 +68,16 @@ export declare const censor: <W>(f: (w: W) => W) => <A>(fa: Writer<W, A>) => Wri
 ```
 
 Added in v2.0.0
+
+## flap
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <E, B>(fab: Writer<E, (a: A) => B>) => Writer<E, B>
+```
+
+Added in v2.10.0
 
 ## listen
 

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -14,7 +14,7 @@ import { FilterableWithIndex1, PredicateWithIndex, RefinementWithIndex } from '.
 import { Foldable1 } from './Foldable'
 import { FoldableWithIndex1 } from './FoldableWithIndex'
 import { Lazy, Predicate, Refinement } from './function'
-import { Functor1 } from './Functor'
+import { flap as flap_, Functor1 } from './Functor'
 import { FunctorWithIndex1 } from './FunctorWithIndex'
 import { Monad1 } from './Monad'
 import { Monoid } from './Monoid'
@@ -1637,6 +1637,18 @@ export const apS: <A, N extends string, B>(
   name: Exclude<N, keyof A>,
   fb: Array<B>
 ) => (fa: Array<A>) => Array<{ [K in keyof A | N]: K extends keyof A ? A[K] : B }> = RA.apS as any
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/Const.ts
+++ b/src/Const.ts
@@ -15,7 +15,7 @@ import { Bounded } from './Bounded'
 import { Contravariant2 } from './Contravariant'
 import { Eq } from './Eq'
 import { identity, pipe, unsafeCoerce } from './function'
-import { Functor2 } from './Functor'
+import { flap as flap_, Functor2 } from './Functor'
 import { HeytingAlgebra } from './HeytingAlgebra'
 import { Monoid } from './Monoid'
 import { Ord } from './Ord'
@@ -229,6 +229,18 @@ export const Bifunctor: Bifunctor2<URI> = {
   bimap: _bimap,
   mapLeft: _mapLeft
 }
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -31,7 +31,7 @@ import { Filterable2C } from './Filterable'
 import { Foldable2 } from './Foldable'
 import { FromEither2 } from './FromEither'
 import { flow, identity, Lazy, pipe, Predicate, Refinement } from './function'
-import { bindTo as bindTo_, Functor2 } from './Functor'
+import { bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
 import { HKT } from './HKT'
 import { bind as bind_, chainFirst as chainFirst_, Monad2, Monad2C } from './Monad'
 import { MonadThrow2, MonadThrow2C } from './MonadThrow'
@@ -1369,6 +1369,18 @@ export const traverseArray = <E, A, B>(
 export const sequenceArray: <E, A>(as: ReadonlyArray<Either<E, A>>) => Either<E, ReadonlyArray<A>> =
   /*#__PURE__*/
   traverseArray(identity)
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/Functor.ts
+++ b/src/Functor.ts
@@ -113,6 +113,29 @@ export function map<F, G>(
 }
 
 // -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category derivables
+ * @since 2.10.0
+ */
+export function flap<F extends URIS4>(
+  F: Functor4<F>
+): <A>(a: A) => <S, R, E, B>(fab: Kind4<F, S, R, E, (a: A) => B>) => Kind4<F, S, R, E, B>
+export function flap<F extends URIS3>(
+  F: Functor3<F>
+): <A>(a: A) => <R, E, B>(fab: Kind3<F, R, E, (a: A) => B>) => Kind3<F, R, E, B>
+export function flap<F extends URIS2>(
+  F: Functor2<F>
+): <A>(a: A) => <E, B>(fab: Kind2<F, E, (a: A) => B>) => Kind2<F, E, B>
+export function flap<F extends URIS>(F: Functor1<F>): <A>(a: A) => <B>(fab: Kind<F, (a: A) => B>) => Kind<F, B>
+export function flap<F>(F: Functor<F>): <A>(a: A) => <B>(fab: HKT<F, (a: A) => B>) => HKT<F, B>
+export function flap<F>(F: Functor<F>): <A>(a: A) => <B>(fab: HKT<F, (a: A) => B>) => HKT<F, B> {
+  return (a) => (fab) => F.map(fab, (f) => f(a))
+}
+
+// -------------------------------------------------------------------------------------
 // utils
 // -------------------------------------------------------------------------------------
 

--- a/src/IO.ts
+++ b/src/IO.ts
@@ -16,7 +16,7 @@ import { apFirst as apFirst_, Apply1, apSecond as apSecond_, apS as apS_, getApp
 import { ChainRec1 } from './ChainRec'
 import { FromIO1 } from './FromIO'
 import { constant, identity } from './function'
-import { bindTo as bindTo_, Functor1 } from './Functor'
+import { bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import { bind as bind_, chainFirst as chainFirst_, Monad1 } from './Monad'
 import { MonadIO1 } from './MonadIO'
 import { Monoid } from './Monoid'
@@ -312,6 +312,18 @@ export const traverseArray = <A, B>(f: (a: A) => IO<B>): ((as: ReadonlyArray<A>)
 export const sequenceArray: <A>(arr: ReadonlyArray<IO<A>>) => IO<ReadonlyArray<A>> =
   /*#__PURE__*/
   traverseArray(identity)
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/IOEither.ts
+++ b/src/IOEither.ts
@@ -37,7 +37,7 @@ import {
 } from './FromEither'
 import { FromIO2 } from './FromIO'
 import { flow, identity, Lazy, pipe, Predicate, Refinement } from './function'
-import { bindTo as bindTo_, Functor2 } from './Functor'
+import { bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
 import * as I from './IO'
 import { bind as bind_, chainFirst as chainFirst_, Monad2, Monad2C } from './Monad'
 import { MonadIO2, MonadIO2C } from './MonadIO'
@@ -853,6 +853,18 @@ export const traverseSeqArray = <A, E, B>(
 export const sequenceSeqArray: <E, A>(arr: ReadonlyArray<IOEither<E, A>>) => IOEither<E, ReadonlyArray<A>> =
   /*#__PURE__*/
   traverseSeqArray(identity)
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/Identity.ts
+++ b/src/Identity.ts
@@ -10,7 +10,7 @@ import { Eq } from './Eq'
 import { Extend1 } from './Extend'
 import { Foldable1 } from './Foldable'
 import { identity as id, pipe } from './function'
-import { bindTo as bindTo_, Functor1 } from './Functor'
+import { bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import { HKT } from './HKT'
 import { bind as bind_, chainFirst as chainFirst_, Monad1 } from './Monad'
 import { Monoid } from './Monoid'
@@ -388,6 +388,18 @@ export const bind =
 export const apS =
   /*#__PURE__*/
   apS_(Apply)
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -8,7 +8,7 @@ import { Filterable2 } from './Filterable'
 import { FilterableWithIndex2C } from './FilterableWithIndex'
 import { Foldable, Foldable1, Foldable2, Foldable3 } from './Foldable'
 import { Predicate, Refinement } from './function'
-import { Functor2 } from './Functor'
+import { flap as flap_, Functor2 } from './Functor'
 import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3 } from './HKT'
 import { Magma } from './Magma'
 import { Monoid } from './Monoid'
@@ -382,6 +382,18 @@ export const Filterable: Filterable2<URI> = {
   partition: _partition,
   partitionMap: _partitionMap
 }
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/NonEmptyArray.ts
+++ b/src/NonEmptyArray.ts
@@ -12,7 +12,7 @@ import { Extend1 } from './Extend'
 import { Foldable1 } from './Foldable'
 import { FoldableWithIndex1 } from './FoldableWithIndex'
 import { Lazy, Predicate, Refinement } from './function'
-import { Functor1 } from './Functor'
+import { flap as flap_, Functor1 } from './Functor'
 import { FunctorWithIndex1 } from './FunctorWithIndex'
 import { Monad1 } from './Monad'
 import { Option } from './Option'
@@ -767,6 +767,18 @@ export const apS: <A, N extends string, B>(
   name: Exclude<N, keyof A>,
   fb: NonEmptyArray<B>
 ) => (fa: NonEmptyArray<A>) => NonEmptyArray<{ [K in keyof A | N]: K extends keyof A ? A[K] : B }> = RNEA.apS as any
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -29,7 +29,7 @@ import { Extend1 } from './Extend'
 import { Filterable1 } from './Filterable'
 import { Foldable1 } from './Foldable'
 import { constNull, constUndefined, flow, identity, Lazy, pipe, Predicate, Refinement } from './function'
-import { bindTo as bindTo_, Functor1 } from './Functor'
+import { bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import { HKT } from './HKT'
 import { bind as bind_, chainFirst as chainFirst_, Monad1 } from './Monad'
 import { MonadThrow1 } from './MonadThrow'
@@ -1175,6 +1175,18 @@ export function exists<A>(predicate: Predicate<A>): (ma: Option<A>) => boolean {
 export function getRefinement<A, B extends A>(getOption: (a: A) => Option<B>): Refinement<A, B> {
   return (a: A): a is B => isSome(getOption(a))
 }
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#__PURE__*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // do notation

--- a/src/Reader.ts
+++ b/src/Reader.ts
@@ -7,7 +7,7 @@ import { Category2 } from './Category'
 import { Choice2 } from './Choice'
 import * as E from './Either'
 import { constant, flow, identity, pipe } from './function'
-import { bindTo as bindTo_, Functor2 } from './Functor'
+import { bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
 import { bind as bind_, chainFirst as chainFirst_, Monad2 } from './Monad'
 import { Monoid } from './Monoid'
 import { Pointed2 } from './Pointed'
@@ -402,6 +402,18 @@ export const traverseArray = <R, A, B>(
 export const sequenceArray: <R, A>(arr: ReadonlyArray<Reader<R, A>>) => Reader<R, ReadonlyArray<A>> =
   /*#__PURE__*/
   traverseArray(identity)
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/ReaderEither.ts
+++ b/src/ReaderEither.ts
@@ -33,7 +33,7 @@ import {
   fromPredicate as fromPredicate_
 } from './FromEither'
 import { flow, identity, pipe, Predicate, Refinement } from './function'
-import { bindTo as bindTo_, Functor2, Functor3 } from './Functor'
+import { bindTo as bindTo_, flap as flap_, Functor2, Functor3 } from './Functor'
 import { bind as bind_, chainFirst as chainFirst_, Monad3, Monad3C } from './Monad'
 import { MonadThrow3, MonadThrow3C } from './MonadThrow'
 import { Monoid } from './Monoid'
@@ -748,6 +748,18 @@ export const sequenceArray: <R, E, A>(
 ) => ReaderEither<R, E, ReadonlyArray<A>> =
   /*#__PURE__*/
   traverseArray(identity)
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/ReaderTask.ts
+++ b/src/ReaderTask.ts
@@ -10,7 +10,7 @@ import {
   getApplySemigroup as getApplySemigroup_
 } from './Apply'
 import { flow, identity, pipe } from './function'
-import { bindTo as bindTo_, Functor2 } from './Functor'
+import { bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
 import { IO } from './IO'
 import { bind as bind_, chainFirst as chainFirst_, Monad2 } from './Monad'
 import { MonadTask2 } from './MonadTask'
@@ -467,6 +467,18 @@ export const traverseSeqArray = <R, A, B>(
 export const sequenceSeqArray: <R, A>(arr: ReadonlyArray<ReaderTask<R, A>>) => ReaderTask<R, ReadonlyArray<A>> =
   /*#__PURE__*/
   traverseSeqArray(identity)
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/ReaderTaskEither.ts
+++ b/src/ReaderTaskEither.ts
@@ -36,7 +36,7 @@ import {
 import { FromIO3 } from './FromIO'
 import { FromTask3 } from './FromTask'
 import { flow, identity, pipe, Predicate, Refinement } from './function'
-import { bindTo as bindTo_, Functor2, Functor3 } from './Functor'
+import { bindTo as bindTo_, flap as flap_, Functor2, Functor3 } from './Functor'
 import { IO } from './IO'
 import { IOEither } from './IOEither'
 import { bind as bind_, chainFirst as chainFirst_, Monad3, Monad3C } from './Monad'
@@ -985,6 +985,18 @@ export const sequenceSeqArray: <R, E, A>(
 ) => ReaderTaskEither<R, E, ReadonlyArray<A>> =
   /*#__PURE__*/
   traverseSeqArray(identity)
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/ReadonlyArray.ts
+++ b/src/ReadonlyArray.ts
@@ -19,7 +19,7 @@ import {
 import { Foldable1 } from './Foldable'
 import { FoldableWithIndex1 } from './FoldableWithIndex'
 import { identity, Lazy, pipe, Predicate, Refinement } from './function'
-import { bindTo as bindTo_, Functor1 } from './Functor'
+import { bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import { FunctorWithIndex1 } from './FunctorWithIndex'
 import { HKT } from './HKT'
 import { bind as bind_, chainFirst as chainFirst_, Monad1 } from './Monad'
@@ -2350,6 +2350,18 @@ export const bind =
 export const apS =
   /*#__PURE__*/
   apS_(Apply)
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/ReadonlyMap.ts
+++ b/src/ReadonlyMap.ts
@@ -10,7 +10,7 @@ import { FilterableWithIndex2C } from './FilterableWithIndex'
 import { Foldable, Foldable1, Foldable2, Foldable2C, Foldable3 } from './Foldable'
 import { FoldableWithIndex2C } from './FoldableWithIndex'
 import { pipe, Predicate, Refinement } from './function'
-import { Functor2 } from './Functor'
+import { flap as flap_, Functor2 } from './Functor'
 import { FunctorWithIndex2C } from './FunctorWithIndex'
 import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3 } from './HKT'
 import { Magma } from './Magma'
@@ -997,6 +997,18 @@ export function getWitherable<K>(O: Ord<K>): Witherable2C<URI, K> & TraversableW
     }
   }
 }
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/ReadonlyNonEmptyArray.ts
+++ b/src/ReadonlyNonEmptyArray.ts
@@ -12,7 +12,7 @@ import { Extend1 } from './Extend'
 import { Foldable1 } from './Foldable'
 import { FoldableWithIndex1 } from './FoldableWithIndex'
 import { Lazy, Predicate, Refinement } from './function'
-import { bindTo as bindTo_, Functor1 } from './Functor'
+import { bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import { FunctorWithIndex1 } from './FunctorWithIndex'
 import { bind as bind_, Monad1 } from './Monad'
 import { NonEmptyArray } from './NonEmptyArray'
@@ -848,6 +848,18 @@ export const bind =
 export const apS =
   /*#__PURE__*/
   apS_(Apply)
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/ReadonlyRecord.ts
+++ b/src/ReadonlyRecord.ts
@@ -10,7 +10,7 @@ import { FilterableWithIndex1, PredicateWithIndex, RefinementWithIndex } from '.
 import { Foldable as FoldableHKT, Foldable1, Foldable2, Foldable3 } from './Foldable'
 import { FoldableWithIndex1 } from './FoldableWithIndex'
 import { identity, Predicate, Refinement, pipe } from './function'
-import { Functor1 } from './Functor'
+import { flap as flap_, Functor1 } from './Functor'
 import { FunctorWithIndex1 } from './FunctorWithIndex'
 import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3 } from './HKT'
 import { Magma } from './Magma'
@@ -1214,6 +1214,18 @@ export const Witherable: Witherable1<URI> = {
   wither: _wither,
   wilt: _wilt
 }
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/ReadonlyTuple.ts
+++ b/src/ReadonlyTuple.ts
@@ -10,7 +10,7 @@ import { Comonad2 } from './Comonad'
 import { Either } from './Either'
 import { Foldable2 } from './Foldable'
 import { identity, pipe } from './function'
-import { Functor2 } from './Functor'
+import { flap as flap_, Functor2 } from './Functor'
 import { HKT } from './HKT'
 import { Monad2C } from './Monad'
 import { Monoid } from './Monoid'
@@ -369,6 +369,18 @@ export const Traversable: Traversable2<URI> = {
   traverse: _traverse,
   sequence
 }
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -10,7 +10,7 @@ import { FilterableWithIndex1, PredicateWithIndex, RefinementWithIndex } from '.
 import { Foldable as FoldableHKT, Foldable1, Foldable2, Foldable3 } from './Foldable'
 import { FoldableWithIndex1 } from './FoldableWithIndex'
 import { Predicate, Refinement } from './function'
-import { Functor1 } from './Functor'
+import { flap as flap_, Functor1 } from './Functor'
 import { FunctorWithIndex1 } from './FunctorWithIndex'
 import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3 } from './HKT'
 import { Magma } from './Magma'
@@ -771,6 +771,18 @@ export const Witherable: Witherable1<URI> = {
   wither: _wither,
   wilt: _wilt
 }
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/Separated.ts
+++ b/src/Separated.ts
@@ -12,7 +12,7 @@
  */
 
 import { pipe } from './function'
-import { Functor2 } from './Functor'
+import { flap as flap_, Functor2 } from './Functor'
 import { Bifunctor2 } from './Bifunctor'
 
 // -------------------------------------------------------------------------------------
@@ -120,3 +120,15 @@ export const Functor: Functor2<URI> = {
   URI,
   map: _map
 }
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)

--- a/src/State.ts
+++ b/src/State.ts
@@ -4,7 +4,7 @@
 import { Applicative2 } from './Applicative'
 import { apFirst as apFirst_, Apply2, apSecond as apSecond_, apS as apS_ } from './Apply'
 import { identity, pipe } from './function'
-import { bindTo as bindTo_, Functor2 } from './Functor'
+import { bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
 import { bind as bind_, chainFirst as chainFirst_, Monad2 } from './Monad'
 import { Pointed2 } from './Pointed'
 
@@ -322,6 +322,18 @@ export const traverseArray = <A, S, B>(
 export const sequenceArray: <S, A>(arr: ReadonlyArray<State<S, A>>) => State<S, ReadonlyArray<A>> =
   /*#__PURE__*/
   traverseArray(identity)
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/StateReaderTaskEither.ts
+++ b/src/StateReaderTaskEither.ts
@@ -19,7 +19,7 @@ import {
 import { FromIO4 } from './FromIO'
 import { FromTask4 } from './FromTask'
 import { flow, identity, Lazy, pipe, Predicate, Refinement } from './function'
-import { bindTo as bindTo_, Functor4 } from './Functor'
+import { bindTo as bindTo_, flap as flap_, Functor4 } from './Functor'
 import { IO } from './IO'
 import { IOEither } from './IOEither'
 import { bind as bind_, chainFirst as chainFirst_, Monad4 } from './Monad'
@@ -874,6 +874,18 @@ export const sequenceArray: <S, R, E, A>(
 ) => StateReaderTaskEither<S, R, E, ReadonlyArray<A>> =
   /*#__PURE__*/
   traverseArray(identity)
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -3,7 +3,7 @@
  */
 import { Comonad2 } from './Comonad'
 import { Endomorphism, identity, pipe } from './function'
-import { Functor as FunctorHKT, Functor1, Functor2, Functor2C, Functor3, Functor3C } from './Functor'
+import { flap as flap_, Functor as FunctorHKT, Functor1, Functor2, Functor2C, Functor3, Functor3C } from './Functor'
 import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3 } from './HKT'
 import { Extend2 } from './Extend'
 
@@ -163,6 +163,18 @@ export const Comonad: Comonad2<URI> = {
   extend: _extend,
   extract
 }
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -21,7 +21,7 @@ import {
 import { FromIO1 } from './FromIO'
 import { FromTask1 } from './FromTask'
 import { flow, identity, pipe } from './function'
-import { bindTo as bindTo_, Functor1 } from './Functor'
+import { bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import { IO } from './IO'
 import { bind as bind_, chainFirst as chainFirst_, Monad1 } from './Monad'
 import { MonadTask1 } from './MonadTask'
@@ -463,6 +463,18 @@ export const traverseSeqArray = <A, B>(f: (a: A) => Task<B>): ((as: ReadonlyArra
 export const sequenceSeqArray: <A>(arr: ReadonlyArray<Task<A>>) => Task<ReadonlyArray<A>> =
   /*#__PURE__*/
   traverseSeqArray(identity)
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -43,7 +43,7 @@ import {
 import { FromIO2 } from './FromIO'
 import { FromTask2 } from './FromTask'
 import { flow, identity, Lazy, pipe, Predicate, Refinement } from './function'
-import { bindTo as bindTo_, Functor2 } from './Functor'
+import { bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
 import { IO } from './IO'
 import { IOEither } from './IOEither'
 import { bind as bind_, chainFirst as chainFirst_, Monad2, Monad2C } from './Monad'
@@ -1036,6 +1036,18 @@ export const traverseSeqArray = <A, B, E>(
 export const sequenceSeqArray: <A, E>(arr: ReadonlyArray<TaskEither<E, A>>) => TaskEither<E, ReadonlyArray<A>> =
   /*#__PURE__*/
   traverseSeqArray(identity)
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/TaskOption.ts
+++ b/src/TaskOption.ts
@@ -16,7 +16,7 @@ import {
 import { FromIO1 } from './FromIO'
 import { FromTask1 } from './FromTask'
 import { flow, identity, Lazy, pipe, Predicate } from './function'
-import { bindTo as bindTo_, Functor1 } from './Functor'
+import { bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import { bind as bind_, chainFirst as chainFirst_, Monad1 } from './Monad'
 import { MonadIO1 } from './MonadIO'
 import { MonadTask1 } from './MonadTask'
@@ -680,3 +680,15 @@ export const traverseSeqArray: <A, B>(
 export const sequenceSeqArray: <A>(as: ReadonlyArray<TaskOption<A>>) => TaskOption<ReadonlyArray<A>> =
   /*#__PURE__*/
   traverseSeqArray(identity)
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)

--- a/src/TaskThese.ts
+++ b/src/TaskThese.ts
@@ -13,7 +13,7 @@ import {
 import { FromIO2 } from './FromIO'
 import { FromTask2 } from './FromTask'
 import { flow, Lazy, pipe } from './function'
-import { Functor2 } from './Functor'
+import { flap as flap_, Functor2 } from './Functor'
 import { IO } from './IO'
 import { IOEither } from './IOEither'
 import { Monad2C } from './Monad'
@@ -438,3 +438,15 @@ export const taskThese: Functor2<URI> & Bifunctor2<URI> = {
  */
 export const getSemigroup = <E, A>(SE: Semigroup<E>, SA: Semigroup<A>): Semigroup<TaskThese<E, A>> =>
   getApplySemigroup(T.ApplySeq)(TH.getSemigroup(SE, SA))
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)

--- a/src/These.ts
+++ b/src/These.ts
@@ -27,7 +27,7 @@ import { Eq, fromEquals } from './Eq'
 import { Foldable2 } from './Foldable'
 import { FromEither2, fromOption as fromOption_, fromOptionK as fromOptionK_ } from './FromEither'
 import { identity, Lazy, pipe } from './function'
-import { Functor2 } from './Functor'
+import { flap as flap_, Functor2 } from './Functor'
 import { HKT } from './HKT'
 import { Monad2C } from './Monad'
 import { MonadThrow2C } from './MonadThrow'
@@ -650,6 +650,18 @@ export const toTuple = <E, A>(e: E, a: A): ((fa: These<E, A>) => [E, A]) =>
     () => a
   ) as any
 /* tslint:enable:readonly-array */
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/Traced.ts
+++ b/src/Traced.ts
@@ -2,7 +2,7 @@
  * @since 2.0.0
  */
 import { Comonad2C } from './Comonad'
-import { Functor2 } from './Functor'
+import { flap as flap_, Functor2 } from './Functor'
 import { Monoid } from './Monoid'
 import { pipe } from './function'
 
@@ -131,6 +131,18 @@ export const Functor: Functor2<URI> = {
   URI,
   map: _map
 }
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/Tree.ts
+++ b/src/Tree.ts
@@ -15,7 +15,7 @@ import { Eq, fromEquals } from './Eq'
 import { Extend1 } from './Extend'
 import { Foldable1 } from './Foldable'
 import { identity, pipe } from './function'
-import { bindTo as bindTo_, Functor1 } from './Functor'
+import { bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import { HKT, Kind, Kind2, Kind3, Kind4, URIS, URIS2, URIS3, URIS4 } from './HKT'
 import {
   bind as bind_,
@@ -626,6 +626,18 @@ export const bind =
 export const apS =
   /*#__PURE__*/
   apS_(Apply)
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/Tuple.ts
+++ b/src/Tuple.ts
@@ -14,7 +14,7 @@ import * as RT from './ReadonlyTuple'
 import { Semigroup } from './Semigroup'
 import { Semigroupoid2 } from './Semigroupoid'
 import { Traversable2, PipeableTraverse2 } from './Traversable'
-import { Functor2 } from './Functor'
+import { flap as flap_, Functor2 } from './Functor'
 import { Extend2 } from './Extend'
 
 // tslint:disable:readonly-array
@@ -254,6 +254,18 @@ export const Traversable: Traversable2<URI> = {
   traverse: _traverse,
   sequence
 }
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/src/Writer.ts
+++ b/src/Writer.ts
@@ -4,7 +4,7 @@
 import { Applicative2C } from './Applicative'
 import { Apply2C } from './Apply'
 import { pipe } from './function'
-import { Functor2 } from './Functor'
+import { flap as flap_, Functor2 } from './Functor'
 import { Monad2C } from './Monad'
 import { Monoid } from './Monoid'
 import { Pointed2C } from './Pointed'
@@ -216,6 +216,18 @@ export const evaluate: <W, A>(fa: Writer<W, A>) => A = (fa) => fa()[0]
  * @since 2.8.0
  */
 export const execute: <W, A>(fa: Writer<W, A>) => W = (fa) => fa()[1]
+
+// -------------------------------------------------------------------------------------
+// derivables
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category combinators
+ * @since 2.10.0
+ */
+export const flap =
+  /*#_PURE_*/
+  flap_(Functor)
 
 // -------------------------------------------------------------------------------------
 // deprecated

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -17,6 +17,12 @@ describe('Option', () => {
       assert.deepStrictEqual(pipe(_.none, _.map(double)), _.none)
     })
 
+    it('flap', () => {
+      const double = (n: number) => n * 2
+      assert.deepStrictEqual(pipe(_.some(double), _.flap(2)), _.some(4))
+      assert.deepStrictEqual(pipe(_.none, _.flap(2)), _.none)
+    })
+
     it('ap', () => {
       const double = (n: number) => n * 2
       assert.deepStrictEqual(pipe(_.some(double), _.ap(_.some(2))), _.some(4))


### PR DESCRIPTION
Flap is a convenience that allows functions under structure to be applied to values. It could be compared to `ap`, but with the argument unwrapped. I write this PR after some conversation about having to wrap an argument with `Option` before being able to use `ap`. 

Slack Thread: https://functionalprogramming.slack.com/archives/CPKPCAGP4/p1612453287148200