### PR TITLE
Add swapped/swappedW to TaskEither

### DIFF
--- a/docs/modules/TaskEither.ts.md
+++ b/docs/modules/TaskEither.ts.md
@@ -63,6 +63,8 @@ Added in v2.0.0
   - [orElse](#orelse)
   - [orElseW](#orelsew)
   - [swap](#swap)
+  - [swapped](#swapped)
+  - [swappedW](#swappedw)
 - [constructors](#constructors)
   - [fromEither](#fromeither)
   - [fromIO](#fromio)
@@ -651,6 +653,32 @@ export declare const swap: <E, A>(ma: TaskEither<E, A>) => TaskEither<A, E>
 ```
 
 Added in v2.0.0
+
+## swapped
+
+**Signature**
+
+```ts
+export declare const swapped: <E, A>(
+  f: (fa: TaskEither<A, E>) => TaskEither<A, E>
+) => (ma: TaskEither<E, A>) => TaskEither<E, A>
+```
+
+Added in v2.11.0
+
+## swappedW
+
+Less strict version of [`swapped`](#swapped).
+
+**Signature**
+
+```ts
+export declare const swappedW: <E1, E2, A1, A2>(
+  f: (fa: TaskEither<A1, E1>) => TaskEither<A2, E2>
+) => (ma: TaskEither<E1, A1>) => TaskEither<E2, A2>
+```
+
+Added in v2.11.0
 
 # constructors
 

--- a/dtslint/ts3.5/TaskEither.ts
+++ b/dtslint/ts3.5/TaskEither.ts
@@ -46,6 +46,57 @@ pipe(
 )
 
 //
+// swapped
+//
+
+// $ExpectType TaskEither<number, string>
+pipe(
+  _.right<number, string>('foo'),
+  _.swapped(
+    _.mapLeft((a) => `${a}bar`)
+  )
+)
+
+// $ExpectType TaskEither<number, string>
+pipe(
+  _.left<number, string>(1),
+  _.swapped(
+    _.map((a) => a + 1)
+  )
+)
+
+//
+// swappedW
+//
+
+// $ExpectType TaskEither<number, number>
+pipe(
+  _.right<number, string>('foo'),
+  _.swappedW(
+    _.mapLeft((a) => a.length)
+  )
+)
+
+// $ExpectType TaskEither<string, string>
+pipe(
+  _.left<number, string>(1),
+  _.swappedW(
+    _.map(String)
+  )
+)
+
+// $ExpectType TaskEither<string, number>
+pipe(
+  _.left<number, string>(1),
+  _.swappedW(
+    _.bimap(
+      (a) => a.length,
+      String
+    )
+  )
+)
+
+//
 // fromTaskOption
 //
 

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -777,6 +777,24 @@ export const chainFirstW: <E2, A, B>(
 ) => <E1>(ma: TaskEither<E1, A>) => TaskEither<E1 | E2, A> = chainFirst as any
 
 /**
+ * Less strict version of [`swapped`](#swapped).
+ *
+ * @category combinators
+ * @since 2.11.0
+ */
+export const swappedW: <E1, E2, A1, A2>(
+  f: (fa: TaskEither<A1, E1>) => TaskEither<A2, E2>
+) => (ma: TaskEither<E1, A1>) => TaskEither<E2, A2> = (f) => flow(swap, f, swap)
+
+/**
+ * @category combinators
+ * @since 2.11.0
+ */
+export const swapped: <E, A>(
+  f: (fa: TaskEither<A, E>) => TaskEither<A, E>
+) => (ma: TaskEither<E, A>) => TaskEither<E, A> = swappedW
+
+/**
  * @category instances
  * @since 2.7.0
  */

--- a/test/TaskEither.ts
+++ b/test/TaskEither.ts
@@ -83,6 +83,19 @@ describe('TaskEither', () => {
     )
   })
 
+  it('swapped', async () => {
+    U.deepStrictEqual(
+      await pipe(_.right<number, string>('foo'), _.swapped(_.mapLeft((a) => `${a}bar`)))(),
+      E.right('foobar')
+    )
+    U.deepStrictEqual(await pipe(_.left<number, string>(1), _.swapped(_.map((a) => a + 1)))(), E.left(2))
+  })
+
+  it('swappedW', async () => {
+    U.deepStrictEqual(await pipe(_.right<number, string>('foo'), _.swappedW(_.mapLeft((a) => a.length)))(), E.right(3))
+    U.deepStrictEqual(await pipe(_.left<number, string>(1), _.swappedW(_.map(String)))(), E.left('1'))
+  })
+
   it('flatten', async () => {
     U.deepStrictEqual(await pipe(_.right(_.right('a')), _.flatten)(), E.right('a'))
   })


### PR DESCRIPTION
Similar to https://github.com/gcanti/fp-ts/issues/1360, I've been looking for a good way to be able to write log messages while on the `left` side of an `Either`. `chainFirstIOK` will be perfect for this, but there's no equivalent for the left side (where more logging will happen). Currently, I'm [using `swap` twice](https://github.com/sciety/sciety/blob/1b8e0ca613deb81bad019c04ce878ff418b68c19/src/infrastructure/fetch-static-file.ts#L14-L21) to allow the use of `chainFirst` etc (as opposed to `mapLeft` and returning the original value).

This adds a `swapped`/`swappedW` function which applies a function with the `left` and `right` sides swapped, then swaps them back again.

Leaving this as WIP for feedback, in case there's a better approach, name etc. Would need rolling out to the other `Either` categories too.