### PR TITLE
Remove matechs-effect from ecosystem.md

### DIFF
--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -28,7 +28,6 @@ has_toc: false
 - [@nll/datum](https://github.com/nullpub/datum) - Datum and DatumEither types, another take on RemoteData and [flow](https://medium.com/@gcanti/slaying-a-ui-antipattern-with-flow-5eed0cfb627b)
 - [fetcher-ts](https://github.com/YBogomolov/fetcher-ts) - Type-safe REST HTTP client with io-ts response validation
 - [alga-ts](https://github.com/algebraic-graphs/typescript) – Algebraic encoding for graphs, which makes invalid graphs unrepresentable
-- [matechs-effect](https://github.com/mikearnaldi/matechs-effect) – Contravariant trifunctor effect with useful integrations (http, react, orm, cqrs, etc.)
 - [morphic-ts](https://github.com/sledorze/morphic-ts) - Code first Domain modeling with extensive pattern supports (matchers, predicates, lenses) with useful, extensible, customisable derivations (Show, Eq, io-ts, fast-check, jsonSchema, ..).
 - [graphics-ts](https://github.com/gcanti/graphics-ts) - A porting of purescript-{canvas, drawing} featuring fp-ts
 - [expressive-ts](https://github.com/IMax153/expressive-ts) - Comonadic builders for writing complex regular expressions


### PR DESCRIPTION
Since the matechs library was renamed to effect-ts it's probably a good idea to update links in the ecosystem.md file