### PR TITLE
Backport ReadonlyRecord & Record

### DIFF
--- a/docs/modules/ReadonlyRecord.ts.md
+++ b/docs/modules/ReadonlyRecord.ts.md
@@ -43,18 +43,27 @@ Added in v2.5.0
   - [Compactable](#compactable-1)
   - [Filterable](#filterable-1)
   - [FilterableWithIndex](#filterablewithindex)
-  - [Foldable](#foldable-1)
-  - [FoldableWithIndex](#foldablewithindex)
   - [Functor](#functor)
   - [FunctorWithIndex](#functorwithindex)
-  - [Traversable](#traversable)
-  - [TraversableWithIndex](#traversablewithindex)
   - [URI](#uri)
   - [URI (type alias)](#uri-type-alias)
-  - [Witherable](#witherable-1)
+  - [getDifferenceMagma](#getdifferencemagma)
   - [getEq](#geteq)
+  - [getFoldable](#getfoldable)
+  - [getFoldableWithIndex](#getfoldablewithindex)
+  - [getIntersectionSemigroup](#getintersectionsemigroup)
   - [getMonoid](#getmonoid)
   - [getShow](#getshow)
+  - [getTraversable](#gettraversable)
+  - [getTraversableWithIndex](#gettraversablewithindex)
+  - [getUnionMonoid](#getunionmonoid)
+  - [getUnionSemigroup](#getunionsemigroup)
+  - [getWitherable](#getwitherable)
+  - [~~FoldableWithIndex~~](#foldablewithindex)
+  - [~~Foldable~~](#foldable)
+  - [~~TraversableWithIndex~~](#traversablewithindex)
+  - [~~Traversable~~](#traversable)
+  - [~~Witherable~~](#witherable)
   - [~~readonlyRecord~~](#readonlyrecord)
 - [interop](#interop)
   - [fromRecord](#fromrecord)
@@ -63,6 +72,7 @@ Added in v2.5.0
   - [ReadonlyRecord (type alias)](#readonlyrecord-type-alias)
 - [utils](#utils)
   - [collect](#collect)
+  - [difference](#difference)
   - [elem](#elem)
   - [empty](#empty)
   - [every](#every)
@@ -71,6 +81,7 @@ Added in v2.5.0
   - [fromFoldable](#fromfoldable)
   - [fromFoldableMap](#fromfoldablemap)
   - [has](#has)
+  - [intersection](#intersection)
   - [isEmpty](#isempty)
   - [isSubrecord](#issubrecord)
   - [keys](#keys)
@@ -87,6 +98,7 @@ Added in v2.5.0
   - [toReadonlyArray](#toreadonlyarray)
   - [traverse](#traverse)
   - [traverseWithIndex](#traversewithindex)
+  - [union](#union)
   - [updateAt](#updateat)
   - [~~hasOwnProperty (function)~~](#hasownproperty-function)
 
@@ -179,7 +191,10 @@ Added in v2.5.0
 **Signature**
 
 ```ts
-export declare const foldMap: <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => (fa: Readonly<Record<string, A>>) => M
+export declare function foldMap(
+  O: Ord<string>
+): <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => (fa: Readonly<Record<string, A>>) => M
+export declare function foldMap<M>(M: Monoid<M>): <A>(f: (a: A) => M) => (fa: Readonly<Record<string, A>>) => M
 ```
 
 Added in v2.5.0
@@ -189,7 +204,10 @@ Added in v2.5.0
 **Signature**
 
 ```ts
-export declare const reduce: <A, B>(b: B, f: (b: B, a: A) => B) => (fa: Readonly<Record<string, A>>) => B
+export declare function reduce(
+  O: Ord<string>
+): <A, B>(b: B, f: (b: B, a: A) => B) => (fa: Readonly<Record<string, A>>) => B
+export declare function reduce<A, B>(b: B, f: (b: B, a: A) => B): (fa: Readonly<Record<string, A>>) => B
 ```
 
 Added in v2.5.0
@@ -199,10 +217,13 @@ Added in v2.5.0
 **Signature**
 
 ```ts
-export declare const reduceRight: <A, B>(b: B, f: (a: A, b: B) => B) => (fa: Readonly<Record<string, A>>) => B
+export declare function reduceRight(
+  O: Ord<string>
+): <A, B>(b: B, f: (a: A, b: B) => B) => (fa: Readonly<Record<string, A>>) => B
+export declare function reduceRight<A, B>(b: B, f: (a: A, b: B) => B): (fa: Readonly<Record<string, A>>) => B
 ```
 
-Added in v2.5.0
+Added in v2.11.0
 
 # Witherable
 
@@ -381,26 +402,6 @@ export declare const FilterableWithIndex: FilterableWithIndex1<'ReadonlyRecord',
 
 Added in v2.7.0
 
-## Foldable
-
-**Signature**
-
-```ts
-export declare const Foldable: Foldable1<'ReadonlyRecord'>
-```
-
-Added in v2.7.0
-
-## FoldableWithIndex
-
-**Signature**
-
-```ts
-export declare const FoldableWithIndex: FoldableWithIndex1<'ReadonlyRecord', string>
-```
-
-Added in v2.7.0
-
 ## Functor
 
 **Signature**
@@ -417,26 +418,6 @@ Added in v2.7.0
 
 ```ts
 export declare const FunctorWithIndex: FunctorWithIndex1<'ReadonlyRecord', string>
-```
-
-Added in v2.7.0
-
-## Traversable
-
-**Signature**
-
-```ts
-export declare const Traversable: Traversable1<'ReadonlyRecord'>
-```
-
-Added in v2.7.0
-
-## TraversableWithIndex
-
-**Signature**
-
-```ts
-export declare const TraversableWithIndex: TraversableWithIndex1<'ReadonlyRecord', string>
 ```
 
 Added in v2.7.0
@@ -461,15 +442,15 @@ export type URI = typeof URI
 
 Added in v2.5.0
 
-## Witherable
+## getDifferenceMagma
 
 **Signature**
 
 ```ts
-export declare const Witherable: Witherable1<'ReadonlyRecord'>
+export declare const getDifferenceMagma: <A>() => Magma<Readonly<Record<string, A>>>
 ```
 
-Added in v2.7.0
+Added in v2.11.0
 
 ## getEq
 
@@ -480,6 +461,36 @@ export declare function getEq<K extends string, A>(E: Eq<A>): Eq<ReadonlyRecord<
 ```
 
 Added in v2.5.0
+
+## getFoldable
+
+**Signature**
+
+```ts
+export declare const getFoldable: (O: Ord<string>) => Foldable1<URI>
+```
+
+Added in v2.7.0
+
+## getFoldableWithIndex
+
+**Signature**
+
+```ts
+export declare const getFoldableWithIndex: (O: Ord<string>) => FoldableWithIndex1<URI, string>
+```
+
+Added in v2.11.0
+
+## getIntersectionSemigroup
+
+**Signature**
+
+```ts
+export declare const getIntersectionSemigroup: <A>(S: Semigroup<A>) => Semigroup<Readonly<Record<string, A>>>
+```
+
+Added in v2.11.0
 
 ## getMonoid
 
@@ -508,10 +519,121 @@ Added in v2.5.0
 **Signature**
 
 ```ts
+export declare function getShow(O: Ord<string>): <A>(S: Show<A>) => Show<ReadonlyRecord<string, A>>
 export declare function getShow<A>(S: Show<A>): Show<ReadonlyRecord<string, A>>
 ```
 
 Added in v2.5.0
+
+## getTraversable
+
+**Signature**
+
+```ts
+export declare const getTraversable: (O: Ord<string>) => Traversable1<URI>
+```
+
+Added in v2.11.0
+
+## getTraversableWithIndex
+
+**Signature**
+
+```ts
+export declare const getTraversableWithIndex: (O: Ord<string>) => TraversableWithIndex1<URI, string>
+```
+
+Added in v2.11.0
+
+## getUnionMonoid
+
+**Signature**
+
+```ts
+export declare const getUnionMonoid: <A>(S: Semigroup<A>) => Monoid<Readonly<Record<string, A>>>
+```
+
+Added in v2.11.0
+
+## getUnionSemigroup
+
+**Signature**
+
+```ts
+export declare const getUnionSemigroup: <A>(S: Semigroup<A>) => Semigroup<Readonly<Record<string, A>>>
+```
+
+Added in v2.11.0
+
+## getWitherable
+
+**Signature**
+
+```ts
+export declare const getWitherable: (O: Ord<string>) => Witherable1<URI>
+```
+
+Added in v2.11.0
+
+## ~~FoldableWithIndex~~
+
+Use `getFoldableWithIndex` instead
+
+**Signature**
+
+```ts
+export declare const FoldableWithIndex: FoldableWithIndex1<'ReadonlyRecord', string>
+```
+
+Added in v2.7.0
+
+## ~~Foldable~~
+
+Use `getFoldable` instead
+
+**Signature**
+
+```ts
+export declare const Foldable: Foldable1<'ReadonlyRecord'>
+```
+
+Added in v2.7.0
+
+## ~~TraversableWithIndex~~
+
+Use `getTraversableWithIndex` instead
+
+**Signature**
+
+```ts
+export declare const TraversableWithIndex: TraversableWithIndex1<'ReadonlyRecord', string>
+```
+
+Added in v2.7.0
+
+## ~~Traversable~~
+
+Use `getTraversable` instead
+
+**Signature**
+
+```ts
+export declare const Traversable: Traversable1<'ReadonlyRecord'>
+```
+
+Added in v2.7.0
+
+## ~~Witherable~~
+
+Use `getWitherable` instead
+
+**Signature**
+
+```ts
+export declare const Witherable: Witherable1<'ReadonlyRecord'>
+```
+
+Added in v2.7.0
 
 ## ~~readonlyRecord~~
 
@@ -572,24 +694,40 @@ Map a `ReadonlyRecord` into an `ReadonlyArray`.
 **Signature**
 
 ```ts
-export declare const collect: <K extends string, A, B>(
+export declare function collect(
+  O: Ord<string>
+): <K extends string, A, B>(f: (k: K, a: A) => B) => (r: ReadonlyRecord<K, A>) => ReadonlyArray<B>
+export declare function collect<K extends string, A, B>(
   f: (k: K, a: A) => B
-) => (r: Readonly<Record<K, A>>) => readonly B[]
+): (r: ReadonlyRecord<K, A>) => ReadonlyArray<B>
 ```
 
 **Example**
 
 ```ts
 import { collect } from 'fp-ts/ReadonlyRecord'
+import { Ord } from 'fp-ts/string'
 
 const x: { readonly a: string; readonly b: boolean } = { a: 'c', b: false }
-assert.deepStrictEqual(collect((key, val) => ({ key: key, value: val }))(x), [
+assert.deepStrictEqual(collect(Ord)((key, val) => ({ key: key, value: val }))(x), [
   { key: 'a', value: 'c' },
   { key: 'b', value: false },
 ])
 ```
 
-Added in v2.5.0
+Added in v2.11.0
+
+## difference
+
+**Signature**
+
+```ts
+export declare const difference: <A>(
+  second: Readonly<Record<string, A>>
+) => (first: Readonly<Record<string, A>>) => Readonly<Record<string, A>>
+```
+
+Added in v2.11.0
 
 ## elem
 
@@ -646,12 +784,21 @@ Added in v2.5.0
 **Signature**
 
 ```ts
+export declare function foldMapWithIndex(
+  O: Ord<string>
+): <M>(M: Monoid<M>) => <K extends string, A>(f: (k: K, a: A) => M) => (fa: ReadonlyRecord<K, A>) => M
+export declare function foldMapWithIndex(
+  O: Ord<string>
+): <M>(M: Monoid<M>) => <A>(f: (k: string, a: A) => M) => (fa: ReadonlyRecord<string, A>) => M
 export declare function foldMapWithIndex<M>(
   M: Monoid<M>
 ): <K extends string, A>(f: (k: K, a: A) => M) => (fa: ReadonlyRecord<K, A>) => M
+export declare function foldMapWithIndex<M>(
+  M: Monoid<M>
+): <A>(f: (k: string, a: A) => M) => (fa: ReadonlyRecord<string, A>) => M
 ```
 
-Added in v2.5.0
+Added in v2.11.0
 
 ## fromFoldable
 
@@ -759,6 +906,18 @@ export declare const has: <K extends string>(k: string, r: Readonly<Record<K, un
 ```
 
 Added in v2.10.0
+
+## intersection
+
+**Signature**
+
+```ts
+export declare const intersection: <A>(
+  M: Magma<A>
+) => (second: Readonly<Record<string, A>>) => (first: Readonly<Record<string, A>>) => Readonly<Record<string, A>>
+```
+
+Added in v2.11.0
 
 ## isEmpty
 
@@ -873,26 +1032,52 @@ Added in v2.5.0
 **Signature**
 
 ```ts
+export declare function reduceRightWithIndex(
+  O: Ord<string>
+): <K extends string, A, B>(b: B, f: (k: K, a: A, b: B) => B) => (fa: ReadonlyRecord<K, A>) => B
+export declare function reduceRightWithIndex(
+  O: Ord<string>
+): <A, B>(b: B, f: (k: string, a: A, b: B) => B) => (fa: ReadonlyRecord<string, A>) => B
 export declare function reduceRightWithIndex<K extends string, A, B>(
   b: B,
   f: (k: K, a: A, b: B) => B
 ): (fa: ReadonlyRecord<K, A>) => B
+export declare function reduceRightWithIndex<A, B>(
+  b: B,
+  f: (k: string, a: A, b: B) => B
+): (fa: ReadonlyRecord<string, A>) => B
 ```
 
-Added in v2.5.0
+Added in v2.11.0
 
 ## reduceWithIndex
 
 **Signature**
 
 ```ts
+export declare function reduceWithIndex(
+  O: Ord<string>
+): <K extends string, A, B>(b: B, f: (k: K, b: B, a: A) => B) => (fa: ReadonlyRecord<K, A>) => B
+export declare function reduceWithIndex(
+  O: Ord<string>
+): <A, B>(b: B, f: (k: string, b: B, a: A) => B) => (fa: ReadonlyRecord<string, A>) => B
 export declare function reduceWithIndex<K extends string, A, B>(
   b: B,
   f: (k: K, b: B, a: A) => B
 ): (fa: ReadonlyRecord<K, A>) => B
+export declare function reduceWithIndex<A, B>(
+  b: B,
+  f: (k: string, b: B, a: A) => B
+): (fa: ReadonlyRecord<string, A>) => B
+export declare function reduceWithIndex(
+  O: Ord<string>
+): <K extends string, A, B>(b: B, f: (k: K, b: B, a: A) => B) => (fa: ReadonlyRecord<K, A>) => B
+export declare function reduceWithIndex(
+  O: Ord<string>
+): <A, B>(b: B, f: (k: string, b: B, a: A) => B) => (fa: ReadonlyRecord<string, A>) => B
 ```
 
-Added in v2.5.0
+Added in v2.11.0
 
 ## sequence
 
@@ -1026,6 +1211,18 @@ export declare function traverseWithIndex<F>(
 ```
 
 Added in v2.5.0
+
+## union
+
+**Signature**
+
+```ts
+export declare const union: <A>(
+  M: Magma<A>
+) => (second: Readonly<Record<string, A>>) => (first: Readonly<Record<string, A>>) => Readonly<Record<string, A>>
+```
+
+Added in v2.11.0
 
 ## updateAt
 

--- a/docs/modules/Record.ts.md
+++ b/docs/modules/Record.ts.md
@@ -34,18 +34,23 @@ Added in v2.0.0
   - [Compactable](#compactable-1)
   - [Filterable](#filterable-1)
   - [FilterableWithIndex](#filterablewithindex)
-  - [Foldable](#foldable-1)
-  - [FoldableWithIndex](#foldablewithindex)
   - [Functor](#functor)
   - [FunctorWithIndex](#functorwithindex)
-  - [Traversable](#traversable)
-  - [TraversableWithIndex](#traversablewithindex)
   - [URI](#uri)
   - [URI (type alias)](#uri-type-alias)
-  - [Witherable](#witherable-1)
   - [getEq](#geteq)
+  - [getFoldable](#getfoldable)
+  - [getFoldableWithIndex](#getfoldablewithindex)
   - [getMonoid](#getmonoid)
   - [getShow](#getshow)
+  - [getTraversable](#gettraversable)
+  - [getTraversableWithIndex](#gettraversablewithindex)
+  - [getWitherable](#getwitherable)
+  - [~~FoldableWithIndex~~](#foldablewithindex)
+  - [~~Foldable~~](#foldable)
+  - [~~TraversableWithIndex~~](#traversablewithindex)
+  - [~~Traversable~~](#traversable)
+  - [~~Witherable~~](#witherable)
   - [~~record~~](#record)
 - [utils](#utils)
   - [collect](#collect)
@@ -168,7 +173,10 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export declare const foldMap: <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => (fa: Record<string, A>) => M
+export declare function foldMap(
+  O: Ord<string>
+): <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => (fa: Record<string, A>) => M
+export declare function foldMap<M>(M: Monoid<M>): <A>(f: (a: A) => M) => (fa: Record<string, A>) => M
 ```
 
 Added in v2.0.0
@@ -178,7 +186,8 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export declare const reduce: <A, B>(b: B, f: (b: B, a: A) => B) => (fa: Record<string, A>) => B
+export declare function reduce(O: Ord<string>): <A, B>(b: B, f: (b: B, a: A) => B) => (fa: Record<string, A>) => B
+export declare function reduce<A, B>(b: B, f: (b: B, a: A) => B): (fa: Record<string, A>) => B
 ```
 
 Added in v2.0.0
@@ -188,7 +197,8 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export declare const reduceRight: <A, B>(b: B, f: (a: A, b: B) => B) => (fa: Record<string, A>) => B
+export declare function reduceRight(O: Ord<string>): <A, B>(b: B, f: (a: A, b: B) => B) => (fa: Record<string, A>) => B
+export declare function reduceRight<A, B>(b: B, f: (a: A, b: B) => B): (fa: Record<string, A>) => B
 ```
 
 Added in v2.0.0
@@ -273,26 +283,6 @@ export declare const FilterableWithIndex: FilterableWithIndex1<'Record', string>
 
 Added in v2.7.0
 
-## Foldable
-
-**Signature**
-
-```ts
-export declare const Foldable: Foldable1<'Record'>
-```
-
-Added in v2.7.0
-
-## FoldableWithIndex
-
-**Signature**
-
-```ts
-export declare const FoldableWithIndex: FoldableWithIndex1<'Record', string>
-```
-
-Added in v2.7.0
-
 ## Functor
 
 **Signature**
@@ -309,26 +299,6 @@ Added in v2.7.0
 
 ```ts
 export declare const FunctorWithIndex: FunctorWithIndex1<'Record', string>
-```
-
-Added in v2.7.0
-
-## Traversable
-
-**Signature**
-
-```ts
-export declare const Traversable: Traversable1<'Record'>
-```
-
-Added in v2.7.0
-
-## TraversableWithIndex
-
-**Signature**
-
-```ts
-export declare const TraversableWithIndex: TraversableWithIndex1<'Record', string>
 ```
 
 Added in v2.7.0
@@ -353,16 +323,6 @@ export type URI = typeof URI
 
 Added in v2.0.0
 
-## Witherable
-
-**Signature**
-
-```ts
-export declare const Witherable: Witherable1<'Record'>
-```
-
-Added in v2.7.0
-
 ## getEq
 
 **Signature**
@@ -372,6 +332,26 @@ export declare const getEq: <K extends string, A>(E: Eq<A>) => Eq<Record<K, A>>
 ```
 
 Added in v2.0.0
+
+## getFoldable
+
+**Signature**
+
+```ts
+export declare const getFoldable: (O: Ord<string>) => Foldable1<URI>
+```
+
+Added in v2.7.0
+
+## getFoldableWithIndex
+
+**Signature**
+
+```ts
+export declare const getFoldableWithIndex: (O: Ord<string>) => FoldableWithIndex1<URI, string>
+```
+
+Added in v2.7.0
 
 ## getMonoid
 
@@ -400,10 +380,101 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export declare const getShow: <A>(S: Show<A>) => Show<Record<string, A>>
+export declare function getShow(O: Ord<string>): <A>(S: Show<A>) => Show<Record<string, A>>
+export declare function getShow<A>(S: Show<A>): Show<Record<string, A>>
 ```
 
 Added in v2.0.0
+
+## getTraversable
+
+**Signature**
+
+```ts
+export declare const getTraversable: (O: Ord<string>) => Traversable1<URI>
+```
+
+Added in v2.11.0
+
+## getTraversableWithIndex
+
+**Signature**
+
+```ts
+export declare const getTraversableWithIndex: (O: Ord<string>) => TraversableWithIndex1<URI, string>
+```
+
+Added in v2.7.0
+
+## getWitherable
+
+**Signature**
+
+```ts
+export declare const getWitherable: (O: Ord<string>) => Witherable1<URI>
+```
+
+Added in v2.7.0
+
+## ~~FoldableWithIndex~~
+
+Use `getFoldableWithIndex` instead
+
+**Signature**
+
+```ts
+export declare const FoldableWithIndex: FoldableWithIndex1<'Record', string>
+```
+
+Added in v2.7.0
+
+## ~~Foldable~~
+
+Use `getFoldable` instead
+
+**Signature**
+
+```ts
+export declare const Foldable: Foldable1<'Record'>
+```
+
+Added in v2.7.0
+
+## ~~TraversableWithIndex~~
+
+Use the `getTraversableWithIndex` instead
+
+**Signature**
+
+```ts
+export declare const TraversableWithIndex: TraversableWithIndex1<'Record', string>
+```
+
+Added in v2.7.0
+
+## ~~Traversable~~
+
+Use `getTraversable` instead
+
+**Signature**
+
+```ts
+export declare const Traversable: Traversable1<'Record'>
+```
+
+Added in v2.7.0
+
+## ~~Witherable~~
+
+Use `getWitherable` instead
+
+**Signature**
+
+```ts
+export declare const Witherable: Witherable1<'Record'>
+```
+
+Added in v2.7.0
 
 ## ~~record~~
 
@@ -430,16 +501,20 @@ Map a `Record` into an `Array`.
 **Signature**
 
 ```ts
-export declare const collect: <K extends string, A, B>(f: (k: K, a: A) => B) => (r: Record<K, A>) => B[]
+export declare function collect(
+  O: Ord<string>
+): <K extends string, A, B>(f: (k: K, a: A) => B) => (r: Record<K, A>) => Array<B>
+export declare function collect<K extends string, A, B>(f: (k: K, a: A) => B): (r: Record<K, A>) => Array<B>
 ```
 
 **Example**
 
 ```ts
 import { collect } from 'fp-ts/Record'
+import { Ord } from 'fp-ts/string'
 
 const x: { readonly a: string; readonly b: boolean } = { a: 'c', b: false }
-assert.deepStrictEqual(collect((key, val) => ({ key: key, value: val }))(x), [
+assert.deepStrictEqual(collect(Ord)((key, val) => ({ key: key, value: val }))(x), [
   { key: 'a', value: 'c' },
   { key: 'b', value: false },
 ])
@@ -515,9 +590,12 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export declare const foldMapWithIndex: <M>(
+export declare function foldMapWithIndex(
+  O: Ord<string>
+): <M>(M: Monoid<M>) => <K extends string, A>(f: (k: K, a: A) => M) => (fa: Record<K, A>) => M
+export declare function foldMapWithIndex<M>(
   M: Monoid<M>
-) => <K extends string, A>(f: (k: K, a: A) => M) => (fa: Record<K, A>) => M
+): <K extends string, A>(f: (k: K, a: A) => M) => (fa: Record<K, A>) => M
 ```
 
 Added in v2.0.0
@@ -764,26 +842,32 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export declare const reduceRightWithIndex: <K extends string, A, B>(
+export declare function reduceRightWithIndex(
+  O: Ord<string>
+): <K extends string, A, B>(b: B, f: (k: K, a: A, b: B) => B) => (fa: Record<K, A>) => B
+export declare function reduceRightWithIndex<K extends string, A, B>(
   b: B,
   f: (k: K, a: A, b: B) => B
-) => (fa: Record<K, A>) => B
+): (fa: Record<K, A>) => B
 ```
 
-Added in v2.0.0
+Added in v2.11.0
 
 ## reduceWithIndex
 
 **Signature**
 
 ```ts
-export declare const reduceWithIndex: <K extends string, A, B>(
+export declare function reduceWithIndex(
+  O: Ord<string>
+): <K extends string, A, B>(b: B, f: (k: K, b: B, a: A) => B) => (fa: Record<K, A>) => B
+export declare function reduceWithIndex<K extends string, A, B>(
   b: B,
   f: (k: K, b: B, a: A) => B
-) => (fa: Record<K, A>) => B
+): (fa: Record<K, A>) => B
 ```
 
-Added in v2.0.0
+Added in v2.11.0
 
 ## sequence
 

--- a/dtslint/ts3.5/ReadonlyRecord.ts
+++ b/dtslint/ts3.5/ReadonlyRecord.ts
@@ -66,6 +66,11 @@ _.collect((_k: 'a', n: number) => n)(l1) // $ExpectType readonly number[]
 _.collect((_k, n: number) => n)(d1) // $ExpectType readonly number[]
 _.collect((_k: 'a' | 'b', n: number) => n)(r1) // $ExpectType readonly number[]
 
+_.collect(S.Ord)((_k: 'a', n: number) => n)({ a: 1 }) // $ExpectType readonly number[]
+_.collect(S.Ord)((_k: 'a', n: number) => n)(l1) // $ExpectType readonly number[]
+_.collect(S.Ord)((_k, n: number) => n)(d1) // $ExpectType readonly number[]
+_.collect(S.Ord)((_k: 'a' | 'b', n: number) => n)(r1) // $ExpectType readonly number[]
+
 //
 // insertAt
 //
@@ -108,11 +113,20 @@ _.map((n: number) => n > 2)(r1) // $ExpectType Readonly<Record<"a" | "b", boolea
 // reduceWithIndex
 //
 
+_.reduceWithIndex(S.Ord)('', (k: string, _n) => k)(d1) // $ExpectType string
+_.reduceWithIndex(S.Ord)('', (k: 'a' | 'b', _n) => k)(r1) // $ExpectType string
+
 _.reduceWithIndex('', (k: string, _n) => k)(d1) // $ExpectType string
 _.reduceWithIndex('', (k: 'a' | 'b', _n) => k)(r1) // $ExpectType string
 
+_.foldMapWithIndex(S.Ord)(S.Monoid)((k: string, _n) => k)(d1) // $ExpectType string
+_.foldMapWithIndex(S.Ord)(S.Monoid)((k: 'a' | 'b', _n) => k)(r1) // $ExpectType string
+
 _.foldMapWithIndex(S.Monoid)((k: string, _n) => k)(d1) // $ExpectType string
 _.foldMapWithIndex(S.Monoid)((k: 'a' | 'b', _n) => k)(r1) // $ExpectType string
+
+_.reduceRightWithIndex(S.Ord)('', (k: string, _n, _b) => k)(d1) // $ExpectType string
+_.reduceRightWithIndex(S.Ord)('', (k: 'a' | 'b', _n, _b) => k)(r1) // $ExpectType string
 
 _.reduceRightWithIndex('', (k: string, _n, _b) => k)(d1) // $ExpectType string
 _.reduceRightWithIndex('', (k: 'a' | 'b', _n, _b) => k)(r1) // $ExpectType string

--- a/dtslint/ts3.5/Record.ts
+++ b/dtslint/ts3.5/Record.ts
@@ -66,6 +66,11 @@ _.collect((_k: 'a', n: number) => n)(l1) // $ExpectType number[]
 _.collect((_k, n: number) => n)(d1) // $ExpectType number[]
 _.collect((_k: 'a' | 'b', n: number) => n)(r1) // $ExpectType number[]
 
+_.collect(S.Ord)((_k: 'a', n: number) => n)({ a: 1 }) // $ExpectType number[]
+_.collect(S.Ord)((_k: 'a', n: number) => n)(l1) // $ExpectType number[]
+_.collect(S.Ord)((_k, n: number) => n)(d1) // $ExpectType number[]
+_.collect(S.Ord)((_k: 'a' | 'b', n: number) => n)(r1) // $ExpectType number[]
+
 //
 // toArray
 //
@@ -117,11 +122,20 @@ _.map((n: number) => n > 2)(r1) // $ExpectType Record<"a" | "b", boolean>
 // reduceWithIndex
 //
 
+_.reduceWithIndex(S.Ord)('', (k: string, _n) => k)(d1) // $ExpectType string
+_.reduceWithIndex(S.Ord)('', (k: 'a' | 'b', _n) => k)(r1) // $ExpectType string
+
 _.reduceWithIndex('', (k: string, _n) => k)(d1) // $ExpectType string
 _.reduceWithIndex('', (k: 'a' | 'b', _n) => k)(r1) // $ExpectType string
 
+_.foldMapWithIndex(S.Ord)(S.Monoid)((k: string, _n) => k)(d1) // $ExpectType string
+_.foldMapWithIndex(S.Ord)(S.Monoid)((k: 'a' | 'b', _n) => k)(r1) // $ExpectType string
+
 _.foldMapWithIndex(S.Monoid)((k: string, _n) => k)(d1) // $ExpectType string
 _.foldMapWithIndex(S.Monoid)((k: 'a' | 'b', _n) => k)(r1) // $ExpectType string
+
+_.reduceRightWithIndex(S.Ord)('', (k: string, _n, _b) => k)(d1) // $ExpectType string
+_.reduceRightWithIndex(S.Ord)('', (k: 'a' | 'b', _n, _b) => k)(r1) // $ExpectType string
 
 _.reduceRightWithIndex('', (k: string, _n, _b) => k)(d1) // $ExpectType string
 _.reduceRightWithIndex('', (k: 'a' | 'b', _n, _b) => k)(r1) // $ExpectType string

--- a/test/ReadonlyRecord.ts
+++ b/test/ReadonlyRecord.ts
@@ -28,6 +28,21 @@ describe('ReadonlyRecord', () => {
       U.deepStrictEqual(
         pipe(
           { k1: 'a', k2: 'b' },
+          _.reduce(S.Ord)('', (b, a) => b + a)
+        ),
+        'ab'
+      )
+      U.deepStrictEqual(
+        pipe(
+          { k2: 'b', k1: 'a' },
+          _.reduce(S.Ord)('', (b, a) => b + a)
+        ),
+        'ab'
+      )
+      U.deepStrictEqual(
+        pipe(
+          { k1: 'a', k2: 'b' },
+          // tslint:disable-next-line: deprecation
           _.reduce('', (b, a) => b + a)
         ),
         'ab'
@@ -35,6 +50,7 @@ describe('ReadonlyRecord', () => {
       U.deepStrictEqual(
         pipe(
           { k2: 'b', k1: 'a' },
+          // tslint:disable-next-line: deprecation
           _.reduce('', (b, a) => b + a)
         ),
         'ab'
@@ -42,11 +58,20 @@ describe('ReadonlyRecord', () => {
     })
 
     it('foldMap', () => {
+      U.deepStrictEqual(pipe({ a: 'a', b: 'b' }, _.foldMap(S.Ord)(S.Monoid)(identity)), 'ab')
+      U.deepStrictEqual(_.getFoldable(S.Ord).foldMap(S.Monoid)({ a: 'a', b: 'b' }, identity), 'ab')
+
+      // tslint:disable-next-line: deprecation
       U.deepStrictEqual(pipe({ a: 'a', b: 'b' }, _.foldMap(S.Monoid)(identity)), 'ab')
+      // tslint:disable-next-line: deprecation
+      U.deepStrictEqual(_.Foldable.foldMap(S.Monoid)({ a: 'a', b: 'b' }, identity), 'ab')
     })
 
     it('reduceRight', () => {
       const f = (a: string, acc: string) => acc + a
+      U.deepStrictEqual(pipe({ a: 'a', b: 'b' }, _.reduceRight(S.Ord)('', f)), 'ba')
+
+      // tslint:disable-next-line: deprecation
       U.deepStrictEqual(pipe({ a: 'a', b: 'b' }, _.reduceRight('', f)), 'ba')
     })
 
@@ -107,6 +132,22 @@ describe('ReadonlyRecord', () => {
       U.deepStrictEqual(
         pipe(
           { k1: 'a', k2: 'b' },
+          _.reduceWithIndex(S.Ord)('', (k, b, a) => b + k + a)
+        ),
+        'k1ak2b'
+      )
+      U.deepStrictEqual(
+        pipe(
+          { k2: 'b', k1: 'a' },
+          _.reduceWithIndex(S.Ord)('', (k, b, a) => b + k + a)
+        ),
+        'k1ak2b'
+      )
+
+      U.deepStrictEqual(
+        pipe(
+          { k1: 'a', k2: 'b' },
+          // tslint:disable-next-line: deprecation
           _.reduceWithIndex('', (k, b, a) => b + k + a)
         ),
         'k1ak2b'
@@ -114,6 +155,7 @@ describe('ReadonlyRecord', () => {
       U.deepStrictEqual(
         pipe(
           { k2: 'b', k1: 'a' },
+          // tslint:disable-next-line: deprecation
           _.reduceWithIndex('', (k, b, a) => b + k + a)
         ),
         'k1ak2b'
@@ -124,8 +166,26 @@ describe('ReadonlyRecord', () => {
       U.deepStrictEqual(
         pipe(
           { k1: 'a', k2: 'b' },
+          _.foldMapWithIndex(S.Ord)(S.Monoid)((k, a) => k + a)
+        ),
+        'k1ak2b'
+      )
+      U.deepStrictEqual(
+        _.getFoldableWithIndex(S.Ord).foldMapWithIndex(S.Monoid)({ k1: 'a', k2: 'b' }, (k, a) => k + a),
+        'k1ak2b'
+      )
+
+      U.deepStrictEqual(
+        pipe(
+          { k1: 'a', k2: 'b' },
+          // tslint:disable-next-line: deprecation
           _.foldMapWithIndex(S.Monoid)((k, a) => k + a)
         ),
+        'k1ak2b'
+      )
+      U.deepStrictEqual(
+        // tslint:disable-next-line: deprecation
+        _.FoldableWithIndex.foldMapWithIndex(S.Monoid)({ k1: 'a', k2: 'b' }, (k, a) => k + a),
         'k1ak2b'
       )
     })
@@ -134,6 +194,14 @@ describe('ReadonlyRecord', () => {
       U.deepStrictEqual(
         pipe(
           { k1: 'a', k2: 'b' },
+          _.reduceRightWithIndex(S.Ord)('', (k, a, b) => b + k + a)
+        ),
+        'k2bk1a'
+      )
+      U.deepStrictEqual(
+        pipe(
+          { k1: 'a', k2: 'b' },
+          // tslint:disable-next-line: deprecation
           _.reduceRightWithIndex('', (k, a, b) => b + k + a)
         ),
         'k2bk1a'
@@ -180,26 +248,48 @@ describe('ReadonlyRecord', () => {
         O.some({ a: 1, b: 2 })
       )
       U.deepStrictEqual(_.traverse(O.Applicative)((n: number) => (n >= 2 ? O.some(n) : O.none))({ a: 1, b: 2 }), O.none)
+
+      U.deepStrictEqual(
+        _.getTraversable(S.Ord).traverse(O.Applicative)({ a: 1, b: 2 }, (n: number) => (n <= 2 ? O.some(n) : O.none)),
+        O.some({ a: 1, b: 2 })
+      )
+      U.deepStrictEqual(
+        _.getTraversable(S.Ord).traverse(O.Applicative)({ a: 1, b: 2 }, (n: number) => (n >= 2 ? O.some(n) : O.none)),
+        O.none
+      )
     })
 
     it('sequence', () => {
       const sequence = _.sequence(O.Applicative)
       U.deepStrictEqual(sequence({ a: O.some(1), b: O.some(2) }), O.some({ a: 1, b: 2 }))
       U.deepStrictEqual(sequence({ a: O.none, b: O.some(2) }), O.none)
+
+      U.deepStrictEqual(
+        // tslint:disable-next-line: deprecation
+        _.readonlyRecord.sequence(O.Applicative)({ a: O.some(1), b: O.some(2) }),
+        O.some({ a: 1, b: 2 })
+      )
     })
 
     it('traverseWithIndex', () => {
-      const traverseWithIndex = _.traverseWithIndex(O.Applicative)(
-        (k, n: number): O.Option<number> => (k !== 'a' ? O.some(n) : O.none)
-      )
+      const f = (k: string, n: number): O.Option<number> => (k !== 'a' ? O.some(n) : O.none)
+      const traverseWithIndex = _.traverseWithIndex(O.Applicative)(f)
       U.deepStrictEqual(pipe({ a: 1, b: 2 }, traverseWithIndex), O.none)
       U.deepStrictEqual(pipe({ b: 2 }, traverseWithIndex), O.some({ b: 2 }))
+
+      U.deepStrictEqual(
+        _.getTraversableWithIndex(S.Ord).traverseWithIndex(O.Applicative)({ b: 2 }, f),
+        O.some({ b: 2 })
+      )
     })
 
     it('wither', async () => {
-      const wither = _.wither(T.ApplicativePar)((n: number) => T.of(p(n) ? O.some(n + 1) : O.none))
+      const f = (n: number) => T.of(p(n) ? O.some(n + 1) : O.none)
+      const wither = _.wither(T.ApplicativePar)(f)
       U.deepStrictEqual(await pipe({}, wither)(), {})
       U.deepStrictEqual(await pipe({ a: 1, b: 3 }, wither)(), { b: 4 })
+
+      U.deepStrictEqual(await _.getWitherable(S.Ord).wither(T.ApplicativePar)({ a: 1, b: 3 }, f)(), { b: 4 })
     })
 
     it('wilt', async () => {
@@ -386,10 +476,16 @@ describe('ReadonlyRecord', () => {
   })
 
   it('getShow', () => {
-    const Sh = _.getShow(S.Show)
+    const Sh = _.getShow(S.Ord)(S.Show)
     U.deepStrictEqual(Sh.show({}), `{}`)
     U.deepStrictEqual(Sh.show({ a: 'a' }), `{ "a": "a" }`)
     U.deepStrictEqual(Sh.show({ a: 'a', b: 'b' }), `{ "a": "a", "b": "b" }`)
+
+    // tslint:disable-next-line: deprecation
+    const DepSh = _.getShow(S.Show)
+    U.deepStrictEqual(DepSh.show({}), `{}`)
+    U.deepStrictEqual(DepSh.show({ a: 'a' }), `{ "a": "a" }`)
+    U.deepStrictEqual(DepSh.show({ a: 'a', b: 'b' }), `{ "a": "a", "b": "b" }`)
   })
 
   it('singleton', () => {
@@ -452,6 +548,74 @@ describe('ReadonlyRecord', () => {
     const bs = _.toRecord(as)
     U.deepStrictEqual(bs, as)
     assert.notStrictEqual(bs, as)
+  })
+
+  it('getUnionMonoid', () => {
+    const M = _.getUnionMonoid(S.Semigroup)
+    const x: _.ReadonlyRecord<string, string> = {
+      a: 'a1',
+      b: 'b1',
+      c: 'c1'
+    }
+    const y: _.ReadonlyRecord<string, string> = {
+      b: 'b2',
+      c: 'c2',
+      d: 'd2'
+    }
+    U.strictEqual(M.concat(x, M.empty), x)
+    U.strictEqual(M.concat(M.empty, x), x)
+    U.strictEqual(M.concat(x, {}), x)
+    U.strictEqual(M.concat({}, x), x)
+    U.deepStrictEqual(M.concat(x, y), {
+      a: 'a1',
+      b: 'b1b2',
+      c: 'c1c2',
+      d: 'd2'
+    })
+  })
+
+  it('getIntersectionSemigroup', () => {
+    const M = _.getIntersectionSemigroup(S.Semigroup)
+    const x: _.ReadonlyRecord<string, string> = {
+      a: 'a1',
+      b: 'b1',
+      c: 'c1'
+    }
+    const y: _.ReadonlyRecord<string, string> = {
+      b: 'b2',
+      c: 'c2',
+      d: 'd2'
+    }
+    U.strictEqual(M.concat(x, _.empty), _.empty)
+    U.strictEqual(M.concat(x, _.empty), _.empty)
+    U.strictEqual(M.concat(x, {}), _.empty)
+    U.strictEqual(M.concat(x, {}), _.empty)
+    U.deepStrictEqual(M.concat(x, y), {
+      b: 'b1b2',
+      c: 'c1c2'
+    })
+  })
+
+  it('getDifferenceMagma', () => {
+    const M = _.getDifferenceMagma<string>()
+    const x: _.ReadonlyRecord<string, string> = {
+      a: 'a1',
+      b: 'b1',
+      c: 'c1'
+    }
+    const y: _.ReadonlyRecord<string, string> = {
+      b: 'b2',
+      c: 'c2',
+      d: 'd2'
+    }
+    U.strictEqual(M.concat(_.empty, x), x)
+    U.strictEqual(M.concat(x, _.empty), x)
+    U.strictEqual(M.concat({}, x), x)
+    U.strictEqual(M.concat(x, {}), x)
+    U.deepStrictEqual(M.concat(x, y), {
+      a: 'a1',
+      d: 'd2'
+    })
   })
 
   it('mapWithIndex', () => {

--- a/test/Record.ts
+++ b/test/Record.ts
@@ -18,6 +18,19 @@ const noPrototype = Object.create(null)
 
 describe('Record', () => {
   describe('pipeables', () => {
+    it('collect', () => {
+      const x: { readonly a: string; readonly b: boolean } = { a: 'c', b: false }
+      U.deepStrictEqual(_.collect(S.Ord)((key, val) => ({ key: key, value: val }))(x), [
+        { key: 'a', value: 'c' },
+        { key: 'b', value: false }
+      ])
+      // tslint:disable-next-line: deprecation
+      U.deepStrictEqual(_.collect((key, val) => ({ key: key, value: val }))(x), [
+        { key: 'a', value: 'c' },
+        { key: 'b', value: false }
+      ])
+    })
+
     it('map', () => {
       U.deepStrictEqual(pipe({ k1: 1, k2: 2 }, _.map(U.double)), { k1: 2, k2: 4 })
       U.deepStrictEqual(pipe({ a: 1, b: 2 }, _.map(U.double)), { a: 2, b: 4 })
@@ -32,6 +45,22 @@ describe('Record', () => {
       U.deepStrictEqual(
         pipe(
           { k1: 'a', k2: 'b' },
+          _.reduce(S.Ord)('', (b, a) => b + a)
+        ),
+        'ab'
+      )
+      U.deepStrictEqual(
+        pipe(
+          { k2: 'b', k1: 'a' },
+          _.reduce(S.Ord)('', (b, a) => b + a)
+        ),
+        'ab'
+      )
+
+      U.deepStrictEqual(
+        pipe(
+          { k1: 'a', k2: 'b' },
+          // tslint:disable-next-line: deprecation
           _.reduce('', (b, a) => b + a)
         ),
         'ab'
@@ -39,6 +68,7 @@ describe('Record', () => {
       U.deepStrictEqual(
         pipe(
           { k2: 'b', k1: 'a' },
+          // tslint:disable-next-line: deprecation
           _.reduce('', (b, a) => b + a)
         ),
         'ab'
@@ -46,11 +76,20 @@ describe('Record', () => {
     })
 
     it('foldMap', () => {
+      U.deepStrictEqual(pipe({ a: 'a', b: 'b' }, _.foldMap(S.Ord)(S.Monoid)(identity)), 'ab')
+      U.deepStrictEqual(_.getFoldable(S.Ord).foldMap(S.Monoid)({ a: 'a', b: 'b' }, identity), 'ab')
+
+      // tslint:disable-next-line: deprecation
       U.deepStrictEqual(pipe({ a: 'a', b: 'b' }, _.foldMap(S.Monoid)(identity)), 'ab')
+      // tslint:disable-next-line: deprecation
+      U.deepStrictEqual(_.Foldable.foldMap(S.Monoid)({ a: 'a', b: 'b' }, identity), 'ab')
     })
 
     it('reduceRight', () => {
       const f = (a: string, acc: string) => acc + a
+      U.deepStrictEqual(pipe({ a: 'a', b: 'b' }, _.reduceRight(S.Ord)('', f)), 'ba')
+
+      // tslint:disable-next-line: deprecation
       U.deepStrictEqual(pipe({ a: 'a', b: 'b' }, _.reduceRight('', f)), 'ba')
     })
 
@@ -105,6 +144,22 @@ describe('Record', () => {
       U.deepStrictEqual(
         pipe(
           { k1: 'a', k2: 'b' },
+          _.reduceWithIndex(S.Ord)('', (k, b, a) => b + k + a)
+        ),
+        'k1ak2b'
+      )
+      U.deepStrictEqual(
+        pipe(
+          { k2: 'b', k1: 'a' },
+          _.reduceWithIndex(S.Ord)('', (k, b, a) => b + k + a)
+        ),
+        'k1ak2b'
+      )
+
+      U.deepStrictEqual(
+        pipe(
+          { k1: 'a', k2: 'b' },
+          // tslint:disable-next-line: deprecation
           _.reduceWithIndex('', (k, b, a) => b + k + a)
         ),
         'k1ak2b'
@@ -112,6 +167,7 @@ describe('Record', () => {
       U.deepStrictEqual(
         pipe(
           { k2: 'b', k1: 'a' },
+          // tslint:disable-next-line: deprecation
           _.reduceWithIndex('', (k, b, a) => b + k + a)
         ),
         'k1ak2b'
@@ -122,8 +178,26 @@ describe('Record', () => {
       U.deepStrictEqual(
         pipe(
           { k1: 'a', k2: 'b' },
+          _.foldMapWithIndex(S.Ord)(S.Monoid)((k, a) => k + a)
+        ),
+        'k1ak2b'
+      )
+      U.deepStrictEqual(
+        _.getFoldableWithIndex(S.Ord).foldMapWithIndex(S.Monoid)({ k1: 'a', k2: 'b' }, (k, a) => k + a),
+        'k1ak2b'
+      )
+
+      U.deepStrictEqual(
+        pipe(
+          { k1: 'a', k2: 'b' },
+          // tslint:disable-next-line: deprecation
           _.foldMapWithIndex(S.Monoid)((k, a) => k + a)
         ),
+        'k1ak2b'
+      )
+      U.deepStrictEqual(
+        // tslint:disable-next-line: deprecation
+        _.FoldableWithIndex.foldMapWithIndex(S.Monoid)({ k1: 'a', k2: 'b' }, (k, a) => k + a),
         'k1ak2b'
       )
     })
@@ -132,6 +206,14 @@ describe('Record', () => {
       U.deepStrictEqual(
         pipe(
           { k1: 'a', k2: 'b' },
+          _.reduceRightWithIndex(S.Ord)('', (k, a, b) => b + k + a)
+        ),
+        'k2bk1a'
+      )
+      U.deepStrictEqual(
+        pipe(
+          { k1: 'a', k2: 'b' },
+          // tslint:disable-next-line: deprecation
           _.reduceRightWithIndex('', (k, a, b) => b + k + a)
         ),
         'k2bk1a'
@@ -186,11 +268,11 @@ describe('Record', () => {
       U.deepStrictEqual(_.traverse(O.Applicative)((n: number) => (n >= 2 ? O.some(n) : O.none))({ a: 1, b: 2 }), O.none)
 
       U.deepStrictEqual(
-        _.Traversable.traverse(O.Applicative)({ a: 1, b: 2 }, (n: number) => (n <= 2 ? O.some(n) : O.none)),
+        _.getTraversable(S.Ord).traverse(O.Applicative)({ a: 1, b: 2 }, (n: number) => (n <= 2 ? O.some(n) : O.none)),
         O.some({ a: 1, b: 2 })
       )
       U.deepStrictEqual(
-        _.Traversable.traverse(O.Applicative)({ a: 1, b: 2 }, (n: number) => (n >= 2 ? O.some(n) : O.none)),
+        _.getTraversable(S.Ord).traverse(O.Applicative)({ a: 1, b: 2 }, (n: number) => (n >= 2 ? O.some(n) : O.none)),
         O.none
       )
     })
@@ -199,20 +281,33 @@ describe('Record', () => {
       const sequence = _.sequence(O.Applicative)
       U.deepStrictEqual(sequence({ a: O.some(1), b: O.some(2) }), O.some({ a: 1, b: 2 }))
       U.deepStrictEqual(sequence({ a: O.none, b: O.some(2) }), O.none)
+
+      U.deepStrictEqual(
+        // tslint:disable-next-line: deprecation
+        _.record.sequence(O.Applicative)({ a: O.some(1), b: O.some(2) }),
+        O.some({ a: 1, b: 2 })
+      )
     })
 
     it('traverseWithIndex', () => {
-      const traverseWithIndex = _.traverseWithIndex(O.Applicative)(
-        (k, n: number): O.Option<number> => (k !== 'a' ? O.some(n) : O.none)
-      )
+      const f = (k: string, n: number): O.Option<number> => (k !== 'a' ? O.some(n) : O.none)
+      const traverseWithIndex = _.traverseWithIndex(O.Applicative)(f)
       U.deepStrictEqual(pipe({ a: 1, b: 2 }, traverseWithIndex), O.none)
       U.deepStrictEqual(pipe({ b: 2 }, traverseWithIndex), O.some({ b: 2 }))
+
+      U.deepStrictEqual(
+        _.getTraversableWithIndex(S.Ord).traverseWithIndex(O.Applicative)({ b: 2 }, f),
+        O.some({ b: 2 })
+      )
     })
 
     it('wither', async () => {
-      const wither = _.wither(T.ApplicativePar)((n: number) => T.of(p(n) ? O.some(n + 1) : O.none))
+      const f = (n: number) => T.of(p(n) ? O.some(n + 1) : O.none)
+      const wither = _.wither(T.ApplicativePar)(f)
       U.deepStrictEqual(await pipe({}, wither)(), {})
       U.deepStrictEqual(await pipe({ a: 1, b: 3 }, wither)(), { b: 4 })
+
+      U.deepStrictEqual(await _.getWitherable(S.Ord).wither(T.ApplicativePar)({ a: 1, b: 3 }, f)(), { b: 4 })
     })
 
     it('wilt', async () => {
@@ -382,10 +477,16 @@ describe('Record', () => {
   })
 
   it('getShow', () => {
-    const Sh = _.getShow(S.Show)
+    const Sh = _.getShow(S.Ord)(S.Show)
     U.deepStrictEqual(Sh.show({}), `{}`)
     U.deepStrictEqual(Sh.show({ a: 'a' }), `{ "a": "a" }`)
     U.deepStrictEqual(Sh.show({ a: 'a', b: 'b' }), `{ "a": "a", "b": "b" }`)
+
+    // tslint:disable-next-line: deprecation
+    const DepSh = _.getShow(S.Show)
+    U.deepStrictEqual(DepSh.show({}), `{}`)
+    U.deepStrictEqual(DepSh.show({ a: 'a' }), `{ "a": "a" }`)
+    U.deepStrictEqual(DepSh.show({ a: 'a', b: 'b' }), `{ "a": "a", "b": "b" }`)
   })
 
   it('singleton', () => {


### PR DESCRIPTION
Backports `ReadonlyRecord` from 3.0.0 based on the 2.11 roadmap https://github.com/gcanti/fp-ts/issues/1446

I agree w/ the `Ord` idea outlined in the roadmap, but I can change if desired.

Notes:
- I used `Ord` constraints in `Record` as well, I can change it to use `Ord.trivial` if desired
- I wasn't sure why `ReadonlyRecord.wilt` and `ReadonlyRecord.wither` [use `Ord.trivial`  in 3.0.0](https://github.com/gcanti/fp-ts/blob/f7ae980afcab8f68d46b801f35462e644a64a65c/src/ReadonlyRecord.ts#L756), but I mirrored that - I'm not sure if that was correct
- I also added `Ord` instances to these, which were unspecified - we can use `Ord.trivial` instead if desired
  - `traverse`
  - `sequence`
  - `getShow`
  - typeclass instances (`Traversable` -> `getTraversable: (O: Ord<string>) => ...`)