### PR TITLE
Turn TaskOptions to TaskEithers and vice versa

### DIFF
--- a/docs/modules/TaskEither.ts.md
+++ b/docs/modules/TaskEither.ts.md
@@ -70,6 +70,7 @@ Added in v2.0.0
   - [fromOption](#fromoption)
   - [fromPredicate](#frompredicate)
   - [fromTask](#fromtask)
+  - [fromTaskOption](#fromtaskoption)
   - [left](#left)
   - [leftIO](#leftio)
   - [leftTask](#lefttask)
@@ -715,6 +716,16 @@ export declare const fromTask: <E, A>(fa: T.Task<A>) => TaskEither<E, A>
 ```
 
 Added in v2.7.0
+
+## fromTaskOption
+
+**Signature**
+
+```ts
+export declare const fromTaskOption: <E>(onNone: Lazy<E>) => <A>(e: TaskOption<A>) => TaskEither<E, A>
+```
+
+Added in v2.11.0
 
 ## left
 

--- a/docs/modules/TaskOption.ts.md
+++ b/docs/modules/TaskOption.ts.md
@@ -53,6 +53,7 @@ Added in v2.10.0
   - [fromOption](#fromoption)
   - [fromPredicate](#frompredicate)
   - [fromTask](#fromtask)
+  - [fromTaskEither](#fromtaskeither)
   - [none](#none)
   - [some](#some)
 - [destructors](#destructors)
@@ -462,6 +463,16 @@ export declare const fromTask: <A>(fa: T.Task<A>) => TaskOption<A>
 ```
 
 Added in v2.10.0
+
+## fromTaskEither
+
+**Signature**
+
+```ts
+export declare const fromTaskEither: <A>(e: TaskEither<unknown, A>) => TaskOption<A>
+```
+
+Added in v2.11.0
 
 ## none
 

--- a/dtslint/ts3.5/TaskEither.ts
+++ b/dtslint/ts3.5/TaskEither.ts
@@ -1,6 +1,7 @@
 import * as _ from '../../src/TaskEither'
 import * as T from '../../src/Task'
 import * as E from '../../src/Either'
+import * as TO from '../../src/TaskOption'
 import * as IOE from '../../src/IOEither'
 import { pipe } from '../../src/function'
 
@@ -42,6 +43,16 @@ pipe(
 pipe(
   _.right<string, string>('a'),
   _.chainIOEitherKW(() => IOE.right<number, number>(1))
+)
+
+//
+// fromTaskOption
+//
+
+// $ExpectType TaskEither<string, number>
+pipe(
+  TO.some(1),
+  _.fromTaskOption(() => 'a')
 )
 
 //

--- a/dtslint/ts3.5/TaskOption.ts
+++ b/dtslint/ts3.5/TaskOption.ts
@@ -1,0 +1,11 @@
+import * as _ from '../../src/TaskOption'
+import * as TE from '../../src/TaskEither'
+import { pipe } from '../../src/function'
+
+declare const tesn: TE.TaskEither<string, number>
+
+//
+// fromTaskEither
+//
+
+pipe(tesn, _.fromTaskEither) // $ExpectType TaskOption<number>

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -60,6 +60,7 @@ import { Monoid } from './Monoid'
 import { Pointed2 } from './Pointed'
 import { Semigroup } from './Semigroup'
 import * as T from './Task'
+import { TaskOption } from './TaskOption'
 
 // -------------------------------------------------------------------------------------
 // model
@@ -827,6 +828,14 @@ export const fromOptionK =
 export const chainOptionK =
   /*#__PURE__*/
   chainOptionK_(FromEither, Chain)
+
+/**
+ * @category constructors
+ * @since 2.11.0
+ */
+export const fromTaskOption: <E>(onNone: Lazy<E>) => <A>(e: TaskOption<A>) => TaskEither<E, A> =
+  /*#__PURE__*/
+  (onNone) => T.map(E.fromOption(onNone))
 
 /**
  * @category combinators

--- a/src/TaskOption.ts
+++ b/src/TaskOption.ts
@@ -32,6 +32,7 @@ import * as OT from './OptionT'
 import { Pointed1 } from './Pointed'
 import { Separated } from './Separated'
 import * as T from './Task'
+import { TaskEither } from './TaskEither'
 
 import Task = T.Task
 import Option = O.Option
@@ -96,6 +97,14 @@ export const fromIO: FromIO1<URI>['fromIO'] = (ma) => fromTask(T.fromIO(ma))
 export const fromTask: FromTask1<URI>['fromTask'] =
   /*#__PURE__*/
   OT.fromF(T.Functor)
+
+/**
+ * @category constructors
+ * @since 2.11.0
+ */
+export const fromTaskEither: <A>(e: TaskEither<unknown, A>) => TaskOption<A> =
+  /*#__PURE__*/
+  T.map(O.fromEither)
 
 // -------------------------------------------------------------------------------------
 // destructors

--- a/test/TaskEither.ts
+++ b/test/TaskEither.ts
@@ -10,6 +10,7 @@ import { none, some } from '../src/Option'
 import { pipeable } from '../src/pipeable'
 import * as N from '../src/number'
 import * as T from '../src/Task'
+import * as TO from '../src/TaskOption'
 import * as _ from '../src/TaskEither'
 import * as S from '../src/string'
 import { left, right } from '../src/Separated'
@@ -466,6 +467,23 @@ describe('TaskEither', () => {
       await pipe(
         some(1),
         _.fromOption(() => 'none')
+      )(),
+      E.right(1)
+    )
+  })
+
+  it('fromTaskOption', async () => {
+    U.deepStrictEqual(
+      await pipe(
+        TO.none,
+        _.fromTaskOption(() => 'none')
+      )(),
+      E.left('none')
+    )
+    U.deepStrictEqual(
+      await pipe(
+        TO.some(1),
+        _.fromTaskOption(() => 'none')
       )(),
       E.right(1)
     )

--- a/test/TaskOption.ts
+++ b/test/TaskOption.ts
@@ -2,6 +2,7 @@ import * as U from './util'
 import { pipe } from '../src/function'
 import * as O from '../src/Option'
 import * as T from '../src/Task'
+import * as TE from '../src/TaskEither'
 import * as _ from '../src/TaskOption'
 
 describe('TaskOption', () => {
@@ -116,6 +117,15 @@ describe('TaskOption', () => {
     const f = _.fromPredicate(p)
     U.deepStrictEqual(await f(1)(), O.none)
     U.deepStrictEqual(await f(3)(), O.some(3))
+  })
+
+  it('fromTaskEither', async () => {
+    const pl = TE.left('a')
+    const pr = TE.right('a')
+    const fl = _.fromTaskEither(pl)
+    const fr = _.fromTaskEither(pr)
+    U.deepStrictEqual(await fl(), O.none)
+    U.deepStrictEqual(await fr(), O.some('a'))
   })
 
   // -------------------------------------------------------------------------------------


### PR DESCRIPTION
We convert options to either inside tasks at various point, this allows turning a `TaskOption` into a `TaskEither` and back.