### PR TITLE
update Apply example

### DIFF
--- a/docs/modules/Apply.ts.md
+++ b/docs/modules/Apply.ts.md
@@ -23,7 +23,7 @@ Formally, `Apply` represents a strong lax semi-monoidal endofunctor.
 import * as O from 'fp-ts/Option'
 import { pipe } from 'fp-ts/function'
 
-const f = (a: string) => (b: number) => (c: boolean) => a + String(b) + (c ? 'true' : 'false')
+const f = (a: string) => (b: number) => (c: boolean) => a + String(b) + String(c)
 const fa: O.Option<string> = O.some('s')
 const fb: O.Option<number> = O.some(1)
 const fc: O.Option<boolean> = O.some(true)

--- a/src/Apply.ts
+++ b/src/Apply.ts
@@ -14,7 +14,7 @@
  * import * as O from 'fp-ts/Option'
  * import { pipe } from 'fp-ts/function'
  *
- * const f = (a: string) => (b: number) => (c: boolean) => a + String(b) + (c ? 'true' : 'false')
+ * const f = (a: string) => (b: number) => (c: boolean) => a + String(b) + String(c)
  * const fa: O.Option<string> = O.some('s')
  * const fb: O.Option<number> = O.some(1)
  * const fc: O.Option<boolean> = O.some(true)


### PR DESCRIPTION
Make the example slightly more declarative.

The current use of the `ternary operator` is equal to `String(x)` or `x.toString()`

Node repl session
```
> c = true
> (c ? 'true' : 'false') === String(c)
true

> c = false
> (c ? 'true' : 'false') === String(c)
true
```

Note: I changed the source example and ran `npm run docs`
