### PR TITLE
Add object.prop function

### DIFF
--- a/docs/modules/struct.ts.md
+++ b/docs/modules/struct.ts.md
@@ -89,8 +89,11 @@ Accesses a property of an object
 **Signature**
 
 ```ts
-export declare function prop<Path extends string, Value, Rest>(path: Path, obj: Record<Path, Value> & Rest): Value
-export declare function prop<Path extends string, Value, Rest>(path: Path): (obj: Record<Path, Value> & Rest) => Value
+export declare const prop: <Path extends keyof A extends never ? string : keyof A, A>(
+  path: Path
+) => <B extends { [k in Path]: unknown }>(
+  obj: keyof A extends never ? B : A
+) => Path extends keyof A ? A[Path] : B[Path]
 ```
 
 **Example**

--- a/docs/modules/struct.ts.md
+++ b/docs/modules/struct.ts.md
@@ -89,7 +89,8 @@ Accesses a property of an object
 **Signature**
 
 ```ts
-export declare const prop: <Path extends string>(path: Path) => <Value, Rest>(obj: Record<Path, Value> & Rest) => Value
+export declare function prop<Path extends string, Value, Rest>(path: Path, obj: Record<Path, Value> & Rest): Value
+export declare function prop<Path extends string, Value, Rest>(path: Path): (obj: Record<Path, Value> & Rest) => Value
 ```
 
 **Example**

--- a/docs/modules/struct.ts.md
+++ b/docs/modules/struct.ts.md
@@ -16,6 +16,7 @@ Added in v2.10.0
   - [getAssignSemigroup](#getassignsemigroup)
 - [utils](#utils)
   - [evolve](#evolve)
+  - [prop](#prop)
 
 ---
 
@@ -77,6 +78,34 @@ assert.deepStrictEqual(
   ),
   { a: 1, b: 2 }
 )
+```
+
+Added in v2.11.0
+
+## prop
+
+Accesses a property of an object
+
+**Signature**
+
+```ts
+export declare const prop: <Path extends string>(path: Path) => <Value, Rest>(obj: Record<Path, Value> & Rest) => Value
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/function'
+import { prop } from 'fp-ts/struct'
+
+type Person = {
+  readonly name: string
+  readonly age: number
+}
+
+const person: Person = { name: 'Jane', age: 62 }
+assert.deepStrictEqual(prop('name')(person), 'Jane')
+assert.deepStrictEqual(pipe(person, prop('age')), 62)
 ```
 
 Added in v2.11.0

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -63,3 +63,24 @@ export const evolve = <A, F extends { [K in keyof A]: (a: A[K]) => unknown }>(tr
   }
   return out as any
 }
+
+/**
+ * Accesses a property of an object
+ *
+ * @example
+ * import { pipe } from 'fp-ts/function'
+ * import { prop } from 'fp-ts/struct'
+ *
+ * type Person = {
+ *   readonly name: string
+ *   readonly age: number
+ * }
+ *
+ * const person: Person = { name: 'Jane', age: 62 }
+ * assert.deepStrictEqual(prop('name')(person), 'Jane')
+ * assert.deepStrictEqual(pipe(person, prop('age')), 62)
+ *
+ * @since 2.11.0
+ */
+export const prop = <Path extends string>(path: Path) => <Value, Rest>(obj: Record<Path, Value> & Rest): Value =>
+  obj[path]

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -82,12 +82,8 @@ export const evolve = <A, F extends { [K in keyof A]: (a: A[K]) => unknown }>(tr
  *
  * @since 2.11.0
  */
-export function prop<Path extends string, Value, Rest>(path: Path, obj: Record<Path, Value> & Rest): Value
-export function prop<Path extends string, Value, Rest>(path: Path): (obj: Record<Path, Value> & Rest) => Value
-export function prop<Path extends string, Value, Rest>(path: Path, obj?: Record<Path, Value & Rest>) {
-  if (typeof obj === 'object') {
-    return obj[path]
-  }
-
-  return (obj: Record<Path, Value> & Rest) => obj[path]
-}
+export const prop = <Path extends keyof A extends never ? string : keyof A, A>(path: Path) => <
+  B extends { [k in Path]: unknown }
+>(
+  obj: keyof A extends never ? B : A
+) => (obj as B)[path] as Path extends keyof A ? A[Path] : B[Path]

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -82,5 +82,12 @@ export const evolve = <A, F extends { [K in keyof A]: (a: A[K]) => unknown }>(tr
  *
  * @since 2.11.0
  */
-export const prop = <Path extends string>(path: Path) => <Value, Rest>(obj: Record<Path, Value> & Rest): Value =>
-  obj[path]
+export function prop<Path extends string, Value, Rest>(path: Path, obj: Record<Path, Value> & Rest): Value
+export function prop<Path extends string, Value, Rest>(path: Path): (obj: Record<Path, Value> & Rest) => Value
+export function prop<Path extends string, Value, Rest>(path: Path, obj?: Record<Path, Value & Rest>) {
+  if (typeof obj === 'object') {
+    return obj[path]
+  }
+
+  return (obj: Record<Path, Value> & Rest) => obj[path]
+}

--- a/test/struct.ts
+++ b/test/struct.ts
@@ -36,4 +36,15 @@ describe('struct', () => {
     x.b = 1
     U.deepStrictEqual(pipe(x, _.evolve({ b: (b) => b > 0 })), { b: true })
   })
+
+  it('prop', () => {
+    interface Person {
+      readonly name: string
+      readonly age: number
+    }
+
+    const person: Person = { name: 'Jane', age: 62 }
+    U.deepStrictEqual(_.prop('name')(person), 'Jane')
+    U.deepStrictEqual(pipe(person, _.prop('age')), 62)
+  })
 })


### PR DESCRIPTION
New feature for `object` module:
- added `prop` function 

Reasoning: Small and handy utility function which is also something that many folks in the JS ecosystem are used to and learn when getting started with functional programming. Usually they use something like `get` from lodash or they see the `prop` function from the Mostly Adequate Guide to FP (https://mostly-adequate.gitbook.io/mostly-adequate-guide/appendix_c#prop).

**Question**: Do you prefer to add overloads so that we can have both curried/uncurried versions of this? (e.g. `prop('myKey', myObject)` or `prop('myKey')(myObject)`)