### PR TITLE
Expand struct Module

### DIFF
--- a/docs/modules/Eq.ts.md
+++ b/docs/modules/Eq.ts.md
@@ -23,7 +23,6 @@ Added in v2.0.0
 - [Contravariant](#contravariant)
   - [contramap](#contramap)
 - [combinators](#combinators)
-  - [struct](#struct)
   - [tuple](#tuple)
   - [~~getStructEq~~](#getstructeq)
   - [~~getTupleEq~~](#gettupleeq)
@@ -62,16 +61,6 @@ Added in v2.0.0
 
 # combinators
 
-## struct
-
-**Signature**
-
-```ts
-export declare const struct: <A>(eqs: { [K in keyof A]: Eq<A[K]> }) => Eq<{ readonly [K in keyof A]: A[K] }>
-```
-
-Added in v2.10.0
-
 ## tuple
 
 Given a tuple of `Eq`s returns a `Eq` for the tuple
@@ -101,7 +90,7 @@ Added in v2.10.0
 
 ## ~~getStructEq~~
 
-Use `struct` instead.
+Use `struct.getEq` instead.
 
 **Signature**
 

--- a/docs/modules/Monoid.ts.md
+++ b/docs/modules/Monoid.ts.md
@@ -45,7 +45,6 @@ Added in v2.0.0
 
 - [combinators](#combinators)
   - [reverse](#reverse)
-  - [struct](#struct)
   - [tuple](#tuple)
   - [~~getDualMonoid~~](#getdualmonoid)
   - [~~getStructMonoid~~](#getstructmonoid)
@@ -95,37 +94,6 @@ assert.deepStrictEqual(reverse(S.Monoid).concat('a', 'b'), 'ba')
 
 Added in v2.10.0
 
-## struct
-
-Given a struct of monoids returns a monoid for the struct.
-
-**Signature**
-
-```ts
-export declare const struct: <A>(monoids: { [K in keyof A]: Monoid<A[K]> }) => Monoid<{ readonly [K in keyof A]: A[K] }>
-```
-
-**Example**
-
-```ts
-import { struct } from 'fp-ts/Monoid'
-import * as N from 'fp-ts/number'
-
-interface Point {
-  readonly x: number
-  readonly y: number
-}
-
-const M = struct<Point>({
-  x: N.MonoidSum,
-  y: N.MonoidSum,
-})
-
-assert.deepStrictEqual(M.concat({ x: 1, y: 2 }, { x: 3, y: 4 }), { x: 4, y: 6 })
-```
-
-Added in v2.10.0
-
 ## tuple
 
 Given a tuple of monoids returns a monoid for the tuple.
@@ -169,7 +137,7 @@ Added in v2.0.0
 
 ## ~~getStructMonoid~~
 
-Use `struct` instead.
+Use `struct.getMonoid` instead.
 
 **Signature**
 

--- a/docs/modules/Semigroup.ts.md
+++ b/docs/modules/Semigroup.ts.md
@@ -51,7 +51,6 @@ Added in v2.0.0
 - [combinators](#combinators)
   - [intercalate](#intercalate)
   - [reverse](#reverse)
-  - [struct](#struct)
   - [tuple](#tuple)
   - [~~getDualSemigroup~~](#getdualsemigroup)
   - [~~getIntercalateSemigroup~~](#getintercalatesemigroup)
@@ -131,39 +130,6 @@ assert.deepStrictEqual(reverse(S.Semigroup).concat('a', 'b'), 'ba')
 
 Added in v2.10.0
 
-## struct
-
-Given a struct of semigroups returns a semigroup for the struct.
-
-**Signature**
-
-```ts
-export declare const struct: <A>(
-  semigroups: { [K in keyof A]: Semigroup<A[K]> }
-) => Semigroup<{ readonly [K in keyof A]: A[K] }>
-```
-
-**Example**
-
-```ts
-import { struct } from 'fp-ts/Semigroup'
-import * as N from 'fp-ts/number'
-
-interface Point {
-  readonly x: number
-  readonly y: number
-}
-
-const S = struct<Point>({
-  x: N.SemigroupSum,
-  y: N.SemigroupSum,
-})
-
-assert.deepStrictEqual(S.concat({ x: 1, y: 2 }, { x: 3, y: 4 }), { x: 4, y: 6 })
-```
-
-Added in v2.10.0
-
 ## tuple
 
 Given a tuple of semigroups returns a semigroup for the tuple.
@@ -219,7 +185,7 @@ Added in v2.5.0
 
 ## ~~getStructSemigroup~~
 
-Use `struct` instead.
+Use `struct.getSemigroup` instead.
 
 **Signature**
 

--- a/docs/modules/Show.ts.md
+++ b/docs/modules/Show.ts.md
@@ -20,7 +20,6 @@ Added in v2.0.0
 <h2 class="text-delta">Table of contents</h2>
 
 - [combinators](#combinators)
-  - [struct](#struct)
   - [tuple](#tuple)
   - [~~getStructShow~~](#getstructshow)
   - [~~getTupleShow~~](#gettupleshow)
@@ -34,16 +33,6 @@ Added in v2.0.0
 ---
 
 # combinators
-
-## struct
-
-**Signature**
-
-```ts
-export declare const struct: <A>(shows: { [K in keyof A]: Show<A[K]> }) => Show<{ readonly [K in keyof A]: A[K] }>
-```
-
-Added in v2.10.0
 
 ## tuple
 
@@ -59,7 +48,7 @@ Added in v2.10.0
 
 ## ~~getStructShow~~
 
-Use `struct` instead.
+Use `struct.getShow` instead.
 
 **Signature**
 

--- a/docs/modules/struct.ts.md
+++ b/docs/modules/struct.ts.md
@@ -6,16 +6,985 @@ parent: Modules
 
 ## struct overview
 
+A 'struct' is a heterogeneous `ReadonlyRecord`, often an `interface`.
+Many of these functions have a `Record._WithIndex` counterpart.
+e.g. struct.mapS <-> Record.mapWithIndex
+
 Added in v2.10.0
 
 ---
 
 <h2 class="text-delta">Table of contents</h2>
 
+- [combinators](#combinators)
+  - [compactS](#compacts)
+  - [filterMapS](#filtermaps)
+  - [filterS](#filters)
+  - [foldMapS](#foldmaps)
+  - [mapS](#maps)
+  - [partitionMapS](#partitionmaps)
+  - [partitionS](#partitions)
+  - [reduceS](#reduces)
+  - [separateS](#separates)
+  - [traverseS](#traverses)
+  - [traverseS\_](#traverses_)
+  - [unCompact](#uncompact)
+  - [wiltS](#wilts)
+  - [witherS](#withers)
+- [destructors](#destructors)
+  - [keys](#keys)
 - [instances](#instances)
   - [getAssignSemigroup](#getassignsemigroup)
+  - [getEq](#geteq)
+  - [getMonoid](#getmonoid)
+  - [getSemigroup](#getsemigroup)
+  - [getShow](#getshow)
 
 ---
+
+# combinators
+
+## compactS
+
+Given a heterogeneous struct of Options, eliminate
+all keys that are `None` & return a struct of the
+existing values.
+
+**Signature**
+
+```ts
+export declare const compactS: <A>(r: { [K in keyof A]: Option<A[K]> }) => Partial<A>
+```
+
+**Example**
+
+```ts
+import { compactS } from 'fp-ts/struct'
+import * as O from 'fp-ts/Option'
+
+assert.deepStrictEqual(
+  compactS({
+    foo: O.some(123),
+    bar: O.none,
+    baz: O.some('abc'),
+  }),
+  { foo: 123, baz: 'abc' }
+)
+```
+
+Added in v2.10.0
+
+## filterMapS
+
+Given a struct mapping to heterogeneous Optional values,
+filter & trasform a corresponding struct of values.
+
+**Signature**
+
+```ts
+export declare const filterMapS: <A, C extends { [K in keyof A]: (v: A[K]) => Option<unknown> }>(
+  f: C
+) => (fa: NonEmpty<A>) => { [K in keyof A]?: (ReturnType<C[K]> extends Option<infer A> ? A : never) | undefined }
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/function'
+import { filterMapS } from 'fp-ts/struct'
+import * as O from 'fp-ts/Option'
+
+assert.deepStrictEqual(
+  pipe(
+    { a: 'a', b: 1 },
+    filterMapS({
+      a: () => O.none,
+      b: (n) => (n === 1 ? O.some(n + 1) : O.none),
+    })
+  ),
+  { b: 2 }
+)
+```
+
+Added in v2.10.0
+
+## filterS
+
+Given a struct of predicates, filter & potentially refine
+a corresponding struct of values.
+
+**Signature**
+
+```ts
+export declare const filterS: <A, B extends { [K in keyof A]: Predicate<A[K]> | Refinement<A[K], any> }>(
+  predicates: B
+) => (fa: NonEmpty<A>) => { [K in keyof A]?: (B[K] extends (a: any) => a is infer C ? C : A[K]) | undefined }
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/function'
+import { filterS } from 'fp-ts/struct'
+
+assert.deepStrictEqual(
+  pipe(
+    { a: 'a', b: 1 },
+    filterS({
+      a: (a) => a === 'b',
+      b: (b): b is 1 => b === 1,
+    })
+  ),
+  { b: 1 } as const
+)
+```
+
+Added in v2.10.0
+
+## foldMapS
+
+Given a monoid and a struct of functions outputting its type parameter,
+fold a corresponding struct of values into a single value.
+
+**Signature**
+
+```ts
+export declare const foldMapS: (
+  O: Ord<string>
+) => <M>(M: Monoid<M>) => <A>(f: { [key in keyof A]: (a: A[key]) => M }) => (fa: NonEmpty<A>) => M
+```
+
+**Example**
+
+```ts
+import { pipe, identity } from 'fp-ts/function'
+import { foldMapS } from 'fp-ts/struct'
+import * as S from 'fp-ts/string'
+
+assert.deepStrictEqual(
+  pipe(
+    { a: 'a', b: 1 },
+    foldMapS(S.Ord)(S.Monoid)({
+      a: identity,
+      b: (b) => b.toString(),
+    })
+  ),
+  'a1'
+)
+```
+
+Added in v2.10.0
+
+## mapS
+
+Given a struct of functions map a corresponding struct of values.
+
+**Signature**
+
+```ts
+export declare function mapS<A, B extends { [k in keyof A]: (val: A[k]) => unknown }>(
+  f: B
+): (a: NonEmpty<A>) => { [key in keyof A]: ReturnType<B[key]> }
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/function'
+import { mapS } from 'fp-ts/struct'
+
+assert.deepStrictEqual(
+  pipe(
+    { a: 'a', b: 1 },
+    mapS({
+      a: (a) => a.length,
+      b: (b) => b * 2,
+    })
+  ),
+  { a: 1, b: 2 }
+)
+```
+
+Added in v2.10.0
+
+## partitionMapS
+
+Given a struct mapping to heterogeneous Optional values,
+trasform & split a corresponding struct of values
+into a failing `left` struct and a passing `right` struct.
+
+**Signature**
+
+```ts
+export declare const partitionMapS: <R, B extends { [K in keyof R]: (val: R[K]) => Either<unknown, unknown> }>(
+  f: B
+) => (
+  fa: NonEmpty<R>
+) => Separated<
+  { [K in keyof R]?: (ReturnType<B[K]> extends Either<infer E, unknown> ? E : never) | undefined },
+  { [K in keyof R]?: (ReturnType<B[K]> extends Either<unknown, infer A> ? A : never) | undefined }
+>
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/function'
+import { partitionMapS } from 'fp-ts/struct'
+import * as E from 'fp-ts/Either'
+import { separated } from 'fp-ts/Separated'
+
+assert.deepStrictEqual(
+  pipe(
+    { a: 'a', b: 1 },
+    partitionMapS({
+      a: () => E.left('fail'),
+      b: (n) => (n === 1 ? E.right(n + 1) : E.left(n - 1)),
+    })
+  ),
+  separated({ a: 'fail' }, { b: 2 })
+)
+```
+
+Added in v2.10.0
+
+## partitionS
+
+Given a struct of predicates, split & potentially refine
+a corresponding struct of values into a failing `left` struct
+and a passing `right` struct.
+
+**Signature**
+
+```ts
+export declare const partitionS: <R, B extends { [K in keyof R]: Predicate<R[K]> | Refinement<R[K], any> }>(
+  f: B
+) => (
+  fa: NonEmpty<R>
+) => Separated<Partial<R>, { [K in keyof R]?: (B[K] extends (a: any) => a is infer C ? C : R[K]) | undefined }>
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/function'
+import { partitionS } from 'fp-ts/struct'
+import { separated } from 'fp-ts/Separated'
+
+assert.deepStrictEqual(
+  pipe(
+    { a: 'b', b: 1 },
+    partitionS({
+      a: (s) => s === 'a',
+      b: (n): n is 1 => n === 1,
+    })
+  ),
+  separated({ a: 'b' }, { b: 1 } as const)
+)
+```
+
+Added in v2.10.0
+
+## reduceS
+
+Given a struct of functions reduce a corresponding struct of values
+down to a single value.
+
+**Signature**
+
+```ts
+export declare const reduceS: (
+  O: Ord<string>
+) => <A, B>(b: B, f: { [K in keyof A]: (b: B, a: A[K]) => B }) => (fa: NonEmpty<A>) => B
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/function'
+import { reduceS } from 'fp-ts/struct'
+import { Ord } from 'fp-ts/string'
+import { reverse } from 'fp-ts/Ord'
+
+assert.deepStrictEqual(
+  pipe(
+    { a: 'a', b: 1 },
+    reduceS(Ord)('', {
+      a: (acc, cur) => acc + cur,
+      b: (acc, cur) => acc + cur.toString(),
+    })
+  ),
+  'a1'
+)
+
+assert.deepStrictEqual(
+  pipe(
+    { a: 'a', b: 1 },
+    reduceS(reverse(Ord))('', {
+      a: (acc, cur) => acc + cur,
+      b: (acc, cur) => acc + cur.toString(),
+    })
+  ),
+  '1a'
+)
+```
+
+Added in v2.10.0
+
+## separateS
+
+Split a heterogeneous struct of Either values into a failing
+struct of its `lefts` and a struct of its `rights`.
+
+**Signature**
+
+```ts
+export declare const separateS: <R extends Readonly<Record<string, Either<unknown, unknown>>>>(
+  r: R
+) => Separated<
+  { [K in keyof R]?: (R[K] extends Either<infer E, unknown> ? E : never) | undefined },
+  { [K in keyof R]?: (R[K] extends Either<unknown, infer A> ? A : never) | undefined }
+>
+```
+
+**Example**
+
+```ts
+import { separateS } from 'fp-ts/struct'
+import * as E from 'fp-ts/Either'
+import { separated } from 'fp-ts/Separated'
+
+assert.deepStrictEqual(
+  separateS({ foo: E.right(123), bar: E.left('fail'), baz: E.right('abc') }),
+  separated({ bar: 'fail' }, { foo: 123, baz: 'abc' })
+)
+```
+
+Added in v2.10.0
+
+## traverseS
+
+Runs an separate action for each value in a struct, and accumulates the results.
+
+A pipeable version of `traverseS_`
+
+**Signature**
+
+```ts
+export declare function traverseS(
+  O: Ord<string>
+): {
+  <F extends URIS4>(F: Apply4<F>): <
+    S,
+    R,
+    E,
+    A,
+    B extends { [key in keyof A]: (val: A[key]) => Kind4<F, S, R, E, unknown> }
+  >(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => Kind4<
+    F,
+    S,
+    R,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind4<F, S, R, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS3>(F: Apply3<F>): <R, E, A, B extends { [key in keyof A]: (val: A[key]) => Kind3<F, R, E, unknown> }>(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => Kind3<
+    F,
+    R,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind3<F, R, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS3, E>(F: Apply3C<F, E>): <
+    R,
+    A,
+    B extends { [key in keyof A]: (val: A[key]) => Kind3<F, R, E, unknown> }
+  >(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => Kind3<
+    F,
+    R,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind3<F, R, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS2>(F: Apply2<F>): <E, A, B extends { [key in keyof A]: (val: A[key]) => Kind2<F, E, unknown> }>(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => Kind2<
+    F,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind2<F, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS2, E>(F: Apply2C<F, E>): <A, B extends { [key in keyof A]: (val: A[key]) => Kind2<F, E, unknown> }>(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => Kind2<
+    F,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind2<F, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS>(F: Apply1<F>): <A, B extends { [key in keyof A]: (val: A[key]) => Kind<F, unknown> }>(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => Kind<
+    F,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind<F, infer C> ? C : never
+    }
+  >
+  <F>(F: Apply<F>): <A, B extends { [key in keyof A]: (val: A[key]) => HKT<F, unknown> }>(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => HKT<
+    F,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends HKT<F, infer C> ? C : never
+    }
+  >
+}
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/function'
+import { traverseS } from 'fp-ts/struct'
+import { Ord } from 'fp-ts/string'
+import * as O from 'fp-ts/Option'
+
+assert.deepStrictEqual(
+  pipe(
+    { a: 1, b: 'b' },
+    traverseS(Ord)(O.Apply)({
+      a: (n) => (n <= 2 ? O.some(n.toString()) : O.none),
+      b: (b) => (b.length <= 2 ? O.some(b.length) : O.none),
+    })
+  ),
+  O.some({ a: '1', b: 1 })
+)
+```
+
+Added in v2.10.0
+
+## traverseS\_
+
+Runs an separate action for each value in a struct, and accumulates the results.
+
+A non-pipeable version of `traverseS`
+
+**Signature**
+
+```ts
+export declare function traverseS_(
+  O: Ord<string>
+): {
+  <F extends URIS4>(F: Apply4<F>): <
+    S,
+    R,
+    E,
+    B extends ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => Kind4<
+    F,
+    S,
+    R,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind4<F, S, R, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS3>(F: Apply3<F>): <
+    R,
+    E,
+    B extends ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => Kind3<
+    F,
+    R,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind3<F, R, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS3, E>(F: Apply3C<F, E>): <
+    R,
+    B extends ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => Kind3<
+    F,
+    R,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind3<F, R, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS2>(F: Apply2<F>): <
+    E,
+    B extends ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => Kind2<
+    F,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind2<F, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS2, E>(F: Apply2C<F, E>): <
+    B extends ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => Kind2<
+    F,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind2<F, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS>(F: Apply1<F>): <
+    B extends ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => Kind<
+    F,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind<F, infer C> ? C : never
+    }
+  >
+  <F>(F: Apply<F>): <
+    B extends ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => HKT<
+    F,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends HKT<F, infer C> ? C : never
+    }
+  >
+}
+```
+
+**Example**
+
+```ts
+import { traverseS_ } from 'fp-ts/struct'
+import { Ord } from 'fp-ts/string'
+import * as O from 'fp-ts/Option'
+
+const f = {
+  a: (n: number) => (n <= 2 ? O.some(n.toString()) : O.none),
+  b: (b: string) => (b.length <= 2 ? O.some(b.length) : O.none),
+}
+
+assert.deepStrictEqual(traverseS_(Ord)(O.Apply)({ a: 1, b: 'b' }, f), O.some({ a: '1', b: 1 }))
+assert.deepStrictEqual(traverseS_(Ord)(O.Apply)({ a: 3, b: '2' }, f), O.none)
+```
+
+Added in v2.10.0
+
+## unCompact
+
+Wrap each key in heterogeneous struct of nullable values in `Option`.
+
+Note: cannot properly wrap optional/partial keys.
+
+**Signature**
+
+```ts
+export declare const unCompact: <A>(a: NonEmpty<A>) => { [K in keyof A]: Option<NonNullable<A[K]>> }
+```
+
+**Example**
+
+```ts
+import { unCompact } from 'fp-ts/struct'
+import * as O from 'fp-ts/Option'
+
+assert.deepStrictEqual(unCompact({ foo: 123, bar: undefined, baz: 'abc' }), {
+  foo: O.some(123),
+  bar: O.none,
+  baz: O.some('abc'),
+})
+```
+
+Added in v2.10.0
+
+## wiltS
+
+Applies a `traverseS` and a `partitionMap` as a single combined operation.
+
+**Signature**
+
+```ts
+export declare const wiltS: (
+  O: Ord<string>
+) => {
+  <F extends 'ReaderEither' | 'ReaderTaskEither'>(F: Apply3<F>): <
+    R,
+    E,
+    A,
+    B extends { [K in keyof A]: (val: A[K]) => Kind3<F, R, E, Either<unknown, unknown>> }
+  >(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind3<
+    F,
+    R,
+    E,
+    Separated<
+      { [K in keyof A]?: (ReturnType<B[K]> extends Kind3<F, R, E, Either<infer L, unknown>> ? L : never) | undefined },
+      { [K in keyof A]?: (ReturnType<B[K]> extends Kind3<F, R, E, Either<unknown, infer R>> ? R : never) | undefined }
+    >
+  >
+  <F extends 'ReaderEither' | 'ReaderTaskEither', E>(F: Apply3C<F, E>): <
+    R,
+    A,
+    B extends { [K in keyof A]: (val: A[K]) => Kind3<F, R, E, Either<unknown, unknown>> }
+  >(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind3<
+    F,
+    R,
+    E,
+    Separated<
+      { [K in keyof A]?: (ReturnType<B[K]> extends Kind3<F, R, E, Either<infer L, unknown>> ? L : never) | undefined },
+      { [K in keyof A]?: (ReturnType<B[K]> extends Kind3<F, R, E, Either<unknown, infer R>> ? R : never) | undefined }
+    >
+  >
+  <
+    F extends
+      | 'Separated'
+      | 'Either'
+      | 'Const'
+      | 'IOEither'
+      | 'ReadonlyMap'
+      | 'Map'
+      | 'Reader'
+      | 'ReaderTask'
+      | 'TaskEither'
+      | 'ReadonlyTuple'
+      | 'State'
+      | 'Store'
+      | 'These'
+      | 'TaskThese'
+      | 'Traced'
+      | 'Tuple'
+      | 'Writer'
+  >(
+    F: Apply2<F>
+  ): <E, A, B extends { [K in keyof A]: (val: A[K]) => Kind2<F, E, Either<unknown, unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind2<
+    F,
+    E,
+    Separated<
+      { [K in keyof A]?: (ReturnType<B[K]> extends Kind2<F, E, Either<infer L, unknown>> ? L : never) | undefined },
+      { [K in keyof A]?: (ReturnType<B[K]> extends Kind2<F, E, Either<unknown, infer R>> ? R : never) | undefined }
+    >
+  >
+  <
+    F extends
+      | 'Separated'
+      | 'Either'
+      | 'Const'
+      | 'IOEither'
+      | 'ReadonlyMap'
+      | 'Map'
+      | 'Reader'
+      | 'ReaderTask'
+      | 'TaskEither'
+      | 'ReadonlyTuple'
+      | 'State'
+      | 'Store'
+      | 'These'
+      | 'TaskThese'
+      | 'Traced'
+      | 'Tuple'
+      | 'Writer',
+    E
+  >(
+    F: Apply2C<F, E>
+  ): <A, B extends { [K in keyof A]: (val: A[K]) => Kind2<F, E, Either<unknown, unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind2<
+    F,
+    E,
+    Separated<
+      { [K in keyof A]?: (ReturnType<B[K]> extends Kind2<F, E, Either<infer L, unknown>> ? L : never) | undefined },
+      { [K in keyof A]?: (ReturnType<B[K]> extends Kind2<F, E, Either<unknown, infer R>> ? R : never) | undefined }
+    >
+  >
+  <
+    F extends
+      | 'Array'
+      | 'Option'
+      | 'ReadonlyRecord'
+      | 'ReadonlyNonEmptyArray'
+      | 'NonEmptyArray'
+      | 'Eq'
+      | 'Ord'
+      | 'ReadonlyArray'
+      | 'IO'
+      | 'Task'
+      | 'Identity'
+      | 'Record'
+      | 'TaskOption'
+      | 'Tree'
+  >(
+    F: Apply1<F>
+  ): <A, B extends { [K in keyof A]: (val: A[K]) => Kind<F, Either<unknown, unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind<
+    F,
+    Separated<
+      { [K in keyof A]?: (ReturnType<B[K]> extends Kind<F, Either<infer L, unknown>> ? L : never) | undefined },
+      { [K in keyof A]?: (ReturnType<B[K]> extends Kind<F, Either<unknown, infer R>> ? R : never) | undefined }
+    >
+  >
+  <F>(F: Apply<F>): <A, B extends { [K in keyof A]: (val: A[K]) => HKT<F, Either<unknown, unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => HKT<
+    F,
+    Separated<
+      { [K in keyof A]?: (ReturnType<B[K]> extends HKT<F, Either<infer L, unknown>> ? L : never) | undefined },
+      { [K in keyof A]?: (ReturnType<B[K]> extends HKT<F, Either<unknown, infer R>> ? R : never) | undefined }
+    >
+  >
+}
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/function'
+import { wiltS } from 'fp-ts/struct'
+import * as Tr from 'fp-ts/Tree'
+import * as E from 'fp-ts/Either'
+import { separated } from 'fp-ts/Separated'
+import * as S from 'fp-ts/string'
+
+assert.deepStrictEqual(
+  pipe(
+    { a: 2, b: 'a' },
+    wiltS(S.Ord)(Tr.Apply)({
+      a: (n) => Tr.of(n === 1 ? E.right(n.toString()) : E.left(n - 1)),
+      b: (n) => Tr.of(n === 'a' ? E.right(n.length) : E.left('fail')),
+    })
+  ),
+  Tr.of(separated({ a: 1 }, { b: 1 }))
+)
+```
+
+Added in v2.10.0
+
+## witherS
+
+Applies a traverseS and a filterMap as a single combined operation.
+
+**Signature**
+
+```ts
+export declare const witherS: (
+  O: Ord<string>
+) => {
+  <F extends 'ReaderEither' | 'ReaderTaskEither'>(F: Apply3<F>): <
+    R,
+    E,
+    A,
+    B extends { [K in keyof A]: (val: A[K]) => Kind3<F, R, E, Option<unknown>> }
+  >(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind3<
+    F,
+    R,
+    E,
+    { [K in keyof A]?: (ReturnType<B[K]> extends Kind3<F, R, E, Option<infer C>> ? C : never) | undefined }
+  >
+  <F extends 'ReaderEither' | 'ReaderTaskEither', E>(F: Apply3C<F, E>): <
+    R,
+    A,
+    B extends { [K in keyof A]: (val: A[K]) => Kind3<F, R, E, Option<unknown>> }
+  >(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind3<
+    F,
+    R,
+    E,
+    { [K in keyof A]?: (ReturnType<B[K]> extends Kind3<F, R, E, Option<infer C>> ? C : never) | undefined }
+  >
+  <
+    F extends
+      | 'Separated'
+      | 'Either'
+      | 'Const'
+      | 'IOEither'
+      | 'ReadonlyMap'
+      | 'Map'
+      | 'Reader'
+      | 'ReaderTask'
+      | 'TaskEither'
+      | 'ReadonlyTuple'
+      | 'State'
+      | 'Store'
+      | 'These'
+      | 'TaskThese'
+      | 'Traced'
+      | 'Tuple'
+      | 'Writer',
+    E
+  >(
+    F: Apply2<F>
+  ): <E, A, B extends { [K in keyof A]: (val: A[K]) => Kind2<F, E, Option<unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind2<F, E, { [K in keyof A]?: (ReturnType<B[K]> extends Kind2<F, E, Option<infer C>> ? C : never) | undefined }>
+  <
+    F extends
+      | 'Separated'
+      | 'Either'
+      | 'Const'
+      | 'IOEither'
+      | 'ReadonlyMap'
+      | 'Map'
+      | 'Reader'
+      | 'ReaderTask'
+      | 'TaskEither'
+      | 'ReadonlyTuple'
+      | 'State'
+      | 'Store'
+      | 'These'
+      | 'TaskThese'
+      | 'Traced'
+      | 'Tuple'
+      | 'Writer',
+    E
+  >(
+    F: Apply2C<F, E>
+  ): <A, B extends { [K in keyof A]: (val: A[K]) => Kind2<F, E, Option<unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind2<F, E, { [K in keyof A]?: (ReturnType<B[K]> extends Kind2<F, E, Option<infer C>> ? C : never) | undefined }>
+  <
+    F extends
+      | 'Array'
+      | 'Option'
+      | 'ReadonlyRecord'
+      | 'ReadonlyNonEmptyArray'
+      | 'NonEmptyArray'
+      | 'Eq'
+      | 'Ord'
+      | 'ReadonlyArray'
+      | 'IO'
+      | 'Task'
+      | 'Identity'
+      | 'Record'
+      | 'TaskOption'
+      | 'Tree'
+  >(
+    F: Apply1<F>
+  ): <A, B extends { [K in keyof A]: (val: A[K]) => Kind<F, Option<unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind<F, { [K in keyof A]?: (ReturnType<B[K]> extends Kind<F, Option<infer C>> ? C : never) | undefined }>
+  <F>(F: Apply<F>): <A, B extends { [K in keyof A]: (val: A[K]) => HKT<F, Option<unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => HKT<F, { [K in keyof A]?: (ReturnType<B[K]> extends HKT<F, Option<infer C>> ? C : never) | undefined }>
+}
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/function'
+import { witherS } from 'fp-ts/struct'
+import * as Tr from 'fp-ts/Tree'
+import * as O from 'fp-ts/Option'
+import * as S from 'fp-ts/string'
+
+assert.deepStrictEqual(
+  pipe(
+    { a: 2, b: 'a' },
+    witherS(S.Ord)(Tr.Apply)({
+      a: (n) => Tr.of(n === 1 ? O.some(n.toString()) : O.none),
+      b: (n) => Tr.of(n === 'a' ? O.some(n.length) : O.none),
+    })
+  ),
+  Tr.of({ b: 1 })
+)
+```
+
+Added in v2.10.0
+
+# destructors
+
+## keys
+
+**Signature**
+
+```ts
+export declare const keys: (O: Ord<string>) => <A>(r: A) => readonly (keyof A)[]
+```
+
+Added in v2.10.0
 
 # instances
 
@@ -41,6 +1010,92 @@ interface Person {
 
 const S = getAssignSemigroup<Person>()
 assert.deepStrictEqual(S.concat({ name: 'name', age: 23 }, { name: 'name', age: 24 }), { name: 'name', age: 24 })
+```
+
+Added in v2.10.0
+
+## getEq
+
+**Signature**
+
+```ts
+export declare const getEq: <A>(eqs: { [K in keyof A]: Eq<A[K]> }) => Eq<{ readonly [K in keyof A]: A[K] }>
+```
+
+Added in v2.10.0
+
+## getMonoid
+
+Given a struct of monoids returns a monoid for the struct.
+
+**Signature**
+
+```ts
+export declare const getMonoid: <A>(
+  monoids: { [K in keyof A]: Monoid<A[K]> }
+) => Monoid<{ readonly [K in keyof A]: A[K] }>
+```
+
+**Example**
+
+```ts
+import { getMonoid } from 'fp-ts/struct'
+import * as N from 'fp-ts/number'
+
+interface Point {
+  readonly x: number
+  readonly y: number
+}
+
+const M = getMonoid<Point>({
+  x: N.MonoidSum,
+  y: N.MonoidSum,
+})
+
+assert.deepStrictEqual(M.concat({ x: 1, y: 2 }, { x: 3, y: 4 }), { x: 4, y: 6 })
+```
+
+Added in v2.10.0
+
+## getSemigroup
+
+Given a struct of semigroups returns a semigroup for the struct.
+
+**Signature**
+
+```ts
+export declare const getSemigroup: <A>(
+  semigroups: { [K in keyof A]: Semigroup<A[K]> }
+) => Semigroup<{ readonly [K in keyof A]: A[K] }>
+```
+
+**Example**
+
+```ts
+import { getSemigroup } from 'fp-ts/struct'
+import * as N from 'fp-ts/number'
+
+interface Point {
+  readonly x: number
+  readonly y: number
+}
+
+const S = getSemigroup<Point>({
+  x: N.SemigroupSum,
+  y: N.SemigroupSum,
+})
+
+assert.deepStrictEqual(S.concat({ x: 1, y: 2 }, { x: 3, y: 4 }), { x: 4, y: 6 })
+```
+
+Added in v2.10.0
+
+## getShow
+
+**Signature**
+
+```ts
+export declare const getShow: <A>(shows: { [K in keyof A]: Show<A[K]> }) => Show<{ readonly [K in keyof A]: A[K] }>
 ```
 
 Added in v2.10.0

--- a/dtslint/ts3.5/Eq.ts
+++ b/dtslint/ts3.5/Eq.ts
@@ -4,13 +4,6 @@ import * as N from '../../src/number'
 import * as B from '../../src/boolean'
 
 //
-// struct
-//
-
-// $ExpectType Eq<{ readonly a: string; readonly b: number; readonly c: boolean; }>
-_.struct({ a: S.Eq, b: N.Eq, c: B.Eq })
-
-//
 // tuple
 //
 

--- a/dtslint/ts3.5/Monoid.ts
+++ b/dtslint/ts3.5/Monoid.ts
@@ -4,13 +4,6 @@ import * as N from '../../src/number'
 import * as B from '../../src/boolean'
 
 //
-// struct
-//
-
-// $ExpectType Monoid<{ readonly a: string; readonly b: number; readonly c: boolean; }>
-_.struct({ a: S.Monoid, b: N.MonoidSum, c: B.MonoidAll })
-
-//
 // tuple
 //
 

--- a/dtslint/ts3.5/Semigroup.ts
+++ b/dtslint/ts3.5/Semigroup.ts
@@ -4,13 +4,6 @@ import * as N from '../../src/number'
 import * as B from '../../src/boolean'
 
 //
-// struct
-//
-
-// $ExpectType Semigroup<{ readonly a: string; readonly b: number; readonly c: boolean; }>
-_.struct({ a: S.Semigroup, b: N.SemigroupSum, c: B.SemigroupAll })
-
-//
 // tuple
 //
 

--- a/dtslint/ts3.5/Show.ts
+++ b/dtslint/ts3.5/Show.ts
@@ -4,13 +4,6 @@ import * as N from '../../src/number'
 import * as B from '../../src/boolean'
 
 //
-// struct
-//
-
-// $ExpectType Show<{ readonly a: string; readonly b: number; readonly c: boolean; }>
-_.struct({ a: S.Show, b: N.Show, c: B.Show })
-
-//
 // tuple
 //
 

--- a/dtslint/ts3.6/struct.ts
+++ b/dtslint/ts3.6/struct.ts
@@ -1,0 +1,77 @@
+import { pipe, identity } from '../../src/function'
+import * as _ from '../../src/struct'
+import * as O from '../../src/Option'
+import * as N from '../../src/number'
+import * as S from '../../src/string'
+import * as E from '../../src/Either'
+import * as Tr from '../../src/Tree'
+
+declare const r1: { a: number, b: string }
+
+//
+// mapS
+//
+
+pipe(r1, _.mapS({ a: n => n > 2, b: n => n.length })) // $ExpectType { a: boolean; b: number; }
+
+//
+// reduceS
+//
+
+pipe(r1, _.reduceS(S.Ord)('', { a: (acc, cur) => acc + cur.toString(), b: (acc, cur) => acc + cur })) // $ExpectType string
+
+pipe(r1, _.foldMapS(S.Ord)(S.Monoid)({ a: k => k.toString(), b: identity })) // $ExpectType string
+
+pipe(r1, _.filterS({ a: (k): k is 1 => k === 1, b: () => false })) // $ExpectType { a?: 1 | undefined; b?: string | undefined; }
+
+pipe(r1, _.filterMapS({ a: (n) => (n === 1 ? O.some(n + 1) : O.none), b: () => O.none })) // $ExpectType { a?: number | undefined; b?: undefined; }
+
+pipe(r1, _.partitionS({ a: (k): k is 1 => k === 1, b: () => false })) // $ExpectType Separated<Partial<{ a: number; b: string; }>, { a?: 1 | undefined; b?: string | undefined; }>
+
+const a = pipe(
+  r1,
+  _.partitionMapS({
+    a: (n): E.Either<number, number> => n === 1 ? E.right(n + 1) : E.left(n - 1),
+    b: () => E.left('fail')
+  })
+)
+a // $ExpectType Separated<{ a?: number | undefined; b?: string | undefined; }, { a?: number | undefined; b?: unknown; }>
+
+_.compactS({ a: O.some(1), b: O.some('a') }) // $ExpectType Partial<{ a: number; b: string; }>
+
+_.unCompact({ a: 1, b: undefined }) // $ExpectType { a: Option<number>; b: Option<never>; }
+
+const b = _.separateS({
+  foo: E.right(123), bar: E.left('fail'), baz: E.right('abc')
+})
+b // $ExpectType Separated<{ foo?: unknown; bar?: string | undefined; baz?: unknown; }, { foo?: number | undefined; bar?: unknown; baz?: string | undefined; }>
+
+pipe(r1, _.traverseS(S.Ord)(O.Apply)({ a: (n) => O.some(n), b: (n) => O.some(n)})) // $ExpectType Option<{ a: number; b: string; }>
+
+const c = pipe(
+  r1,
+  _.witherS(S.Ord)(Tr.Apply)({
+    a: (n) => Tr.of(n === 1 ? O.some(n.toString()) : O.none),
+    b: (n) => Tr.of(n === 'a' ? O.some(n.length) : O.none)
+  })
+)
+c // $ExpectType Tree<{ a?: string | undefined; b?: number | undefined; }>
+
+const d = pipe(
+  r1,
+  _.wiltS(S.Ord)(Tr.Apply)({
+    a: (n) => Tr.of<E.Either<number, string>>(n === 1 ? E.right(n.toString()) : E.left(n - 1)),
+    b: (n) => Tr.of<E.Either<string, number>>(n === 'a' ? E.right(n.length) : E.left('fail'))
+  })
+)
+d // $ExpectType Tree<Separated<{ a?: number | undefined; b?: string | undefined; }, { a?: string | undefined; b?: number | undefined; }>>
+
+_.traverseS_(S.Ord)(O.Apply)(r1, { a: (n: number) => O.some(n), b: (n: string) => O.some(n)}) // $ExpectType Option<{ a: number; b: string; }>
+
+_.getShow({ key1: N.Show, key2: S.Show }) // $ExpectType Show<{ readonly key1: number; readonly key2: string; }>
+
+_.getEq({ key1: N.Eq, key2: S.Eq }) // $ExpectType Eq<{ readonly key1: number; readonly key2: string; }>
+
+_.getSemigroup({ key1: N.SemigroupSum, key2: S.Semigroup }) // $ExpectType Semigroup<{ readonly key1: number; readonly key2: string; }>
+
+_.getMonoid({ key1: N.MonoidSum, key2: S.Monoid }) // $ExpectType Monoid<{ readonly key1: number; readonly key2: string; }>

--- a/src/Eq.ts
+++ b/src/Eq.ts
@@ -46,20 +46,6 @@ export function fromEquals<A>(equals: (x: A, y: A) => boolean): Eq<A> {
 // -------------------------------------------------------------------------------------
 
 /**
- * @category combinators
- * @since 2.10.0
- */
-export const struct = <A>(eqs: { [K in keyof A]: Eq<A[K]> }): Eq<{ readonly [K in keyof A]: A[K] }> =>
-  fromEquals((first, second) => {
-    for (const key in eqs) {
-      if (!eqs[key].equals(first[key], second[key])) {
-        return false
-      }
-    }
-    return true
-  })
-
-/**
  * Given a tuple of `Eq`s returns a `Eq` for the tuple
  *
  * @example
@@ -174,13 +160,23 @@ export const getTupleEq: <T extends ReadonlyArray<Eq<any>>>(
 ) => Eq<{ [K in keyof T]: T[K] extends Eq<infer A> ? A : never }> = tuple
 
 /**
- * Use `struct` instead.
+ * Use `struct.getEq` instead.
  *
  * @category combinators
  * @since 2.0.0
  * @deprecated
  */
-export const getStructEq: <O extends ReadonlyRecord<string, any>>(eqs: { [K in keyof O]: Eq<O[K]> }) => Eq<O> = struct
+export const getStructEq: <O extends ReadonlyRecord<string, any>>(eqs: { [K in keyof O]: Eq<O[K]> }) => Eq<O> = <A>(
+  eqs: { [K in keyof A]: Eq<A[K]> }
+): Eq<{ readonly [K in keyof A]: A[K] }> =>
+  fromEquals((first, second) => {
+    for (const key in eqs) {
+      if (!eqs[key].equals(first[key], second[key])) {
+        return false
+      }
+    }
+    return true
+  })
 
 /**
  * Use `eqStrict` instead

--- a/src/Monoid.ts
+++ b/src/Monoid.ts
@@ -117,41 +117,6 @@ export const reverse = <A>(M: Monoid<A>): Monoid<A> => ({
 })
 
 /**
- * Given a struct of monoids returns a monoid for the struct.
- *
- * @example
- * import { struct } from 'fp-ts/Monoid'
- * import * as N from 'fp-ts/number'
- *
- * interface Point {
- *   readonly x: number
- *   readonly y: number
- * }
- *
- * const M = struct<Point>({
- *   x: N.MonoidSum,
- *   y: N.MonoidSum
- * })
- *
- * assert.deepStrictEqual(M.concat({ x: 1, y: 2 }, { x: 3, y: 4 }), { x: 4, y: 6 })
- *
- * @category combinators
- * @since 2.10.0
- */
-export const struct = <A>(monoids: { [K in keyof A]: Monoid<A[K]> }): Monoid<{ readonly [K in keyof A]: A[K] }> => {
-  const empty: A = {} as any
-  for (const k in monoids) {
-    if (_.hasOwnProperty.call(monoids, k)) {
-      empty[k] = monoids[k].empty
-    }
-  }
-  return {
-    concat: Se.struct(monoids).concat,
-    empty
-  }
-}
-
-/**
  * Given a tuple of monoids returns a monoid for the tuple.
  *
  * @example
@@ -222,7 +187,7 @@ export const getTupleMonoid: <T extends ReadonlyArray<Monoid<any>>>(
 ) => Monoid<{ [K in keyof T]: T[K] extends Se.Semigroup<infer A> ? A : never }> = tuple as any
 
 /**
- * Use `struct` instead.
+ * Use `struct.getMonoid` instead.
  *
  * @category combinators
  * @since 2.0.0
@@ -230,7 +195,19 @@ export const getTupleMonoid: <T extends ReadonlyArray<Monoid<any>>>(
  */
 export const getStructMonoid: <O extends ReadonlyRecord<string, any>>(
   monoids: { [K in keyof O]: Monoid<O[K]> }
-) => Monoid<O> = struct
+) => Monoid<O> = <A>(monoids: { [K in keyof A]: Monoid<A[K]> }): Monoid<{ readonly [K in keyof A]: A[K] }> => {
+  const empty: A = {} as any
+  for (const k in monoids) {
+    if (_.hasOwnProperty.call(monoids, k)) {
+      empty[k] = monoids[k].empty
+    }
+  }
+  return {
+    // tslint:disable-next-line: deprecation
+    concat: Se.getStructSemigroup(monoids).concat,
+    empty
+  }
+}
 
 /**
  * Use `reverse` instead.

--- a/src/Semigroup.ts
+++ b/src/Semigroup.ts
@@ -124,42 +124,6 @@ export const reverse = <A>(S: Semigroup<A>): Semigroup<A> => ({
 })
 
 /**
- * Given a struct of semigroups returns a semigroup for the struct.
- *
- * @example
- * import { struct } from 'fp-ts/Semigroup'
- * import * as N from 'fp-ts/number'
- *
- * interface Point {
- *   readonly x: number
- *   readonly y: number
- * }
- *
- * const S = struct<Point>({
- *   x: N.SemigroupSum,
- *   y: N.SemigroupSum
- * })
- *
- * assert.deepStrictEqual(S.concat({ x: 1, y: 2 }, { x: 3, y: 4 }), { x: 4, y: 6 })
- *
- * @category combinators
- * @since 2.10.0
- */
-export const struct = <A>(
-  semigroups: { [K in keyof A]: Semigroup<A[K]> }
-): Semigroup<{ readonly [K in keyof A]: A[K] }> => ({
-  concat: (first, second) => {
-    const r: A = {} as any
-    for (const k in semigroups) {
-      if (_.hasOwnProperty.call(semigroups, k)) {
-        r[k] = semigroups[k].concat(first[k], second[k])
-      }
-    }
-    return r
-  }
-})
-
-/**
  * Given a tuple of semigroups returns a semigroup for the tuple.
  *
  * @example
@@ -306,7 +270,7 @@ export const getTupleSemigroup: <T extends ReadonlyArray<Semigroup<any>>>(
 ) => Semigroup<{ [K in keyof T]: T[K] extends Semigroup<infer A> ? A : never }> = tuple as any
 
 /**
- * Use `struct` instead.
+ * Use `struct.getSemigroup` instead.
  *
  * @category combinators
  * @since 2.0.0
@@ -314,7 +278,19 @@ export const getTupleSemigroup: <T extends ReadonlyArray<Semigroup<any>>>(
  */
 export const getStructSemigroup: <O extends ReadonlyRecord<string, any>>(
   semigroups: { [K in keyof O]: Semigroup<O[K]> }
-) => Semigroup<O> = struct
+) => Semigroup<O> = <A>(
+  semigroups: { [K in keyof A]: Semigroup<A[K]> }
+): Semigroup<{ readonly [K in keyof A]: A[K] }> => ({
+  concat: (first, second) => {
+    const r: A = {} as any
+    for (const k in semigroups) {
+      if (_.hasOwnProperty.call(semigroups, k)) {
+        r[k] = semigroups[k].concat(first[k], second[k])
+      }
+    }
+    return r
+  }
+})
 
 /**
  * Use `reverse` instead.

--- a/src/Show.ts
+++ b/src/Show.ts
@@ -31,26 +31,6 @@ export interface Show<A> {
  * @category combinators
  * @since 2.10.0
  */
-export const struct = <A>(shows: { [K in keyof A]: Show<A[K]> }): Show<{ readonly [K in keyof A]: A[K] }> => ({
-  show: (a) => {
-    let s = '{'
-    for (const k in shows) {
-      if (_.hasOwnProperty.call(shows, k)) {
-        s += ` ${k}: ${shows[k].show(a[k])},`
-      }
-    }
-    if (s.length > 1) {
-      s = s.slice(0, -1) + ' '
-    }
-    s += '}'
-    return s
-  }
-})
-
-/**
- * @category combinators
- * @since 2.10.0
- */
 export const tuple = <A extends ReadonlyArray<unknown>>(
   ...shows: { [K in keyof A]: Show<A[K]> }
 ): Show<Readonly<A>> => ({
@@ -73,7 +53,7 @@ export const getTupleShow: <T extends ReadonlyArray<Show<any>>>(
 ) => Show<{ [K in keyof T]: T[K] extends Show<infer A> ? A : never }> = tuple
 
 /**
- * Use `struct` instead.
+ * Use `struct.getShow` instead.
  *
  * @category combinators
  * @since 2.0.0
@@ -81,7 +61,21 @@ export const getTupleShow: <T extends ReadonlyArray<Show<any>>>(
  */
 export const getStructShow: <O extends ReadonlyRecord<string, any>>(
   shows: { [K in keyof O]: Show<O[K]> }
-) => Show<O> = struct
+) => Show<O> = <A>(shows: { [K in keyof A]: Show<A[K]> }): Show<{ readonly [K in keyof A]: A[K] }> => ({
+  show: (a) => {
+    let s = '{'
+    for (const k in shows) {
+      if (_.hasOwnProperty.call(shows, k)) {
+        s += ` ${k}: ${shows[k].show(a[k])},`
+      }
+    }
+    if (s.length > 1) {
+      s = s.slice(0, -1) + ' '
+    }
+    s += '}'
+    return s
+  }
+})
 
 /**
  * Use `boolean.Show` instead.

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -1,11 +1,1041 @@
 /**
+ *
+ * A 'struct' is a heterogeneous `ReadonlyRecord`, often an `interface`.
+ * Many of these functions have a `Record._WithIndex` counterpart.
+ * e.g. struct.mapS <-> Record.mapWithIndex
+ *
  * @since 2.10.0
  */
+import { pipe, Predicate, Refinement } from './function'
+import { URIS3, Kind3, URIS2, Kind2, URIS, Kind, URIS4, Kind4, HKT } from './HKT'
+import { ReadonlyRecord } from './ReadonlyRecord'
+import { Option, isSome, fromNullable } from './Option'
+import { Monoid } from './Monoid'
+import { Either, isLeft } from './Either'
+import { Separated, separated } from './Separated'
+import { Ord } from './Ord'
+import { Ord as StringOrd } from './string'
+import { Apply4, Apply3, Apply3C, Apply2, Apply2C, Apply1, Apply } from './Apply'
+import { Show } from './Show'
+import { Eq, fromEquals } from './Eq'
 import { getObjectSemigroup, Semigroup } from './Semigroup'
+import * as _ from './internal'
+
+type NonEmpty<R> = keyof R extends never ? never : R extends object ? R : never
+
+/**
+ * @category destructors
+ * @since 2.10.0
+ */
+export const keys = (O: Ord<string>) => <A>(r: A): ReadonlyArray<keyof A> =>
+  Object.keys(r).sort(O.compare) as Array<keyof A>
+
+/**
+ * Given a struct of functions map a corresponding struct of values.
+ *
+ * @example
+ * import { pipe } from 'fp-ts/function'
+ * import { mapS } from 'fp-ts/struct'
+ *
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     { a: 'a', b: 1 },
+ *     mapS({
+ *       a: (a) => a.length,
+ *       b: (b) => b * 2
+ *     })
+ *   ),
+ *   { a: 1, b: 2 }
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export function mapS<A, B extends { [k in keyof A]: (val: A[k]) => unknown }>(
+  f: B
+): (a: NonEmpty<A>) => { [key in keyof A]: ReturnType<B[key]> } {
+  return (r) => {
+    const out: any = {}
+    for (const k in r) {
+      if (_.hasOwnProperty.call(r, k)) {
+        out[k] = (f as any)[k](r[k])
+      }
+    }
+    return out as { [key in keyof A]: ReturnType<B[key]> }
+  }
+}
+
+/**
+ * Given a struct of functions reduce a corresponding struct of values
+ * down to a single value.
+ *
+ * @example
+ * import { pipe } from 'fp-ts/function'
+ * import { reduceS } from 'fp-ts/struct'
+ * import { Ord } from 'fp-ts/string'
+ * import { reverse } from 'fp-ts/Ord'
+ *
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     { a: 'a', b: 1 },
+ *     reduceS(Ord)('', {
+ *       a: (acc, cur) => acc + cur,
+ *       b: (acc, cur) => acc + cur.toString()
+ *     })
+ *   ),
+ *   'a1'
+ * )
+ *
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     { a: 'a', b: 1 },
+ *     reduceS(reverse(Ord))('', {
+ *       a: (acc, cur) => acc + cur,
+ *       b: (acc, cur) => acc + cur.toString()
+ *     })
+ *   ),
+ *   '1a'
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const reduceS = (O: Ord<string>) => <A, B>(b: B, f: { [K in keyof A]: (b: B, a: A[K]) => B }) => (
+  fa: NonEmpty<A>
+): B => {
+  let out = b
+  const ks = keys(O)(fa) as Array<keyof A>
+  const len = ks.length
+  for (let i = 0; i < len; i++) {
+    const k = ks[i]
+    out = f[k](out, fa[k])
+  }
+  return out
+}
+
+/**
+ * Given a monoid and a struct of functions outputting its type parameter,
+ * fold a corresponding struct of values into a single value.
+ *
+ * @example
+ * import { pipe, identity } from 'fp-ts/function'
+ * import { foldMapS } from 'fp-ts/struct'
+ * import * as S from 'fp-ts/string'
+ *
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     { a: 'a', b: 1 },
+ *     foldMapS(S.Ord)(S.Monoid)({
+ *       a: identity,
+ *       b: (b) => b.toString()
+ *     })
+ *   ),
+ *   'a1'
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const foldMapS = (O: Ord<string>) => <M>(M: Monoid<M>) => <A>(
+  f: {
+    [key in keyof A]: (a: A[key]) => M
+  }
+) => (fa: NonEmpty<A>): M => {
+  let out = M.empty
+  const ks = keys(O)(fa) as Array<keyof A>
+  const len = ks.length
+  for (let i = 0; i < len; i++) {
+    const k = ks[i]
+    out = M.concat(out, f[k](fa[k]))
+  }
+  return out
+}
+
+/**
+ * Given a struct of predicates, filter & potentially refine
+ * a corresponding struct of values.
+ *
+ * @example
+ * import { pipe } from 'fp-ts/function'
+ * import { filterS } from 'fp-ts/struct'
+ *
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     { a: 'a', b: 1 },
+ *     filterS({
+ *       a: (a) => a === 'b',
+ *       b: (b): b is 1 => b === 1
+ *     })
+ *   ),
+ *   { b: 1 } as const
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const filterS = <A, B extends { [K in keyof A]: Predicate<A[K]> | Refinement<A[K], any> }>(predicates: B) => (
+  fa: NonEmpty<A>
+): {
+  [K in keyof A]?: B[K] extends (a: any) => a is infer C ? C : A[K]
+} => {
+  const out: any = {}
+  let changed = false
+  for (const key in fa) {
+    if (_.hasOwnProperty.call(fa, key)) {
+      const a = fa[key]
+      if ((predicates as any)[key](a)) {
+        out[key] = a as any
+      } else {
+        changed = true
+      }
+    }
+  }
+  return changed
+    ? (out as {
+        [K in keyof A]?: B[K] extends (a: any) => a is infer C ? C : A[K]
+      })
+    : (fa as any)
+}
+
+/**
+ * Given a struct mapping to heterogeneous Optional values,
+ * filter & trasform a corresponding struct of values.
+ *
+ * @example
+ * import { pipe } from 'fp-ts/function'
+ * import { filterMapS } from 'fp-ts/struct'
+ * import * as O from 'fp-ts/Option'
+ *
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     { a: 'a', b: 1 },
+ *     filterMapS({
+ *       a: () => O.none,
+ *       b: (n) => n === 1 ? O.some(n + 1) : O.none
+ *     })
+ *   ),
+ *   { b: 2 }
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const filterMapS = <A, C extends { [K in keyof A]: (v: A[K]) => Option<unknown> }>(f: C) => (
+  fa: NonEmpty<A>
+) => {
+  const out: Record<string, unknown> = {}
+  for (const k in fa) {
+    if (_.hasOwnProperty.call(fa, k)) {
+      const ob = (f as any)[k](fa[k])
+      if (isSome(ob)) {
+        out[k] = ob.value
+      }
+    }
+  }
+  return out as {
+    [K in keyof A]?: ReturnType<C[K]> extends Option<infer A> ? A : never
+  }
+}
+/**
+ * Given a struct of predicates, split & potentially refine
+ * a corresponding struct of values into a failing `left` struct
+ * and a passing `right` struct.
+ *
+ * @example
+ * import { pipe } from 'fp-ts/function'
+ * import { partitionS } from 'fp-ts/struct'
+ * import { separated } from 'fp-ts/Separated'
+ *
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     { a: 'b', b: 1 },
+ *     partitionS({
+ *       a: (s) => s === 'a',
+ *       b: (n): n is 1 => n === 1,
+ *     })
+ *   ),
+ *   separated({ a: 'b' }, { b: 1 } as const)
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const partitionS = <R, B extends { [K in keyof R]: Predicate<R[K]> | Refinement<R[K], any> }>(f: B) => (
+  fa: NonEmpty<R>
+): Separated<Partial<R>, { [K in keyof R]?: B[K] extends (a: any) => a is infer C ? C : R[K] }> => {
+  const left: any = {}
+  const right: any = {}
+  for (const k in fa) {
+    if (_.hasOwnProperty.call(fa, k)) {
+      const a = fa[k]
+      if ((f as any)[k](a)) {
+        right[k] = a
+      } else {
+        left[k] = a
+      }
+    }
+  }
+  return separated(left, right)
+}
+
+/**
+ * Given a struct mapping to heterogeneous Optional values,
+ * trasform & split a corresponding struct of values
+ * into a failing `left` struct and a passing `right` struct.
+ *
+ * @example
+ * import { pipe } from 'fp-ts/function'
+ * import { partitionMapS } from 'fp-ts/struct'
+ * import * as E from 'fp-ts/Either'
+ * import { separated } from 'fp-ts/Separated'
+ *
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     { a: 'a', b: 1 },
+ *     partitionMapS({
+ *       a: () => E.left('fail'),
+ *       b: (n) => n === 1 ? E.right(n + 1) : E.left(n - 1)
+ *     })
+ *   ),
+ *   separated({ a: 'fail' }, { b: 2 })
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const partitionMapS = <R, B extends { [K in keyof R]: (val: R[K]) => Either<unknown, unknown> }>(f: B) => (
+  fa: NonEmpty<R>
+) => {
+  const left: any = {}
+  const right: any = {}
+  for (const k in fa) {
+    if (_.hasOwnProperty.call(fa, k)) {
+      const e = (f as any)[k](fa[k])
+      switch (e._tag) {
+        case 'Left':
+          left[k] = e.left
+          break
+        case 'Right':
+          right[k] = e.right
+          break
+      }
+    }
+  }
+  return separated(
+    left as {
+      [K in keyof R]?: ReturnType<B[K]> extends Either<infer E, unknown> ? E : never
+    },
+    right as {
+      [K in keyof R]?: ReturnType<B[K]> extends Either<unknown, infer A> ? A : never
+    }
+  )
+}
+
+/**
+ * Given a heterogeneous struct of Options, eliminate
+ * all keys that are `None` & return a struct of the
+ * existing values.
+ *
+ * @example
+ * import { compactS } from 'fp-ts/struct'
+ * import * as O from 'fp-ts/Option'
+ *
+ * assert.deepStrictEqual(
+ *   compactS({
+ *     foo: O.some(123),
+ *     bar: O.none,
+ *     baz: O.some('abc')
+ *   }),
+ *   { foo: 123, baz: 'abc' }
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const compactS = <A>(r: { [K in keyof A]: Option<A[K]> }): Partial<A> => {
+  const out: Partial<A> = {}
+  for (const k in r) {
+    if (_.hasOwnProperty.call(r, k)) {
+      const oa = r[k]
+      if (isSome(oa)) {
+        out[k] = oa.value
+      }
+    }
+  }
+  return out
+}
+
+/**
+ * Wrap each key in heterogeneous struct of nullable values in `Option`.
+ *
+ * Note: cannot properly wrap optional/partial keys.
+ *
+ * @example
+ * import { unCompact } from 'fp-ts/struct'
+ * import * as O from 'fp-ts/Option'
+ *
+ * assert.deepStrictEqual(
+ *   unCompact({ foo: 123, bar: undefined, baz: 'abc' }),
+ *   { foo: O.some(123), bar: O.none, baz: O.some('abc') }
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const unCompact = <A>(
+  a: NonEmpty<A>
+): {
+  [K in keyof A]: Option<NonNullable<A[K]>>
+} => {
+  const ks = keys(StringOrd)(a) as Array<keyof A>
+  const ops = {} as { [K in keyof A]: Option<NonNullable<A[K]>> }
+  for (const key of ks) {
+    ops[key] = fromNullable(a[key])
+  }
+  return ops
+}
+
+/**
+ * Split a heterogeneous struct of Either values into a failing
+ * struct of its `lefts` and a struct of its `rights`.
+ *
+ * @example
+ * import { separateS } from 'fp-ts/struct'
+ * import * as E from 'fp-ts/Either'
+ * import { separated } from 'fp-ts/Separated'
+ *
+ * assert.deepStrictEqual(
+ *   separateS({ foo: E.right(123), bar: E.left('fail'), baz: E.right('abc') }),
+ *   separated({ bar: 'fail' }, { foo: 123, baz: 'abc' })
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const separateS = <R extends ReadonlyRecord<string, Either<unknown, unknown>>>(r: R) => {
+  const left = {} as { [K in keyof R]?: R[K] extends Either<infer E, unknown> ? E : never }
+  const right = {} as { [K in keyof R]?: R[K] extends Either<unknown, infer A> ? A : never }
+  for (const k in r) {
+    if (_.hasOwnProperty.call(r, k)) {
+      const e: Either<unknown, unknown> = r[k]
+      if (isLeft(e)) {
+        left[k] = e.left as any
+      } else {
+        right[k] = e.right as any
+      }
+    }
+  }
+  return separated(left, right)
+}
+
+/**
+ * Runs an separate action for each value in a struct, and accumulates the results.
+ *
+ * A pipeable version of `traverseS_`
+ *
+ * @example
+ * import { pipe } from 'fp-ts/function'
+ * import { traverseS } from 'fp-ts/struct'
+ * import { Ord } from 'fp-ts/string'
+ * import * as O from 'fp-ts/Option'
+ *
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     { a: 1, b: 'b' },
+ *     traverseS(Ord)(O.Apply)({
+ *       a: (n) => n <= 2 ? O.some(n.toString()) : O.none,
+ *       b: (b) => b.length <= 2 ? O.some(b.length) : O.none
+ *     })
+ *   ),
+ *   O.some({ a: '1', b: 1 })
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export function traverseS(
+  O: Ord<string>
+): {
+  <F extends URIS4>(F: Apply4<F>): <
+    S,
+    R,
+    E,
+    A,
+    B extends { [key in keyof A]: (val: A[key]) => Kind4<F, S, R, E, unknown> }
+  >(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => Kind4<
+    F,
+    S,
+    R,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind4<F, S, R, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS3>(F: Apply3<F>): <R, E, A, B extends { [key in keyof A]: (val: A[key]) => Kind3<F, R, E, unknown> }>(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => Kind3<
+    F,
+    R,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind3<F, R, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS3, E>(F: Apply3C<F, E>): <
+    R,
+    A,
+    B extends { [key in keyof A]: (val: A[key]) => Kind3<F, R, E, unknown> }
+  >(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => Kind3<
+    F,
+    R,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind3<F, R, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS2>(F: Apply2<F>): <E, A, B extends { [key in keyof A]: (val: A[key]) => Kind2<F, E, unknown> }>(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => Kind2<
+    F,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind2<F, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS2, E>(F: Apply2C<F, E>): <A, B extends { [key in keyof A]: (val: A[key]) => Kind2<F, E, unknown> }>(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => Kind2<
+    F,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind2<F, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS>(F: Apply1<F>): <A, B extends { [key in keyof A]: (val: A[key]) => Kind<F, unknown> }>(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => Kind<
+    F,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind<F, infer C> ? C : never
+    }
+  >
+  <F>(F: Apply<F>): <A, B extends { [key in keyof A]: (val: A[key]) => HKT<F, unknown> }>(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => HKT<
+    F,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends HKT<F, infer C> ? C : never
+    }
+  >
+}
+export function traverseS(
+  O: Ord<string>
+): <F>(
+  F: Apply<F>
+) => <A extends ReadonlyRecord<string, unknown>, B extends { [key in keyof A]: (val: A[key]) => HKT<F, unknown> }>(
+  f: B
+) => (
+  ta: NonEmpty<A>
+) => HKT<
+  F,
+  {
+    [key in keyof B]: ReturnType<B[key]> extends HKT<F, infer C> ? C : never
+  }
+> {
+  return <F>(F: Apply<F>) => <A, B extends { [key in keyof A]: (val: A[key]) => HKT<F, unknown> }>(f: B) => (
+    ta: NonEmpty<A>
+  ) => {
+    const ks = keys(O)(ta) as Array<keyof A>
+    const length = ks.length
+    let fr = F.map(f[ks[0]](ta[ks[0]] as any), (r) => ({ [ks[0]]: r })) as HKT<
+      F,
+      {
+        [key in keyof B]: ReturnType<B[key]> extends HKT<F, infer C> ? C : never
+      }
+    >
+    for (let i = 1; i < length; i++) {
+      fr = F.ap(
+        F.map(fr, (r) => (b: any) => {
+          r[ks[i]] = b
+          return r
+        }),
+        f[ks[i]](ta[ks[i]] as any)
+      )
+    }
+    return fr as any
+  }
+}
+
+/**
+ * Runs an separate action for each value in a struct, and accumulates the results.
+ *
+ * A non-pipeable version of `traverseS`
+ *
+ * @example
+ * import { traverseS_ } from 'fp-ts/struct'
+ * import { Ord } from 'fp-ts/string'
+ * import * as O from 'fp-ts/Option'
+ *
+ * const f = {
+ *   a: (n: number) => n <= 2 ? O.some(n.toString()) : O.none,
+ *   b: (b: string) => b.length <= 2 ? O.some(b.length) : O.none
+ * }
+ *
+ * assert.deepStrictEqual(
+ *   traverseS_(Ord)(O.Apply)({a: 1, b: 'b' }, f),
+ *   O.some({ a: '1', b: 1 })
+ * )
+ * assert.deepStrictEqual(
+ *   traverseS_(Ord)(O.Apply)({ a: 3, b: '2' }, f),
+ *   O.none
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export function traverseS_(
+  O: Ord<string>
+): {
+  <F extends URIS4>(F: Apply4<F>): <
+    S,
+    R,
+    E,
+    B extends ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => Kind4<
+    F,
+    S,
+    R,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind4<F, S, R, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS3>(F: Apply3<F>): <
+    R,
+    E,
+    B extends ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => Kind3<
+    F,
+    R,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind3<F, R, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS3, E>(F: Apply3C<F, E>): <
+    R,
+    B extends ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => Kind3<
+    F,
+    R,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind3<F, R, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS2>(F: Apply2<F>): <
+    E,
+    B extends ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => Kind2<
+    F,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind2<F, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS2, E>(F: Apply2C<F, E>): <
+    B extends ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => Kind2<
+    F,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind2<F, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS>(F: Apply1<F>): <
+    B extends ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => Kind<
+    F,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind<F, infer C> ? C : never
+    }
+  >
+  <F>(F: Apply<F>): <
+    B extends ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => HKT<
+    F,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends HKT<F, infer C> ? C : never
+    }
+  >
+}
+export function traverseS_(
+  O: Ord<string>
+): <F>(
+  F: Apply<F>
+) => <B extends ReadonlyRecord<string, (v: never) => unknown>, A extends { [K in keyof B]: Parameters<B[K]>[0] }>(
+  fa: NonEmpty<A>,
+  f: B
+) => HKT<
+  F,
+  {
+    [key in keyof B]: ReturnType<B[key]> extends HKT<F, infer C> ? C : never
+  }
+> {
+  return <F>(F: Apply<F>) => <
+    B extends ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    ta: NonEmpty<A>,
+    f: B
+  ) => traverseS(O)(F)(f as any)(ta as never) as any
+}
+
+/**
+ * Applies a traverseS and a filterMap as a single combined operation.
+ *
+ * @example
+ * import { pipe } from 'fp-ts/function'
+ * import { witherS } from 'fp-ts/struct'
+ * import * as Tr from 'fp-ts/Tree'
+ * import * as O from 'fp-ts/Option'
+ * import * as S from 'fp-ts/string'
+ *
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     { a: 2, b: 'a' },
+ *     witherS(S.Ord)(Tr.Apply)({
+ *       a: (n) => Tr.of(n === 1 ? O.some(n.toString()) : O.none),
+ *       b: (n) => Tr.of(n === 'a' ? O.some(n.length) : O.none)
+ *     })
+ *   ),
+ *   Tr.of({ b: 1 })
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const witherS = (
+  O: Ord<string>
+): {
+  <F extends URIS3>(F: Apply3<F>): <
+    R,
+    E,
+    A,
+    B extends { [K in keyof A]: (val: A[K]) => Kind3<F, R, E, Option<unknown>> }
+  >(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind3<
+    F,
+    R,
+    E,
+    {
+      [K in keyof A]?: ReturnType<B[K]> extends Kind3<F, R, E, Option<infer C>> ? C : never
+    }
+  >
+  <F extends URIS3, E>(F: Apply3C<F, E>): <
+    R,
+    A,
+    B extends { [K in keyof A]: (val: A[K]) => Kind3<F, R, E, Option<unknown>> }
+  >(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind3<
+    F,
+    R,
+    E,
+    {
+      [K in keyof A]?: ReturnType<B[K]> extends Kind3<F, R, E, Option<infer C>> ? C : never
+    }
+  >
+  <F extends URIS2, E>(F: Apply2<F>): <E, A, B extends { [K in keyof A]: (val: A[K]) => Kind2<F, E, Option<unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind2<
+    F,
+    E,
+    {
+      [K in keyof A]?: ReturnType<B[K]> extends Kind2<F, E, Option<infer C>> ? C : never
+    }
+  >
+  <F extends URIS2, E>(F: Apply2C<F, E>): <
+    A,
+    B extends { [K in keyof A]: (val: A[K]) => Kind2<F, E, Option<unknown>> }
+  >(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind2<
+    F,
+    E,
+    {
+      [K in keyof A]?: ReturnType<B[K]> extends Kind2<F, E, Option<infer C>> ? C : never
+    }
+  >
+  <F extends URIS>(F: Apply1<F>): <A, B extends { [K in keyof A]: (val: A[K]) => Kind<F, Option<unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind<
+    F,
+    {
+      [K in keyof A]?: ReturnType<B[K]> extends Kind<F, Option<infer C>> ? C : never
+    }
+  >
+  <F>(F: Apply<F>): <A, B extends { [K in keyof A]: (val: A[K]) => HKT<F, Option<unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => HKT<
+    F,
+    {
+      [K in keyof A]?: ReturnType<B[K]> extends HKT<F, Option<infer C>> ? C : never
+    }
+  >
+} => <F>(F: Apply<F>) => <A>(f: any) => (fa: NonEmpty<A>) => F.map(pipe(fa, traverseS(O)(F)(f)), compactS as any) as any
+
+/**
+ * Applies a `traverseS` and a `partitionMap` as a single combined operation.
+ *
+ * @example
+ * import { pipe } from 'fp-ts/function'
+ * import { wiltS } from 'fp-ts/struct'
+ * import * as Tr from 'fp-ts/Tree'
+ * import * as E from 'fp-ts/Either'
+ * import { separated } from 'fp-ts/Separated'
+ * import * as S from 'fp-ts/string'
+ *
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     { a: 2, b: 'a' },
+ *     wiltS(S.Ord)(Tr.Apply)({
+ *       a: (n) => Tr.of(n === 1 ? E.right(n.toString()) : E.left(n - 1)),
+ *       b: (n) => Tr.of(n === 'a' ? E.right(n.length) : E.left('fail'))
+ *     })
+ *   ),
+ *   Tr.of(separated({ a: 1 }, { b: 1 }))
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const wiltS = (
+  O: Ord<string>
+): {
+  <F extends URIS3>(F: Apply3<F>): <
+    R,
+    E,
+    A,
+    B extends { [K in keyof A]: (val: A[K]) => Kind3<F, R, E, Either<unknown, unknown>> }
+  >(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind3<
+    F,
+    R,
+    E,
+    Separated<
+      { [K in keyof A]?: ReturnType<B[K]> extends Kind3<F, R, E, Either<infer L, unknown>> ? L : never },
+      { [K in keyof A]?: ReturnType<B[K]> extends Kind3<F, R, E, Either<unknown, infer R>> ? R : never }
+    >
+  >
+  <F extends URIS3, E>(F: Apply3C<F, E>): <
+    R,
+    A,
+    B extends { [K in keyof A]: (val: A[K]) => Kind3<F, R, E, Either<unknown, unknown>> }
+  >(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind3<
+    F,
+    R,
+    E,
+    Separated<
+      { [K in keyof A]?: ReturnType<B[K]> extends Kind3<F, R, E, Either<infer L, unknown>> ? L : never },
+      { [K in keyof A]?: ReturnType<B[K]> extends Kind3<F, R, E, Either<unknown, infer R>> ? R : never }
+    >
+  >
+  <F extends URIS2>(F: Apply2<F>): <
+    E,
+    A,
+    B extends { [K in keyof A]: (val: A[K]) => Kind2<F, E, Either<unknown, unknown>> }
+  >(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind2<
+    F,
+    E,
+    Separated<
+      { [K in keyof A]?: ReturnType<B[K]> extends Kind2<F, E, Either<infer L, unknown>> ? L : never },
+      { [K in keyof A]?: ReturnType<B[K]> extends Kind2<F, E, Either<unknown, infer R>> ? R : never }
+    >
+  >
+  <F extends URIS2, E>(F: Apply2C<F, E>): <
+    A,
+    B extends { [K in keyof A]: (val: A[K]) => Kind2<F, E, Either<unknown, unknown>> }
+  >(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind2<
+    F,
+    E,
+    Separated<
+      { [K in keyof A]?: ReturnType<B[K]> extends Kind2<F, E, Either<infer L, unknown>> ? L : never },
+      { [K in keyof A]?: ReturnType<B[K]> extends Kind2<F, E, Either<unknown, infer R>> ? R : never }
+    >
+  >
+  <F extends URIS>(F: Apply1<F>): <A, B extends { [K in keyof A]: (val: A[K]) => Kind<F, Either<unknown, unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind<
+    F,
+    Separated<
+      { [K in keyof A]?: ReturnType<B[K]> extends Kind<F, Either<infer L, unknown>> ? L : never },
+      { [K in keyof A]?: ReturnType<B[K]> extends Kind<F, Either<unknown, infer R>> ? R : never }
+    >
+  >
+  <F>(F: Apply<F>): <A, B extends { [K in keyof A]: (val: A[K]) => HKT<F, Either<unknown, unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => HKT<
+    F,
+    Separated<
+      { [K in keyof A]?: ReturnType<B[K]> extends HKT<F, Either<infer L, unknown>> ? L : never },
+      { [K in keyof A]?: ReturnType<B[K]> extends HKT<F, Either<unknown, infer R>> ? R : never }
+    >
+  >
+} => <F>(F: Apply<F>) => <A>(f: any) => (fa: NonEmpty<A>) =>
+  F.map(pipe(fa, traverseS(O)(F)(f)), separateS as any) as any
 
 // -------------------------------------------------------------------------------------
 // instances
 // -------------------------------------------------------------------------------------
+
+/**
+ * @category instances
+ * @since 2.10.0
+ */
+export const getShow = <A>(shows: { [K in keyof A]: Show<A[K]> }): Show<{ readonly [K in keyof A]: A[K] }> => ({
+  show: (a) => {
+    let s = '{'
+    for (const k in shows) {
+      if (_.hasOwnProperty.call(shows, k)) {
+        s += ` ${k}: ${shows[k].show(a[k])},`
+      }
+    }
+    if (s.length > 1) {
+      s = s.slice(0, -1) + ' '
+    }
+    s += '}'
+    return s
+  }
+})
+
+/**
+ * @category instances
+ * @since 2.10.0
+ */
+export const getEq = <A>(eqs: { [K in keyof A]: Eq<A[K]> }): Eq<{ readonly [K in keyof A]: A[K] }> =>
+  fromEquals((first, second) => {
+    for (const key in eqs) {
+      if (!eqs[key].equals(first[key], second[key])) {
+        return false
+      }
+    }
+    return true
+  })
+
+/**
+ * Given a struct of semigroups returns a semigroup for the struct.
+ *
+ * @example
+ * import { getSemigroup } from 'fp-ts/struct'
+ * import * as N from 'fp-ts/number'
+ *
+ * interface Point {
+ *   readonly x: number
+ *   readonly y: number
+ * }
+ *
+ * const S = getSemigroup<Point>({
+ *   x: N.SemigroupSum,
+ *   y: N.SemigroupSum
+ * })
+ *
+ * assert.deepStrictEqual(S.concat({ x: 1, y: 2 }, { x: 3, y: 4 }), { x: 4, y: 6 })
+ *
+ * @category instances
+ * @since 2.10.0
+ */
+export const getSemigroup = <A>(
+  semigroups: { [K in keyof A]: Semigroup<A[K]> }
+): Semigroup<{ readonly [K in keyof A]: A[K] }> => ({
+  concat: (first, second) => {
+    const r: A = {} as any
+    for (const k in semigroups) {
+      if (_.hasOwnProperty.call(semigroups, k)) {
+        r[k] = semigroups[k].concat(first[k], second[k])
+      }
+    }
+    return r
+  }
+})
 
 /**
  * Return a semigroup which works like `Object.assign`.
@@ -26,3 +1056,38 @@ import { getObjectSemigroup, Semigroup } from './Semigroup'
  */
 // tslint:disable-next-line: deprecation
 export const getAssignSemigroup: <A extends object = never>() => Semigroup<A> = getObjectSemigroup
+
+/**
+ * Given a struct of monoids returns a monoid for the struct.
+ *
+ * @example
+ * import { getMonoid } from 'fp-ts/struct'
+ * import * as N from 'fp-ts/number'
+ *
+ * interface Point {
+ *   readonly x: number
+ *   readonly y: number
+ * }
+ *
+ * const M = getMonoid<Point>({
+ *   x: N.MonoidSum,
+ *   y: N.MonoidSum
+ * })
+ *
+ * assert.deepStrictEqual(M.concat({ x: 1, y: 2 }, { x: 3, y: 4 }), { x: 4, y: 6 })
+ *
+ * @category instances
+ * @since 2.10.0
+ */
+export const getMonoid = <A>(monoids: { [K in keyof A]: Monoid<A[K]> }): Monoid<{ readonly [K in keyof A]: A[K] }> => {
+  const empty: A = {} as any
+  for (const k in monoids) {
+    if (_.hasOwnProperty.call(monoids, k)) {
+      empty[k] = monoids[k].empty
+    }
+  }
+  return {
+    concat: getSemigroup(monoids).concat,
+    empty
+  }
+}

--- a/test/Eq.ts
+++ b/test/Eq.ts
@@ -50,8 +50,9 @@ describe('Eq', () => {
     U.deepStrictEqual(nbCall, 1)
   })
 
-  it('struct', () => {
-    const E = _.struct<Person>({
+  it('getStructEq', () => {
+    // tslint:disable-next-line: deprecation
+    const E = _.getStructEq<Person>({
       name: S.Eq,
       age: N.Eq
     })

--- a/test/Map.ts
+++ b/test/Map.ts
@@ -8,7 +8,8 @@ import * as O from '../src/Option'
 import * as Ord from '../src/Ord'
 import * as RA from '../src/ReadonlyArray'
 import * as Se from '../src/Semigroup'
-import { struct, Show } from '../src/Show'
+import * as St from '../src/struct'
+import { Show } from '../src/Show'
 import * as S from '../src/string'
 import * as T from '../src/Task'
 import * as assert from 'assert'
@@ -41,7 +42,7 @@ const ordKey = Ord.fromCompare<Key>((x, y) => N.Ord.compare(x.id % 3, y.id % 3))
 
 const eqValue: Eq<Value> = fromEquals((x, y) => x.value % 3 === y.value % 3)
 
-const semigroupValue = Se.struct({ value: N.SemigroupSum })
+const semigroupValue = St.getSemigroup({ value: N.SemigroupSum })
 
 const key1 = { id: 1 }
 const value1 = { value: 1 }
@@ -1030,7 +1031,7 @@ describe('Map', () => {
   })
 
   it('getShow', () => {
-    const showUser: Show<User> = struct({ id: S.Show })
+    const showUser: Show<User> = St.getShow({ id: S.Show })
     const Sh = _.getShow(showUser, S.Show)
     const m1 = new Map<User, string>([])
     U.deepStrictEqual(Sh.show(m1), `new Map([])`)

--- a/test/Monoid.ts
+++ b/test/Monoid.ts
@@ -45,10 +45,14 @@ describe('Monoid', () => {
     U.deepStrictEqual(M.concat(M.empty, 'a'), 'a')
   })
 
-  it('struct', () => {
+  it('getStructMonoid', () => {
+    // tslint:disable-next-line: deprecation
+    U.deepStrictEqual(_.getStructMonoid({ a: S.Monoid }).empty, { a: '' })
+
     // should ignore non own properties
-    const monoids = Object.create({ a: 1 })
-    const s = _.struct(monoids)
+    const monoids1 = Object.create({ a: 1 })
+    // tslint:disable-next-line: deprecation
+    const s = _.getStructMonoid(monoids1)
     U.deepStrictEqual(s.empty, {})
   })
 })

--- a/test/ReadonlyMap.ts
+++ b/test/ReadonlyMap.ts
@@ -9,8 +9,9 @@ import * as Ord from '../src/Ord'
 import * as RA from '../src/ReadonlyArray'
 import * as _ from '../src/ReadonlyMap'
 import * as Se from '../src/Semigroup'
+import * as St from '../src/struct'
 import { separated } from '../src/Separated'
-import { struct, Show } from '../src/Show'
+import { Show } from '../src/Show'
 import * as S from '../src/string'
 import * as T from '../src/Task'
 import * as U from './util'
@@ -42,7 +43,7 @@ const ordKey = Ord.fromCompare<Key>((x, y) => N.Ord.compare(x.id % 3, y.id % 3))
 
 const eqValue: Eq<Value> = fromEquals((x, y) => x.value % 3 === y.value % 3)
 
-const semigroupValue = Se.struct({ value: N.SemigroupSum })
+const semigroupValue = St.getSemigroup({ value: N.SemigroupSum })
 
 const key1 = { id: 1 }
 const value1 = { value: 1 }
@@ -1074,7 +1075,7 @@ describe('ReadonlyMap', () => {
   })
 
   it('getShow', () => {
-    const showUser: Show<User> = struct({ id: S.Show })
+    const showUser: Show<User> = St.getShow({ id: S.Show })
     const Sh = _.getShow(showUser, S.Show)
     const m1 = new Map<User, string>([])
     U.deepStrictEqual(Sh.show(m1), `new Map([])`)

--- a/test/ReadonlySet.ts
+++ b/test/ReadonlySet.ts
@@ -4,6 +4,7 @@ import { left, right } from '../src/Either'
 import * as Eq from '../src/Eq'
 import { pipe } from '../src/function'
 import { none, some as optionSome } from '../src/Option'
+import { getEq } from '../src/struct'
 import * as _ from '../src/ReadonlySet'
 import * as S from '../src/string'
 import * as N from '../src/number'
@@ -113,8 +114,8 @@ describe('ReadonlySet', () => {
       _.partitionMap(N.Eq, S.Eq)((n: number) => (n % 2 === 0 ? left(n) : right(`${n}`)))(new Set([1, 2, 3])),
       separated(new Set([2]), new Set(['1', '3']))
     )
-    const SL = Eq.struct({ value: N.Eq })
-    const SR = Eq.struct({ value: S.Eq })
+    const SL = getEq({ value: N.Eq })
+    const SR = getEq({ value: S.Eq })
     U.deepStrictEqual(
       _.partitionMap(
         SL,

--- a/test/Semigroup.ts
+++ b/test/Semigroup.ts
@@ -50,9 +50,13 @@ describe('Semigroup', () => {
     U.strictEqual(IS.concat(IS.concat('a', 'b'), 'c'), IS.concat('a', IS.concat('b', 'c')))
   })
 
-  it('struct', () => {
+  it('getStructSemigroup', () => {
+    // tslint:disable-next-line: deprecation
+    U.deepStrictEqual(_.getStructSemigroup({ a: S.Semigroup }).concat({ a: 'a' }, { a: 'b' }), { a: 'ab' })
+
     // should ignore non own properties
-    const S = _.struct(Object.create({ a: 1 }))
-    U.deepStrictEqual(S.concat({}, {}), {})
+    // tslint:disable-next-line: deprecation
+    const s = _.getStructSemigroup(Object.create({ a: 1 }))
+    U.deepStrictEqual(s.concat({}, {}), {})
   })
 })

--- a/test/Set.ts
+++ b/test/Set.ts
@@ -4,6 +4,7 @@ import { left, right } from '../src/Either'
 import * as Eq from '../src/Eq'
 import { pipe } from '../src/function'
 import { none, some as optionSome } from '../src/Option'
+import { getEq } from '../src/struct'
 import * as _ from '../src/Set'
 import * as S from '../src/string'
 import * as N from '../src/number'
@@ -109,8 +110,8 @@ describe('Set', () => {
       _.partitionMap(N.Eq, S.Eq)((n: number) => (n % 2 === 0 ? left(n) : right(`${n}`)))(new Set([1, 2, 3])),
       separated(new Set([2]), new Set(['1', '3']))
     )
-    const SL = Eq.struct({ value: N.Eq })
-    const SR = Eq.struct({ value: S.Eq })
+    const SL = getEq({ value: N.Eq })
+    const SR = getEq({ value: S.Eq })
     U.deepStrictEqual(
       _.partitionMap(
         SL,

--- a/test/Show.ts
+++ b/test/Show.ts
@@ -4,12 +4,15 @@ import * as _ from '../src/Show'
 import * as S from '../src/string'
 
 describe('Show', () => {
-  it('struct', () => {
-    U.deepStrictEqual(_.struct({ a: S.Show }).show({ a: 'a' }), '{ a: "a" }')
-    U.deepStrictEqual(_.struct({ a: S.Show, b: N.Show }).show({ a: 'a', b: 1 }), '{ a: "a", b: 1 }')
+  it('getStructShow', () => {
+    // tslint:disable-next-line: deprecation
+    U.deepStrictEqual(_.getStructShow({ a: S.Show }).show({ a: 'a' }), '{ a: "a" }')
+    // tslint:disable-next-line: deprecation
+    U.deepStrictEqual(_.getStructShow({ a: S.Show, b: N.Show }).show({ a: 'a', b: 1 }), '{ a: "a", b: 1 }')
     // should ignore non own properties
     const shows = Object.create({ a: 1 })
-    const s = _.struct(shows)
+    // tslint:disable-next-line: deprecation
+    const s = _.getStructShow(shows)
     U.deepStrictEqual(s.show({}), '{}')
   })
 

--- a/test/Traced.ts
+++ b/test/Traced.ts
@@ -1,7 +1,8 @@
 import * as U from './util'
 import * as B from '../src/boolean'
 import { pipe } from '../src/function'
-import { struct, Monoid } from '../src/Monoid'
+import { getMonoid } from '../src/struct'
+import { Monoid } from '../src/Monoid'
 import * as _ from '../src/Traced'
 
 // Adapted from https://chshersh.github.io/posts/2019-03-25-comonadic-builders
@@ -12,7 +13,7 @@ interface Settings {
   readonly settingsTravis: boolean
 }
 
-const M: Monoid<Settings> = struct({
+const M: Monoid<Settings> = getMonoid({
   settingsHasLibrary: B.MonoidAny,
   settingsGitHub: B.MonoidAny,
   settingsTravis: B.MonoidAny

--- a/test/struct.ts
+++ b/test/struct.ts
@@ -1,20 +1,284 @@
+import * as E from '../src/Either'
+import { identity, pipe } from '../src/function'
+import * as O from '../src/Option'
 import * as _ from '../src/struct'
+import { separated } from '../src/Separated'
+import * as S from '../src/string'
+import * as T from '../src/Task'
 import * as U from './util'
+import { Eq as NumberEq, Show as NumberShow } from '../src/number'
+import { reverse } from '../src/Ord'
+
+const sp = (s: string): s is 'a' => s === 'a'
+const np = (n: number): n is 1 => n === 1
+
+const noPrototype = Object.create(null)
 
 describe('struct', () => {
-  it('getAssignSemigroup', () => {
-    type T = {
-      readonly foo?: number
-      readonly bar: string
-    }
-    const foo: T = {
-      foo: 123,
-      bar: '456'
-    }
-    const bar: T = {
-      bar: '123'
-    }
-    const S = _.getAssignSemigroup<T>()
-    U.deepStrictEqual(S.concat(foo, bar), Object.assign({}, foo, bar))
+  describe('pipeables', () => {
+    it('mapS', () => {
+      U.deepStrictEqual(pipe({ a: 'a', b: 1 }, _.mapS({ a: (a) => a.length, b: (b) => b * 2 })), { a: 1, b: 2 })
+
+      // should ignore non own properties
+      const x: Record<'b', number> = Object.create({ a: 1 })
+      x.b = 1
+      U.deepStrictEqual(pipe(x, _.mapS({ b: (b) => b > 0 })), { b: true })
+    })
+
+    it('reduceS', () => {
+      U.deepStrictEqual(
+        pipe(
+          { a: 'a', b: 1 },
+          _.reduceS(S.Ord)('', {
+            a: (acc, cur) => acc + cur,
+            b: (acc, cur) => acc + cur.toString()
+          })
+        ),
+        'a1'
+      )
+      U.deepStrictEqual(
+        pipe(
+          { b: 1, a: 'a' },
+          _.reduceS(S.Ord)('', {
+            a: (acc, cur) => acc + cur,
+            b: (acc, cur) => acc + cur.toString()
+          })
+        ),
+        'a1'
+      )
+      U.deepStrictEqual(
+        pipe(
+          { a: 'a', b: 1 },
+          _.reduceS(reverse(S.Ord))('', {
+            a: (acc, cur) => acc + cur,
+            b: (acc, cur) => acc + cur.toString()
+          })
+        ),
+        '1a'
+      )
+    })
+
+    it('foldMapS', () => {
+      U.deepStrictEqual(
+        pipe({ a: 'a', b: 1 }, _.foldMapS(S.Ord)(S.Monoid)({ a: identity, b: (b) => b.toString() })),
+        'a1'
+      )
+    })
+
+    it('filterS', () => {
+      const d = { a: 'a', b: 1 }
+      U.deepStrictEqual(pipe(d, _.filterS({ a: (a) => a === 'b', b: (b) => b === 1 })), { b: 1 })
+      U.deepStrictEqual(pipe({ a: 1, b: 'foo' }, _.filterS({ a: np, b: sp })), { a: 1 })
+
+      const pass = { a: 1, b: 'a' } as const
+      U.deepStrictEqual(pipe(pass, _.filterS({ a: np, b: sp })), pass)
+
+      const x: { readonly a: 1; readonly b: 'foo' } = Object.assign(Object.create({ c: true }), { a: 1, b: 'foo' })
+      U.deepStrictEqual(pipe(x, _.filterS({ a: np, b: sp })), { a: 1 })
+      U.deepStrictEqual(pipe(noPrototype, _.filterS({})), noPrototype)
+    })
+
+    it('filterMapS', () => {
+      U.deepStrictEqual(
+        pipe(
+          { a: 'a', b: 1 },
+          _.filterMapS({
+            a: () => O.none,
+            b: (n) => (np(n) ? O.some(n + 1) : O.none)
+          })
+        ),
+        { b: 2 }
+      )
+
+      const x: { readonly a: number; readonly b: string } = Object.assign(Object.create({ c: true }), {
+        a: 1,
+        b: 'foo'
+      })
+      U.deepStrictEqual(pipe(x, _.filterMapS({ a: O.fromPredicate(np), b: O.fromPredicate(sp) })), { a: 1 })
+    })
+
+    it('partitionS', () => {
+      U.deepStrictEqual(
+        pipe({ a: 'b', b: 1 }, _.partitionS({ a: sp, b: np })),
+        separated({ a: 'b' }, { b: 1 } as const)
+      )
+
+      const x: { readonly a: number; readonly b: string } = Object.assign(Object.create({ c: true }), {
+        a: 1,
+        b: 'foo'
+      })
+      U.deepStrictEqual(pipe(x, _.partitionS({ a: np, b: sp })), separated({ b: 'foo' }, { a: 1 } as const))
+      U.deepStrictEqual(pipe(noPrototype, _.partitionS({})), separated({}, {}))
+    })
+
+    it('partitionMapS', () => {
+      const f = (n: number) => (np(n) ? E.right(n + 1) : E.left(n - 1))
+      U.deepStrictEqual(
+        pipe(
+          { a: 'a', b: 1 },
+          _.partitionMapS({
+            a: () => E.left('fail'),
+            b: f
+          })
+        ),
+        separated({ a: 'fail' }, { b: 2 })
+      )
+
+      const x: { readonly a: number; readonly b: string } = Object.assign(Object.create({ c: true }), {
+        a: 1,
+        b: 'foo'
+      })
+      U.deepStrictEqual(
+        pipe(x, _.partitionMapS({ a: E.fromPredicate(np, () => 'fail'), b: E.fromPredicate(sp, () => 'fail') })),
+        separated({ b: 'fail' }, { a: 1 } as const)
+      )
+      U.deepStrictEqual(pipe(noPrototype, _.partitionMapS({})), separated({}, {}))
+    })
+
+    it('compactS', () => {
+      U.deepStrictEqual(
+        _.compactS({
+          foo: O.some(123),
+          bar: O.none,
+          baz: O.some('abc')
+        }),
+        { foo: 123, baz: 'abc' }
+      )
+      // should ignore non own properties
+      const o: { readonly b: O.Option<number> } = Object.create({ a: 1 })
+      U.deepStrictEqual(pipe(o, _.compactS), {})
+    })
+
+    it('unCompactS', () => {
+      U.deepStrictEqual(_.unCompact({ foo: 123, bar: undefined, baz: 'abc' }), {
+        foo: O.some(123),
+        bar: O.none,
+        baz: O.some('abc')
+      })
+    })
+
+    it('separateS', () => {
+      U.deepStrictEqual(
+        _.separateS({ foo: E.right(123), bar: E.left('fail'), baz: E.right('abc') }),
+        separated({ bar: 'fail' }, { foo: 123, baz: 'abc' })
+      )
+      // should ignore non own properties
+      const o: { readonly b: E.Either<string, number> } = Object.create({ a: 1 })
+      U.deepStrictEqual(pipe(o, _.separateS), separated({}, {}))
+    })
+
+    it('traverseS', () => {
+      U.deepStrictEqual(
+        pipe(
+          { a: 1, b: 'b' },
+          _.traverseS(S.Ord)(O.Apply)({
+            a: (n) => (n <= 2 ? O.some(n.toString()) : O.none),
+            b: (b) => (b.length <= 2 ? O.some(b.length) : O.none)
+          })
+        ),
+        O.some({ a: '1', b: 1 })
+      )
+      U.deepStrictEqual(
+        pipe(
+          { a: 1, b: '2' },
+          _.traverseS(S.Ord)(O.Apply)({
+            a: (n) => (n >= 2 ? O.some(n.toString()) : O.none),
+            b: () => O.some(3)
+          })
+        ),
+        O.none
+      )
+    })
+
+    it('witherS', async () => {
+      U.deepStrictEqual(
+        await pipe(
+          { a: 2, b: 'a' },
+          _.witherS(S.Ord)(T.ApplyPar)({
+            a: (n) => T.of(np(n) ? O.some(n.toString()) : O.none),
+            b: (n) => T.of(sp(n) ? O.some(n.length) : O.none)
+          })
+        )(),
+        { b: 1 }
+      )
+    })
+
+    it('wiltS', async () => {
+      U.deepStrictEqual(
+        await pipe(
+          { a: 2, b: 'a' },
+          _.wiltS(S.Ord)(T.ApplyPar)({
+            a: (n) => T.of(np(n) ? E.right(n.toString()) : E.left(n - 1)),
+            b: (n) => T.of(sp(n) ? E.right(n.length) : E.left('fail'))
+          })
+        )(),
+        separated({ a: 1 }, { b: 1 })
+      )
+    })
+  })
+
+  describe('Non-pipeables', () => {
+    it('traverseS_', () => {
+      const f = {
+        a: (n: number) => (n <= 2 ? O.some(n.toString()) : O.none),
+        b: (b: string) => (b.length <= 2 ? O.some(b.length) : O.none)
+      }
+      U.deepStrictEqual(_.traverseS_(S.Ord)(O.Apply)({ a: 1, b: 'b' }, f), O.some({ a: '1', b: 1 }))
+      U.deepStrictEqual(_.traverseS_(S.Ord)(O.Apply)({ a: 3, b: '2' }, f), O.none)
+    })
+  })
+
+  describe('instances', () => {
+    it('getShow', () => {
+      U.deepStrictEqual(_.getShow({ a: S.Show }).show({ a: 'a' }), '{ a: "a" }')
+      U.deepStrictEqual(_.getShow({ a: S.Show, b: NumberShow }).show({ a: 'a', b: 1 }), '{ a: "a", b: 1 }')
+      // should ignore non own properties
+      const shows = Object.create({ a: 1 })
+      const s = _.getShow(shows)
+      U.deepStrictEqual(s.show({}), '{}')
+    })
+
+    it('getEq', () => {
+      interface Person {
+        readonly name: string
+        readonly age: number
+      }
+      const E = _.getEq<Person>({
+        name: S.Eq,
+        age: NumberEq
+      })
+      U.deepStrictEqual(E.equals({ name: 'a', age: 1 }, { name: 'a', age: 1 }), true)
+      U.deepStrictEqual(E.equals({ name: 'a', age: 1 }, { name: 'a', age: 2 }), false)
+      U.deepStrictEqual(E.equals({ name: 'a', age: 1 }, { name: 'b', age: 1 }), false)
+    })
+
+    it('getSemigroup', () => {
+      // should ignore non own properties
+      const S = _.getSemigroup(Object.create({ a: 1 }))
+      U.deepStrictEqual(S.concat({}, {}), {})
+    })
+
+    it('getAssignSemigroup', () => {
+      type T = {
+        readonly foo?: number
+        readonly bar: string
+      }
+      const foo: T = {
+        foo: 123,
+        bar: '456'
+      }
+      const bar: T = {
+        bar: '123'
+      }
+      const S = _.getAssignSemigroup<T>()
+      U.deepStrictEqual(S.concat(foo, bar), Object.assign({}, foo, bar))
+    })
+
+    it('getMonoid', () => {
+      // should ignore non own properties
+      const monoids = Object.create({ a: 1 })
+      const s = _.getMonoid(monoids)
+      U.deepStrictEqual(s.empty, {})
+    })
   })
 })


### PR DESCRIPTION
This PR adds a few functions to the `struct` module
 
Notes:
- `traverseS_` is an un-curried version of `traverseS` where the transformation struct can be defined separately. It's named after `Foldable.traverse_`, which looks a bit similar. We can remove this if desired, since `Foldable.traverse_` is deprecated in 3.0.0, but I thought it might be useful since `traverseS` won't work outside of `pipe`
- some functions accept an `Ord<string>` for handling keys, following the [convention in 3.0.0](https://github.com/gcanti/fp-ts/commit/3861138ef9ce6fed494191a42a3eea1884e9c52b#diff-2a28f9bcbc06ac11c7768967193244d8f9ca05a4e96225ca8449930aa26870b0)
- `sequenceS` is omitted, again [mirroring 3.0.0](https://github.com/gcanti/fp-ts/commit/0b76cec70d1b155363ca602138d19e08d4163911#diff-07b5152745a16434cfad0bfbf677f4f684c84a4bf2142f8f6c1895001484dc9a)
- `mapS` is [evolve](https://github.com/gcanti/fp-ts/blob/f1884ce7f064bc62002acbacd6bc51019934771e/src/struct.ts#L57) - I'm certainly willing to rename/move it, but to me `mapS` seems like it fits the conventions of this module
- `Show.struct`, `Eq.struct`, `Semigroup.struct` & `Monoid.struct` have all been relocated into `Struct` - I hope this is OK, since they're not in a release yet (only release candidates)
- Most importantly - `Struct` is not a HKT, so it doesn't necessarily fit the ethos of fp-ts. It's _almost_ a member of many typeclasses (Functor, Traversable, Witherable), but it doesn't fit any of the traditional function signatures. For this reason, it might not be a great fit. However, the idea of a `struct` already exists in the library - this module simply consolidates all its relevant functions and adds to them. I think a `Struct` module makes sense as part of fp-ts but I think it could be happy living elsewhere if that's best

Questions:
- Atm this PR is against `master`. Should it be against `3.0.0`? It requires at least Typescript version 3.6 which might be reason enough

Ideas:
- we could add [pick & omit](https://github.com/samhh/fp-ts-std/blob/e5f465778d984f6618d92b3ac419cae8e03551a7/src/Record.ts#L58) from `fp-ts-std`