### PR TITLE
Assert arrays as non-empty when using some()

### DIFF
--- a/src/Array.ts
+++ b/src/Array.ts
@@ -2024,7 +2024,7 @@ export const every: <A>(predicate: Predicate<A>) => (as: Array<A>) => boolean = 
 /**
  * @since 2.9.0
  */
-export const some: <A>(predicate: Predicate<A>) => (as: Array<A>) => boolean = RA.some
+export const some = <A>(predicate: Predicate<A>) => (as: Array<A>): as is NonEmptyArray<A> => as.some(predicate)
 
 // -------------------------------------------------------------------------------------
 // do notation

--- a/src/ReadonlyArray.ts
+++ b/src/ReadonlyArray.ts
@@ -2183,7 +2183,7 @@ export const every = <A>(predicate: Predicate<A>) => (as: ReadonlyArray<A>): boo
  *
  * @since 2.9.0
  */
-export const some = <A>(predicate: Predicate<A>) => (as: ReadonlyArray<A>): boolean => as.some(predicate)
+export const some = <A>(predicate: Predicate<A>) => (as: ReadonlyArray<A>): as is ReadonlyNonEmptyArray<A> => as.some(predicate)
 
 // -------------------------------------------------------------------------------------
 // do notation


### PR DESCRIPTION
`Array.prototype.some()` will always returns `false` if the array is empty, so can be used as a type guard.

(Refs https://github.com/sciety/sciety/blob/dea3e024b36c6c0c7799dc3376f1930f8f93f114/src/article-page/handle-article-version-errors.ts#L31-L34)