### PR TITLE
feat(EitherT): adds bracketT

### DIFF
--- a/docs/modules/EitherT.ts.md
+++ b/docs/modules/EitherT.ts.md
@@ -21,6 +21,7 @@ Added in v2.0.0
   - [altValidation](#altvalidation)
   - [ap](#ap)
   - [bimap](#bimap)
+  - [bracketT](#brackett)
   - [chain](#chain)
   - [getOrElse](#getorelse)
   - [left](#left)
@@ -235,6 +236,66 @@ export declare function bimap<F>(
 ```
 
 Added in v2.10.0
+
+## bracketT
+
+Make sure that a resource is cleaned up in the event of an exception (\*). The release action is called regardless of
+whether the body action throws (\*) or returns.
+
+Errors are collected in a `ReadonlyArray` as both `use` and `release` can fail with a successfully acquired resource.
+
+(\*) i.e. returns a `Left`
+
+**Signature**
+
+```ts
+export declare function bracketT<F extends URIS4>(
+  F: Monad4<F>
+): <S, R, ME, G, B>(
+  acquire: Kind4<F, S, R, ME, Either<G, B>>,
+  release: (fa: Kind4<F, S, R, ME, Either<G, B>>) => Kind4<F, S, R, ME, Either<G, void>>
+) => <E, A>(
+  kleisli: (resource: B) => Kind4<F, S, R, ME, Either<E, A>>
+) => Kind4<F, S, R, ME, Either<ReadonlyArray<E | G>, A>>
+export declare function bracketT<F extends URIS3, ME>(
+  F: Monad3C<F, ME>
+): <R, G, B>(
+  acquire: Kind3<F, R, ME, Either<G, B>>,
+  release: (fa: Kind3<F, R, ME, Either<G, B>>) => Kind3<F, R, ME, Either<G, void>>
+) => <E, A>(kleisli: (resource: B) => Kind3<F, R, ME, Either<E, A>>) => Kind3<F, R, ME, Either<ReadonlyArray<E | G>, A>>
+export declare function bracketT<F extends URIS3>(
+  F: Monad3<F>
+): <R, ME, G, B>(
+  acquire: Kind3<F, R, ME, Either<G, B>>,
+  release: (fa: Kind3<F, R, ME, Either<G, B>>) => Kind3<F, R, ME, Either<G, void>>
+) => <E, A>(kleisli: (resource: B) => Kind3<F, R, ME, Either<E, A>>) => Kind3<F, R, ME, Either<ReadonlyArray<E | G>, A>>
+export declare function bracketT<F extends URIS2, ME>(
+  F: Monad2C<F, ME>
+): <G, B>(
+  acquire: Kind2<F, ME, Either<G, B>>,
+  release: (fa: Kind2<F, ME, Either<G, B>>) => Kind2<F, ME, Either<G, void>>
+) => <E, A>(kleisli: (resource: B) => Kind2<F, ME, Either<E, A>>) => Kind2<F, ME, Either<ReadonlyArray<E | G>, A>>
+export declare function bracketT<F extends URIS2>(
+  F: Monad2<F>
+): <ME, G, B>(
+  acquire: Kind2<F, ME, Either<G, B>>,
+  release: (fa: Kind2<F, ME, Either<G, B>>) => Kind2<F, ME, Either<G, void>>
+) => <E, A>(kleisli: (resource: B) => Kind2<F, ME, Either<E, A>>) => Kind2<F, ME, Either<ReadonlyArray<E | G>, A>>
+export declare function bracketT<F extends URIS>(
+  F: Monad1<F>
+): <G, B>(
+  acquire: Kind<F, Either<G, B>>,
+  release: (fa: Kind<F, Either<G, B>>) => Kind<F, Either<G, void>>
+) => <E, A>(kleisli: (resource: B) => Kind<F, Either<E, A>>) => Kind<F, Either<ReadonlyArray<E | G>, A>>
+export declare function bracketT<F>(
+  F: Monad<F>
+): <G, B>(
+  acquire: HKT<F, Either<G, B>>,
+  release: (fa: HKT<F, Either<G, B>>) => HKT<F, Either<G, void>>
+) => <E, A>(kleisli: (resource: B) => HKT<F, Either<E, A>>) => HKT<F, Either<ReadonlyArray<E | G>, A>>
+```
+
+Added in v2.11.0
 
 ## chain
 

--- a/docs/modules/IOEither.ts.md
+++ b/docs/modules/IOEither.ts.md
@@ -1085,11 +1085,15 @@ whether the body action throws (\*) or returns.
 **Signature**
 
 ```ts
-export declare const bracket: <E, A, B>(
+export declare function bracket<E, A, B>(
   acquire: IOEither<E, A>,
   use: (a: A) => IOEither<E, B>,
-  release: (a: A, e: E.Either<E, B>) => IOEither<E, void>
-) => IOEither<E, B>
+  release: (a: A, e: Either<E, B>) => IOEither<E, void>
+): IOEither<E, B>
+export declare function bracket<G, B>(
+  acquire: IOEither<G, B>,
+  release: (fb: IOEither<G, B>) => IOEither<G, void>
+): <E, A>(kleisli: (b: B) => IOEither<E, A>) => IOEither<ReadonlyArray<E | G>, A>
 ```
 
 Added in v2.0.0

--- a/src/EitherT.ts
+++ b/src/EitherT.ts
@@ -1,17 +1,17 @@
 /**
  * @since 2.0.0
  */
+import * as RA from './ReadonlyArray'
 import { ApplicativeComposition12, ApplicativeComposition22, ApplicativeCompositionHKT2 } from './Applicative'
 import { ap as ap_, Apply, Apply1, Apply2, Apply2C, Apply3, Apply3C, Apply4 } from './Apply'
-import { Chain, Chain1, Chain2, Chain2C, Chain3, Chain3C, Chain4, chainFirst } from './Chain'
+import { Chain, Chain1, Chain2, Chain2C, Chain3, Chain3C, Chain4 } from './Chain'
 import * as E from './Either'
-import { constVoid, flow, Lazy, pipe, tuple } from './function'
+import { flow, Lazy, pipe } from './function'
 import { Functor, Functor1, Functor2, Functor2C, Functor3, Functor3C, Functor4, map as map_ } from './Functor'
 import { HKT, Kind, Kind2, Kind3, Kind4, URIS, URIS2, URIS3, URIS4 } from './HKT'
 import { Monad, Monad1, Monad2, Monad2C, Monad3, Monad3C, Monad4 } from './Monad'
 import { Pointed, Pointed1, Pointed2, Pointed2C, Pointed3, Pointed3C, Pointed4 } from './Pointed'
 import { Semigroup } from './Semigroup'
-import * as O from './Option'
 
 import Either = E.Either
 
@@ -627,7 +627,6 @@ export function bracketT<F>(F: Monad<F>) {
 // tslint:disable: deprecation
 
 import URI = E.URI
-import { readonlyArray as RA } from '.'
 
 /**
  * @category model

--- a/src/EitherT.ts
+++ b/src/EitherT.ts
@@ -531,6 +531,16 @@ export function toUnion<F>(F: Functor<F>): <E, A>(fa: HKT<F, Either<E, A>>) => H
   return (fa) => F.map(fa, E.toUnion)
 }
 
+/**
+ * Make sure that a resource is cleaned up in the event of an exception (\*). The release action is called regardless of
+ * whether the body action throws (\*) or returns.
+ *
+ * Errors are collected in a `ReadonlyArray` as both `use` and `release` can fail with a successfully acquired resource.
+ *
+ * (\*) i.e. returns a `Left`
+ *
+ * @since 2.11.0
+ */
 export function bracketT<F extends URIS4>(
   F: Monad4<F>
 ): <S, R, ME, G, B>(

--- a/src/EitherT.ts
+++ b/src/EitherT.ts
@@ -530,18 +530,50 @@ export function toUnion<F>(F: Functor<F>): <E, A>(fa: HKT<F, Either<E, A>>) => H
   return (fa) => F.map(fa, E.toUnion)
 }
 
-export function bracketT<F>(
-  F: Monad<F>
+export function bracketT<F extends URIS4>(
+  F: Monad4<F>
+): <S, R, ME, G, B>(
+  acquire: Kind4<F, S, R, ME, Either<G, B>>,
+  release: (fa: Kind4<F, S, R, ME, Either<G, B>>) => Kind4<F, S, R, ME, Either<G, void>>
+) => <E, A>(
+  kleisli: (resource: B) => Kind4<F, S, R, ME, Either<E, A>>
+) => Kind4<F, S, R, ME, Either<ReadonlyArray<E | G>, A>>
+export function bracketT<F extends URIS3, ME>(
+  F: Monad3C<F, ME>
+): <R, G, B>(
+  acquire: Kind3<F, R, ME, Either<G, B>>,
+  release: (fa: Kind3<F, R, ME, Either<G, B>>) => Kind3<F, R, ME, Either<G, void>>
+) => <E, A>(kleisli: (resource: B) => Kind3<F, R, ME, Either<E, A>>) => Kind3<F, R, ME, Either<ReadonlyArray<E | G>, A>>
+export function bracketT<F extends URIS3>(
+  F: Monad3<F>
+): <R, ME, G, B>(
+  acquire: Kind3<F, R, ME, Either<G, B>>,
+  release: (fa: Kind3<F, R, ME, Either<G, B>>) => Kind3<F, R, ME, Either<G, void>>
+) => <E, A>(kleisli: (resource: B) => Kind3<F, R, ME, Either<E, A>>) => Kind3<F, R, ME, Either<ReadonlyArray<E | G>, A>>
+export function bracketT<F extends URIS2, ME>(
+  F: Monad2C<F, ME>
 ): <G, B>(
-  acquire: HKT<F, Either<G, B>>,
-  release: (fa: HKT<F, Either<G, B>>) => HKT<F, Either<G, void>>
-) => <E, A>(kleisli: (resource: B) => HKT<F, Either<E, A>>) => HKT<F, Either<ReadonlyArray<E | G>, A>>
+  acquire: Kind2<F, ME, Either<G, B>>,
+  release: (fa: Kind2<F, ME, Either<G, B>>) => Kind2<F, ME, Either<G, void>>
+) => <E, A>(kleisli: (resource: B) => Kind2<F, ME, Either<E, A>>) => Kind2<F, ME, Either<ReadonlyArray<E | G>, A>>
+export function bracketT<F extends URIS2>(
+  F: Monad2<F>
+): <ME, G, B>(
+  acquire: Kind2<F, ME, Either<G, B>>,
+  release: (fa: Kind2<F, ME, Either<G, B>>) => Kind2<F, ME, Either<G, void>>
+) => <E, A>(kleisli: (resource: B) => Kind2<F, ME, Either<E, A>>) => Kind2<F, ME, Either<ReadonlyArray<E | G>, A>>
 export function bracketT<F extends URIS>(
   F: Monad1<F>
 ): <G, B>(
   acquire: Kind<F, Either<G, B>>,
   release: (fa: Kind<F, Either<G, B>>) => Kind<F, Either<G, void>>
 ) => <E, A>(kleisli: (resource: B) => Kind<F, Either<E, A>>) => Kind<F, Either<ReadonlyArray<E | G>, A>>
+export function bracketT<F>(
+  F: Monad<F>
+): <G, B>(
+  acquire: HKT<F, Either<G, B>>,
+  release: (fa: HKT<F, Either<G, B>>) => HKT<F, Either<G, void>>
+) => <E, A>(kleisli: (resource: B) => HKT<F, Either<E, A>>) => HKT<F, Either<ReadonlyArray<E | G>, A>>
 
 export function bracketT<F>(F: Monad<F>) {
   return <G, B>(acquire: HKT<F, Either<G, B>>, release: (fa: HKT<F, Either<G, B>>) => HKT<F, Either<G, void>>) => <
@@ -576,7 +608,7 @@ export function bracketT<F>(F: Monad<F>) {
           )
           const apeqxa = pipe(
             egxa,
-            E.map((a) => (r: void) => a)
+            E.map((a) => (_: void) => a)
           )
           const re = apv.ap(apeqxa, gxv)
           return re

--- a/src/EitherT.ts
+++ b/src/EitherT.ts
@@ -1,18 +1,18 @@
 /**
  * @since 2.0.0
  */
-import * as RA from './ReadonlyArray'
 import { ApplicativeComposition12, ApplicativeComposition22, ApplicativeCompositionHKT2 } from './Applicative'
 import { ap as ap_, Apply, Apply1, Apply2, Apply2C, Apply3, Apply3C, Apply4 } from './Apply'
 import { Chain, Chain1, Chain2, Chain2C, Chain3, Chain3C, Chain4 } from './Chain'
 import * as E from './Either'
-import { flow, identity, Lazy, pipe } from './function'
+import { flow, Lazy, pipe } from './function'
 import { Functor, Functor1, Functor2, Functor2C, Functor3, Functor3C, Functor4, map as map_ } from './Functor'
 import { HKT, Kind, Kind2, Kind3, Kind4, URIS, URIS2, URIS3, URIS4 } from './HKT'
 import { Monad, Monad1, Monad2, Monad2C, Monad3, Monad3C, Monad4 } from './Monad'
-import { Pointed, Pointed1, Pointed2, Pointed2C, Pointed3, Pointed3C, Pointed4 } from './Pointed'
-import { Semigroup } from './Semigroup'
 import * as O from './Option'
+import { Pointed, Pointed1, Pointed2, Pointed2C, Pointed3, Pointed3C, Pointed4 } from './Pointed'
+import * as RA from './ReadonlyArray'
+import { Semigroup } from './Semigroup'
 
 import Either = E.Either
 
@@ -639,7 +639,6 @@ export function bracketT<F>(F: Monad<F>) {
 // tslint:disable: deprecation
 
 import URI = E.URI
-import { readonlyArray } from '.'
 
 /**
  * @category model

--- a/src/IOEither.ts
+++ b/src/IOEither.ts
@@ -778,9 +778,11 @@ export function bracket<E, A, B>(
  * Make sure that a resource is cleaned up in the event of an exception (\*). The release action is called regardless of
  * whether the body action throws (\*) or returns.
  *
+ * Errors are collected in a `ReadonlyArray` as both `use` and `release` can fail with a successfully acquired resource.
+ *
  * (\*) i.e. returns a `Left`
  *
- * @since
+ * @since 2.11.0
  */
 export function bracket<G, B>(
   acquire: IOEither<G, B>,


### PR DESCRIPTION
Adds `bracketT`, for acquiring and releasing resources that are extended from `Either`, just like the other functions in `EitherT`.

## Summary

- [x] Adds `EitherT.bracketT`
- [x] Adds overload for  `EitherT.BracketT` implementation into `IOEither`
- [x] tests and docs

An edge case where `use` and `release` fail,  but `acquire` succeeds. To account for this, the current implementation is to catch errors into a `ReadonlyArray`, which in this case is always non empty.