### PR TITLE
Relocate Struct Instances into the Struct Module

### DIFF
--- a/docs/modules/Eq.ts.md
+++ b/docs/modules/Eq.ts.md
@@ -23,7 +23,6 @@ Added in v2.0.0
 - [Contravariant](#contravariant)
   - [contramap](#contramap)
 - [combinators](#combinators)
-  - [struct](#struct)
   - [tuple](#tuple)
   - [~~getStructEq~~](#getstructeq)
   - [~~getTupleEq~~](#gettupleeq)
@@ -62,16 +61,6 @@ Added in v2.0.0
 
 # combinators
 
-## struct
-
-**Signature**
-
-```ts
-export declare const struct: <A>(eqs: { [K in keyof A]: Eq<A[K]> }) => Eq<{ readonly [K in keyof A]: A[K] }>
-```
-
-Added in v2.10.0
-
 ## tuple
 
 Given a tuple of `Eq`s returns a `Eq` for the tuple
@@ -101,7 +90,7 @@ Added in v2.10.0
 
 ## ~~getStructEq~~
 
-Use `struct` instead.
+Use `struct.getEq` instead.
 
 **Signature**
 

--- a/docs/modules/Monoid.ts.md
+++ b/docs/modules/Monoid.ts.md
@@ -45,7 +45,6 @@ Added in v2.0.0
 
 - [combinators](#combinators)
   - [reverse](#reverse)
-  - [struct](#struct)
   - [tuple](#tuple)
   - [~~getDualMonoid~~](#getdualmonoid)
   - [~~getStructMonoid~~](#getstructmonoid)
@@ -95,37 +94,6 @@ assert.deepStrictEqual(reverse(S.Monoid).concat('a', 'b'), 'ba')
 
 Added in v2.10.0
 
-## struct
-
-Given a struct of monoids returns a monoid for the struct.
-
-**Signature**
-
-```ts
-export declare const struct: <A>(monoids: { [K in keyof A]: Monoid<A[K]> }) => Monoid<{ readonly [K in keyof A]: A[K] }>
-```
-
-**Example**
-
-```ts
-import { struct } from 'fp-ts/Monoid'
-import * as N from 'fp-ts/number'
-
-interface Point {
-  readonly x: number
-  readonly y: number
-}
-
-const M = struct<Point>({
-  x: N.MonoidSum,
-  y: N.MonoidSum,
-})
-
-assert.deepStrictEqual(M.concat({ x: 1, y: 2 }, { x: 3, y: 4 }), { x: 4, y: 6 })
-```
-
-Added in v2.10.0
-
 ## tuple
 
 Given a tuple of monoids returns a monoid for the tuple.
@@ -169,7 +137,7 @@ Added in v2.0.0
 
 ## ~~getStructMonoid~~
 
-Use `struct` instead.
+Use `struct.getMonoid` instead.
 
 **Signature**
 

--- a/docs/modules/Semigroup.ts.md
+++ b/docs/modules/Semigroup.ts.md
@@ -51,7 +51,6 @@ Added in v2.0.0
 - [combinators](#combinators)
   - [intercalate](#intercalate)
   - [reverse](#reverse)
-  - [struct](#struct)
   - [tuple](#tuple)
   - [~~getDualSemigroup~~](#getdualsemigroup)
   - [~~getIntercalateSemigroup~~](#getintercalatesemigroup)
@@ -131,39 +130,6 @@ assert.deepStrictEqual(reverse(S.Semigroup).concat('a', 'b'), 'ba')
 
 Added in v2.10.0
 
-## struct
-
-Given a struct of semigroups returns a semigroup for the struct.
-
-**Signature**
-
-```ts
-export declare const struct: <A>(
-  semigroups: { [K in keyof A]: Semigroup<A[K]> }
-) => Semigroup<{ readonly [K in keyof A]: A[K] }>
-```
-
-**Example**
-
-```ts
-import { struct } from 'fp-ts/Semigroup'
-import * as N from 'fp-ts/number'
-
-interface Point {
-  readonly x: number
-  readonly y: number
-}
-
-const S = struct<Point>({
-  x: N.SemigroupSum,
-  y: N.SemigroupSum,
-})
-
-assert.deepStrictEqual(S.concat({ x: 1, y: 2 }, { x: 3, y: 4 }), { x: 4, y: 6 })
-```
-
-Added in v2.10.0
-
 ## tuple
 
 Given a tuple of semigroups returns a semigroup for the tuple.
@@ -219,7 +185,7 @@ Added in v2.5.0
 
 ## ~~getStructSemigroup~~
 
-Use `struct` instead.
+Use `struct.getSemigroup` instead.
 
 **Signature**
 

--- a/docs/modules/Show.ts.md
+++ b/docs/modules/Show.ts.md
@@ -20,7 +20,6 @@ Added in v2.0.0
 <h2 class="text-delta">Table of contents</h2>
 
 - [combinators](#combinators)
-  - [struct](#struct)
   - [tuple](#tuple)
   - [~~getStructShow~~](#getstructshow)
   - [~~getTupleShow~~](#gettupleshow)
@@ -34,16 +33,6 @@ Added in v2.0.0
 ---
 
 # combinators
-
-## struct
-
-**Signature**
-
-```ts
-export declare const struct: <A>(shows: { [K in keyof A]: Show<A[K]> }) => Show<{ readonly [K in keyof A]: A[K] }>
-```
-
-Added in v2.10.0
 
 ## tuple
 
@@ -59,7 +48,7 @@ Added in v2.10.0
 
 ## ~~getStructShow~~
 
-Use `struct` instead.
+Use `struct.getShow` instead.
 
 **Signature**
 

--- a/docs/modules/struct.ts.md
+++ b/docs/modules/struct.ts.md
@@ -14,6 +14,10 @@ Added in v2.10.0
 
 - [instances](#instances)
   - [getAssignSemigroup](#getassignsemigroup)
+  - [getEq](#geteq)
+  - [getMonoid](#getmonoid)
+  - [getSemigroup](#getsemigroup)
+  - [getShow](#getshow)
 
 ---
 
@@ -41,6 +45,92 @@ interface Person {
 
 const S = getAssignSemigroup<Person>()
 assert.deepStrictEqual(S.concat({ name: 'name', age: 23 }, { name: 'name', age: 24 }), { name: 'name', age: 24 })
+```
+
+Added in v2.10.0
+
+## getEq
+
+**Signature**
+
+```ts
+export declare const getEq: <A>(eqs: { [K in keyof A]: Eq<A[K]> }) => Eq<{ readonly [K in keyof A]: A[K] }>
+```
+
+Added in v2.10.0
+
+## getMonoid
+
+Given a struct of monoids returns a monoid for the struct.
+
+**Signature**
+
+```ts
+export declare const getMonoid: <A>(
+  monoids: { [K in keyof A]: Monoid<A[K]> }
+) => Monoid<{ readonly [K in keyof A]: A[K] }>
+```
+
+**Example**
+
+```ts
+import { getMonoid } from 'fp-ts/struct'
+import * as N from 'fp-ts/number'
+
+interface Point {
+  readonly x: number
+  readonly y: number
+}
+
+const M = getMonoid<Point>({
+  x: N.MonoidSum,
+  y: N.MonoidSum,
+})
+
+assert.deepStrictEqual(M.concat({ x: 1, y: 2 }, { x: 3, y: 4 }), { x: 4, y: 6 })
+```
+
+Added in v2.10.0
+
+## getSemigroup
+
+Given a struct of semigroups returns a semigroup for the struct.
+
+**Signature**
+
+```ts
+export declare const getSemigroup: <A>(
+  semigroups: { [K in keyof A]: Semigroup<A[K]> }
+) => Semigroup<{ readonly [K in keyof A]: A[K] }>
+```
+
+**Example**
+
+```ts
+import { getSemigroup } from 'fp-ts/struct'
+import * as N from 'fp-ts/number'
+
+interface Point {
+  readonly x: number
+  readonly y: number
+}
+
+const S = getSemigroup<Point>({
+  x: N.SemigroupSum,
+  y: N.SemigroupSum,
+})
+
+assert.deepStrictEqual(S.concat({ x: 1, y: 2 }, { x: 3, y: 4 }), { x: 4, y: 6 })
+```
+
+Added in v2.10.0
+
+## getShow
+
+**Signature**
+
+```ts
+export declare const getShow: <A>(shows: { [K in keyof A]: Show<A[K]> }) => Show<{ readonly [K in keyof A]: A[K] }>
 ```
 
 Added in v2.10.0

--- a/dtslint/ts3.5/Eq.ts
+++ b/dtslint/ts3.5/Eq.ts
@@ -4,13 +4,6 @@ import * as N from '../../src/number'
 import * as B from '../../src/boolean'
 
 //
-// struct
-//
-
-// $ExpectType Eq<{ readonly a: string; readonly b: number; readonly c: boolean; }>
-_.struct({ a: S.Eq, b: N.Eq, c: B.Eq })
-
-//
 // tuple
 //
 

--- a/dtslint/ts3.5/Monoid.ts
+++ b/dtslint/ts3.5/Monoid.ts
@@ -4,13 +4,6 @@ import * as N from '../../src/number'
 import * as B from '../../src/boolean'
 
 //
-// struct
-//
-
-// $ExpectType Monoid<{ readonly a: string; readonly b: number; readonly c: boolean; }>
-_.struct({ a: S.Monoid, b: N.MonoidSum, c: B.MonoidAll })
-
-//
 // tuple
 //
 

--- a/dtslint/ts3.5/Semigroup.ts
+++ b/dtslint/ts3.5/Semigroup.ts
@@ -4,13 +4,6 @@ import * as N from '../../src/number'
 import * as B from '../../src/boolean'
 
 //
-// struct
-//
-
-// $ExpectType Semigroup<{ readonly a: string; readonly b: number; readonly c: boolean; }>
-_.struct({ a: S.Semigroup, b: N.SemigroupSum, c: B.SemigroupAll })
-
-//
 // tuple
 //
 

--- a/dtslint/ts3.5/Show.ts
+++ b/dtslint/ts3.5/Show.ts
@@ -4,13 +4,6 @@ import * as N from '../../src/number'
 import * as B from '../../src/boolean'
 
 //
-// struct
-//
-
-// $ExpectType Show<{ readonly a: string; readonly b: number; readonly c: boolean; }>
-_.struct({ a: S.Show, b: N.Show, c: B.Show })
-
-//
 // tuple
 //
 

--- a/dtslint/ts3.5/struct.ts
+++ b/dtslint/ts3.5/struct.ts
@@ -1,0 +1,11 @@
+import * as _ from '../../src/struct'
+import * as N from '../../src/number'
+import * as S from '../../src/string'
+
+_.getShow({ key1: N.Show, key2: S.Show }) // $ExpectType Show<{ readonly key1: number; readonly key2: string; }>
+
+_.getEq({ key1: N.Eq, key2: S.Eq }) // $ExpectType Eq<{ readonly key1: number; readonly key2: string; }>
+
+_.getSemigroup({ key1: N.SemigroupSum, key2: S.Semigroup }) // $ExpectType Semigroup<{ readonly key1: number; readonly key2: string; }>
+
+_.getMonoid({ key1: N.MonoidSum, key2: S.Monoid }) // $ExpectType Monoid<{ readonly key1: number; readonly key2: string; }>

--- a/src/Eq.ts
+++ b/src/Eq.ts
@@ -46,20 +46,6 @@ export function fromEquals<A>(equals: (x: A, y: A) => boolean): Eq<A> {
 // -------------------------------------------------------------------------------------
 
 /**
- * @category combinators
- * @since 2.10.0
- */
-export const struct = <A>(eqs: { [K in keyof A]: Eq<A[K]> }): Eq<{ readonly [K in keyof A]: A[K] }> =>
-  fromEquals((first, second) => {
-    for (const key in eqs) {
-      if (!eqs[key].equals(first[key], second[key])) {
-        return false
-      }
-    }
-    return true
-  })
-
-/**
  * Given a tuple of `Eq`s returns a `Eq` for the tuple
  *
  * @example
@@ -174,13 +160,23 @@ export const getTupleEq: <T extends ReadonlyArray<Eq<any>>>(
 ) => Eq<{ [K in keyof T]: T[K] extends Eq<infer A> ? A : never }> = tuple
 
 /**
- * Use `struct` instead.
+ * Use `struct.getEq` instead.
  *
  * @category combinators
  * @since 2.0.0
  * @deprecated
  */
-export const getStructEq: <O extends ReadonlyRecord<string, any>>(eqs: { [K in keyof O]: Eq<O[K]> }) => Eq<O> = struct
+export const getStructEq: <O extends ReadonlyRecord<string, any>>(eqs: { [K in keyof O]: Eq<O[K]> }) => Eq<O> = <A>(
+  eqs: { [K in keyof A]: Eq<A[K]> }
+): Eq<{ readonly [K in keyof A]: A[K] }> =>
+  fromEquals((first, second) => {
+    for (const key in eqs) {
+      if (!eqs[key].equals(first[key], second[key])) {
+        return false
+      }
+    }
+    return true
+  })
 
 /**
  * Use `eqStrict` instead

--- a/src/Monoid.ts
+++ b/src/Monoid.ts
@@ -117,41 +117,6 @@ export const reverse = <A>(M: Monoid<A>): Monoid<A> => ({
 })
 
 /**
- * Given a struct of monoids returns a monoid for the struct.
- *
- * @example
- * import { struct } from 'fp-ts/Monoid'
- * import * as N from 'fp-ts/number'
- *
- * interface Point {
- *   readonly x: number
- *   readonly y: number
- * }
- *
- * const M = struct<Point>({
- *   x: N.MonoidSum,
- *   y: N.MonoidSum
- * })
- *
- * assert.deepStrictEqual(M.concat({ x: 1, y: 2 }, { x: 3, y: 4 }), { x: 4, y: 6 })
- *
- * @category combinators
- * @since 2.10.0
- */
-export const struct = <A>(monoids: { [K in keyof A]: Monoid<A[K]> }): Monoid<{ readonly [K in keyof A]: A[K] }> => {
-  const empty: A = {} as any
-  for (const k in monoids) {
-    if (_.hasOwnProperty.call(monoids, k)) {
-      empty[k] = monoids[k].empty
-    }
-  }
-  return {
-    concat: Se.struct(monoids).concat,
-    empty
-  }
-}
-
-/**
  * Given a tuple of monoids returns a monoid for the tuple.
  *
  * @example
@@ -222,7 +187,7 @@ export const getTupleMonoid: <T extends ReadonlyArray<Monoid<any>>>(
 ) => Monoid<{ [K in keyof T]: T[K] extends Se.Semigroup<infer A> ? A : never }> = tuple as any
 
 /**
- * Use `struct` instead.
+ * Use `struct.getMonoid` instead.
  *
  * @category combinators
  * @since 2.0.0
@@ -230,7 +195,19 @@ export const getTupleMonoid: <T extends ReadonlyArray<Monoid<any>>>(
  */
 export const getStructMonoid: <O extends ReadonlyRecord<string, any>>(
   monoids: { [K in keyof O]: Monoid<O[K]> }
-) => Monoid<O> = struct
+) => Monoid<O> = <A>(monoids: { [K in keyof A]: Monoid<A[K]> }): Monoid<{ readonly [K in keyof A]: A[K] }> => {
+  const empty: A = {} as any
+  for (const k in monoids) {
+    if (_.hasOwnProperty.call(monoids, k)) {
+      empty[k] = monoids[k].empty
+    }
+  }
+  return {
+    // tslint:disable-next-line: deprecation
+    concat: Se.getStructSemigroup(monoids).concat,
+    empty
+  }
+}
 
 /**
  * Use `reverse` instead.

--- a/src/Semigroup.ts
+++ b/src/Semigroup.ts
@@ -124,42 +124,6 @@ export const reverse = <A>(S: Semigroup<A>): Semigroup<A> => ({
 })
 
 /**
- * Given a struct of semigroups returns a semigroup for the struct.
- *
- * @example
- * import { struct } from 'fp-ts/Semigroup'
- * import * as N from 'fp-ts/number'
- *
- * interface Point {
- *   readonly x: number
- *   readonly y: number
- * }
- *
- * const S = struct<Point>({
- *   x: N.SemigroupSum,
- *   y: N.SemigroupSum
- * })
- *
- * assert.deepStrictEqual(S.concat({ x: 1, y: 2 }, { x: 3, y: 4 }), { x: 4, y: 6 })
- *
- * @category combinators
- * @since 2.10.0
- */
-export const struct = <A>(
-  semigroups: { [K in keyof A]: Semigroup<A[K]> }
-): Semigroup<{ readonly [K in keyof A]: A[K] }> => ({
-  concat: (first, second) => {
-    const r: A = {} as any
-    for (const k in semigroups) {
-      if (_.hasOwnProperty.call(semigroups, k)) {
-        r[k] = semigroups[k].concat(first[k], second[k])
-      }
-    }
-    return r
-  }
-})
-
-/**
  * Given a tuple of semigroups returns a semigroup for the tuple.
  *
  * @example
@@ -306,7 +270,7 @@ export const getTupleSemigroup: <T extends ReadonlyArray<Semigroup<any>>>(
 ) => Semigroup<{ [K in keyof T]: T[K] extends Semigroup<infer A> ? A : never }> = tuple as any
 
 /**
- * Use `struct` instead.
+ * Use `struct.getSemigroup` instead.
  *
  * @category combinators
  * @since 2.0.0
@@ -314,7 +278,19 @@ export const getTupleSemigroup: <T extends ReadonlyArray<Semigroup<any>>>(
  */
 export const getStructSemigroup: <O extends ReadonlyRecord<string, any>>(
   semigroups: { [K in keyof O]: Semigroup<O[K]> }
-) => Semigroup<O> = struct
+) => Semigroup<O> = <A>(
+  semigroups: { [K in keyof A]: Semigroup<A[K]> }
+): Semigroup<{ readonly [K in keyof A]: A[K] }> => ({
+  concat: (first, second) => {
+    const r: A = {} as any
+    for (const k in semigroups) {
+      if (_.hasOwnProperty.call(semigroups, k)) {
+        r[k] = semigroups[k].concat(first[k], second[k])
+      }
+    }
+    return r
+  }
+})
 
 /**
  * Use `reverse` instead.

--- a/src/Show.ts
+++ b/src/Show.ts
@@ -31,26 +31,6 @@ export interface Show<A> {
  * @category combinators
  * @since 2.10.0
  */
-export const struct = <A>(shows: { [K in keyof A]: Show<A[K]> }): Show<{ readonly [K in keyof A]: A[K] }> => ({
-  show: (a) => {
-    let s = '{'
-    for (const k in shows) {
-      if (_.hasOwnProperty.call(shows, k)) {
-        s += ` ${k}: ${shows[k].show(a[k])},`
-      }
-    }
-    if (s.length > 1) {
-      s = s.slice(0, -1) + ' '
-    }
-    s += '}'
-    return s
-  }
-})
-
-/**
- * @category combinators
- * @since 2.10.0
- */
 export const tuple = <A extends ReadonlyArray<unknown>>(
   ...shows: { [K in keyof A]: Show<A[K]> }
 ): Show<Readonly<A>> => ({
@@ -73,7 +53,7 @@ export const getTupleShow: <T extends ReadonlyArray<Show<any>>>(
 ) => Show<{ [K in keyof T]: T[K] extends Show<infer A> ? A : never }> = tuple
 
 /**
- * Use `struct` instead.
+ * Use `struct.getShow` instead.
  *
  * @category combinators
  * @since 2.0.0
@@ -81,7 +61,21 @@ export const getTupleShow: <T extends ReadonlyArray<Show<any>>>(
  */
 export const getStructShow: <O extends ReadonlyRecord<string, any>>(
   shows: { [K in keyof O]: Show<O[K]> }
-) => Show<O> = struct
+) => Show<O> = <A>(shows: { [K in keyof A]: Show<A[K]> }): Show<{ readonly [K in keyof A]: A[K] }> => ({
+  show: (a) => {
+    let s = '{'
+    for (const k in shows) {
+      if (_.hasOwnProperty.call(shows, k)) {
+        s += ` ${k}: ${shows[k].show(a[k])},`
+      }
+    }
+    if (s.length > 1) {
+      s = s.slice(0, -1) + ' '
+    }
+    s += '}'
+    return s
+  }
+})
 
 /**
  * Use `boolean.Show` instead.

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -1,11 +1,81 @@
 /**
  * @since 2.10.0
  */
+import { Monoid } from './Monoid'
+import { Show } from './Show'
+import { Eq, fromEquals } from './Eq'
 import { getObjectSemigroup, Semigroup } from './Semigroup'
+import * as _ from './internal'
 
-// -------------------------------------------------------------------------------------
-// instances
-// -------------------------------------------------------------------------------------
+/**
+ * @category instances
+ * @since 2.10.0
+ */
+export const getShow = <A>(shows: { [K in keyof A]: Show<A[K]> }): Show<{ readonly [K in keyof A]: A[K] }> => ({
+  show: (a) => {
+    let s = '{'
+    for (const k in shows) {
+      if (_.hasOwnProperty.call(shows, k)) {
+        s += ` ${k}: ${shows[k].show(a[k])},`
+      }
+    }
+    if (s.length > 1) {
+      s = s.slice(0, -1) + ' '
+    }
+    s += '}'
+    return s
+  }
+})
+
+/**
+ * @category instances
+ * @since 2.10.0
+ */
+export const getEq = <A>(eqs: { [K in keyof A]: Eq<A[K]> }): Eq<{ readonly [K in keyof A]: A[K] }> =>
+  fromEquals((first, second) => {
+    for (const key in eqs) {
+      if (!eqs[key].equals(first[key], second[key])) {
+        return false
+      }
+    }
+    return true
+  })
+
+/**
+ * Given a struct of semigroups returns a semigroup for the struct.
+ *
+ * @example
+ * import { getSemigroup } from 'fp-ts/struct'
+ * import * as N from 'fp-ts/number'
+ *
+ * interface Point {
+ *   readonly x: number
+ *   readonly y: number
+ * }
+ *
+ * const S = getSemigroup<Point>({
+ *   x: N.SemigroupSum,
+ *   y: N.SemigroupSum
+ * })
+ *
+ * assert.deepStrictEqual(S.concat({ x: 1, y: 2 }, { x: 3, y: 4 }), { x: 4, y: 6 })
+ *
+ * @category instances
+ * @since 2.10.0
+ */
+export const getSemigroup = <A>(
+  semigroups: { [K in keyof A]: Semigroup<A[K]> }
+): Semigroup<{ readonly [K in keyof A]: A[K] }> => ({
+  concat: (first, second) => {
+    const r: A = {} as any
+    for (const k in semigroups) {
+      if (_.hasOwnProperty.call(semigroups, k)) {
+        r[k] = semigroups[k].concat(first[k], second[k])
+      }
+    }
+    return r
+  }
+})
 
 /**
  * Return a semigroup which works like `Object.assign`.
@@ -26,3 +96,38 @@ import { getObjectSemigroup, Semigroup } from './Semigroup'
  */
 // tslint:disable-next-line: deprecation
 export const getAssignSemigroup: <A extends object = never>() => Semigroup<A> = getObjectSemigroup
+
+/**
+ * Given a struct of monoids returns a monoid for the struct.
+ *
+ * @example
+ * import { getMonoid } from 'fp-ts/struct'
+ * import * as N from 'fp-ts/number'
+ *
+ * interface Point {
+ *   readonly x: number
+ *   readonly y: number
+ * }
+ *
+ * const M = getMonoid<Point>({
+ *   x: N.MonoidSum,
+ *   y: N.MonoidSum
+ * })
+ *
+ * assert.deepStrictEqual(M.concat({ x: 1, y: 2 }, { x: 3, y: 4 }), { x: 4, y: 6 })
+ *
+ * @category instances
+ * @since 2.10.0
+ */
+export const getMonoid = <A>(monoids: { [K in keyof A]: Monoid<A[K]> }): Monoid<{ readonly [K in keyof A]: A[K] }> => {
+  const empty: A = {} as any
+  for (const k in monoids) {
+    if (_.hasOwnProperty.call(monoids, k)) {
+      empty[k] = monoids[k].empty
+    }
+  }
+  return {
+    concat: getSemigroup(monoids).concat,
+    empty
+  }
+}

--- a/test/Eq.ts
+++ b/test/Eq.ts
@@ -50,8 +50,9 @@ describe('Eq', () => {
     U.deepStrictEqual(nbCall, 1)
   })
 
-  it('struct', () => {
-    const E = _.struct<Person>({
+  it('getStructEq', () => {
+    // tslint:disable-next-line: deprecation
+    const E = _.getStructEq<Person>({
       name: S.Eq,
       age: N.Eq
     })

--- a/test/Map.ts
+++ b/test/Map.ts
@@ -8,7 +8,8 @@ import * as O from '../src/Option'
 import * as Ord from '../src/Ord'
 import * as RA from '../src/ReadonlyArray'
 import * as Se from '../src/Semigroup'
-import { struct, Show } from '../src/Show'
+import * as St from '../src/struct'
+import { Show } from '../src/Show'
 import * as S from '../src/string'
 import * as T from '../src/Task'
 import * as assert from 'assert'
@@ -41,7 +42,7 @@ const ordKey = Ord.fromCompare<Key>((x, y) => N.Ord.compare(x.id % 3, y.id % 3))
 
 const eqValue: Eq<Value> = fromEquals((x, y) => x.value % 3 === y.value % 3)
 
-const semigroupValue = Se.struct({ value: N.SemigroupSum })
+const semigroupValue = St.getSemigroup({ value: N.SemigroupSum })
 
 const key1 = { id: 1 }
 const value1 = { value: 1 }
@@ -1030,7 +1031,7 @@ describe('Map', () => {
   })
 
   it('getShow', () => {
-    const showUser: Show<User> = struct({ id: S.Show })
+    const showUser: Show<User> = St.getShow({ id: S.Show })
     const Sh = _.getShow(showUser, S.Show)
     const m1 = new Map<User, string>([])
     U.deepStrictEqual(Sh.show(m1), `new Map([])`)

--- a/test/Monoid.ts
+++ b/test/Monoid.ts
@@ -45,10 +45,14 @@ describe('Monoid', () => {
     U.deepStrictEqual(M.concat(M.empty, 'a'), 'a')
   })
 
-  it('struct', () => {
+  it('getStructMonoid', () => {
+    // tslint:disable-next-line: deprecation
+    U.deepStrictEqual(_.getStructMonoid({ a: S.Monoid }).empty, { a: '' })
+
     // should ignore non own properties
-    const monoids = Object.create({ a: 1 })
-    const s = _.struct(monoids)
+    const monoids1 = Object.create({ a: 1 })
+    // tslint:disable-next-line: deprecation
+    const s = _.getStructMonoid(monoids1)
     U.deepStrictEqual(s.empty, {})
   })
 })

--- a/test/ReadonlyMap.ts
+++ b/test/ReadonlyMap.ts
@@ -9,8 +9,9 @@ import * as Ord from '../src/Ord'
 import * as RA from '../src/ReadonlyArray'
 import * as _ from '../src/ReadonlyMap'
 import * as Se from '../src/Semigroup'
+import * as St from '../src/struct'
 import { separated } from '../src/Separated'
-import { struct, Show } from '../src/Show'
+import { Show } from '../src/Show'
 import * as S from '../src/string'
 import * as T from '../src/Task'
 import * as U from './util'
@@ -42,7 +43,7 @@ const ordKey = Ord.fromCompare<Key>((x, y) => N.Ord.compare(x.id % 3, y.id % 3))
 
 const eqValue: Eq<Value> = fromEquals((x, y) => x.value % 3 === y.value % 3)
 
-const semigroupValue = Se.struct({ value: N.SemigroupSum })
+const semigroupValue = St.getSemigroup({ value: N.SemigroupSum })
 
 const key1 = { id: 1 }
 const value1 = { value: 1 }
@@ -1074,7 +1075,7 @@ describe('ReadonlyMap', () => {
   })
 
   it('getShow', () => {
-    const showUser: Show<User> = struct({ id: S.Show })
+    const showUser: Show<User> = St.getShow({ id: S.Show })
     const Sh = _.getShow(showUser, S.Show)
     const m1 = new Map<User, string>([])
     U.deepStrictEqual(Sh.show(m1), `new Map([])`)

--- a/test/ReadonlySet.ts
+++ b/test/ReadonlySet.ts
@@ -4,6 +4,7 @@ import { left, right } from '../src/Either'
 import * as Eq from '../src/Eq'
 import { pipe } from '../src/function'
 import { none, some as optionSome } from '../src/Option'
+import { getEq } from '../src/struct'
 import * as _ from '../src/ReadonlySet'
 import * as S from '../src/string'
 import * as N from '../src/number'
@@ -113,8 +114,8 @@ describe('ReadonlySet', () => {
       _.partitionMap(N.Eq, S.Eq)((n: number) => (n % 2 === 0 ? left(n) : right(`${n}`)))(new Set([1, 2, 3])),
       separated(new Set([2]), new Set(['1', '3']))
     )
-    const SL = Eq.struct({ value: N.Eq })
-    const SR = Eq.struct({ value: S.Eq })
+    const SL = getEq({ value: N.Eq })
+    const SR = getEq({ value: S.Eq })
     U.deepStrictEqual(
       _.partitionMap(
         SL,

--- a/test/Semigroup.ts
+++ b/test/Semigroup.ts
@@ -50,9 +50,13 @@ describe('Semigroup', () => {
     U.strictEqual(IS.concat(IS.concat('a', 'b'), 'c'), IS.concat('a', IS.concat('b', 'c')))
   })
 
-  it('struct', () => {
+  it('getStructSemigroup', () => {
+    // tslint:disable-next-line: deprecation
+    U.deepStrictEqual(_.getStructSemigroup({ a: S.Semigroup }).concat({ a: 'a' }, { a: 'b' }), { a: 'ab' })
+
     // should ignore non own properties
-    const S = _.struct(Object.create({ a: 1 }))
-    U.deepStrictEqual(S.concat({}, {}), {})
+    // tslint:disable-next-line: deprecation
+    const s = _.getStructSemigroup(Object.create({ a: 1 }))
+    U.deepStrictEqual(s.concat({}, {}), {})
   })
 })

--- a/test/Set.ts
+++ b/test/Set.ts
@@ -4,6 +4,7 @@ import { left, right } from '../src/Either'
 import * as Eq from '../src/Eq'
 import { pipe } from '../src/function'
 import { none, some as optionSome } from '../src/Option'
+import { getEq } from '../src/struct'
 import * as _ from '../src/Set'
 import * as S from '../src/string'
 import * as N from '../src/number'
@@ -109,8 +110,8 @@ describe('Set', () => {
       _.partitionMap(N.Eq, S.Eq)((n: number) => (n % 2 === 0 ? left(n) : right(`${n}`)))(new Set([1, 2, 3])),
       separated(new Set([2]), new Set(['1', '3']))
     )
-    const SL = Eq.struct({ value: N.Eq })
-    const SR = Eq.struct({ value: S.Eq })
+    const SL = getEq({ value: N.Eq })
+    const SR = getEq({ value: S.Eq })
     U.deepStrictEqual(
       _.partitionMap(
         SL,

--- a/test/Show.ts
+++ b/test/Show.ts
@@ -4,12 +4,15 @@ import * as _ from '../src/Show'
 import * as S from '../src/string'
 
 describe('Show', () => {
-  it('struct', () => {
-    U.deepStrictEqual(_.struct({ a: S.Show }).show({ a: 'a' }), '{ a: "a" }')
-    U.deepStrictEqual(_.struct({ a: S.Show, b: N.Show }).show({ a: 'a', b: 1 }), '{ a: "a", b: 1 }')
+  it('getStructShow', () => {
+    // tslint:disable-next-line: deprecation
+    U.deepStrictEqual(_.getStructShow({ a: S.Show }).show({ a: 'a' }), '{ a: "a" }')
+    // tslint:disable-next-line: deprecation
+    U.deepStrictEqual(_.getStructShow({ a: S.Show, b: N.Show }).show({ a: 'a', b: 1 }), '{ a: "a", b: 1 }')
     // should ignore non own properties
     const shows = Object.create({ a: 1 })
-    const s = _.struct(shows)
+    // tslint:disable-next-line: deprecation
+    const s = _.getStructShow(shows)
     U.deepStrictEqual(s.show({}), '{}')
   })
 

--- a/test/Traced.ts
+++ b/test/Traced.ts
@@ -1,7 +1,8 @@
 import * as U from './util'
 import * as B from '../src/boolean'
 import { pipe } from '../src/function'
-import { struct, Monoid } from '../src/Monoid'
+import { getMonoid } from '../src/struct'
+import { Monoid } from '../src/Monoid'
 import * as _ from '../src/Traced'
 
 // Adapted from https://chshersh.github.io/posts/2019-03-25-comonadic-builders
@@ -12,7 +13,7 @@ interface Settings {
   readonly settingsTravis: boolean
 }
 
-const M: Monoid<Settings> = struct({
+const M: Monoid<Settings> = getMonoid({
   settingsHasLibrary: B.MonoidAny,
   settingsGitHub: B.MonoidAny,
   settingsTravis: B.MonoidAny

--- a/test/struct.ts
+++ b/test/struct.ts
@@ -1,7 +1,38 @@
 import * as _ from '../src/struct'
+import * as S from '../src/string'
 import * as U from './util'
+import { Eq as NumberEq, Show as NumberShow } from '../src/number'
 
 describe('struct', () => {
+  it('getShow', () => {
+    U.deepStrictEqual(_.getShow({ a: S.Show }).show({ a: 'a' }), '{ a: "a" }')
+    U.deepStrictEqual(_.getShow({ a: S.Show, b: NumberShow }).show({ a: 'a', b: 1 }), '{ a: "a", b: 1 }')
+    // should ignore non own properties
+    const shows = Object.create({ a: 1 })
+    const s = _.getShow(shows)
+    U.deepStrictEqual(s.show({}), '{}')
+  })
+
+  it('getEq', () => {
+    interface Person {
+      readonly name: string
+      readonly age: number
+    }
+    const E = _.getEq<Person>({
+      name: S.Eq,
+      age: NumberEq
+    })
+    U.deepStrictEqual(E.equals({ name: 'a', age: 1 }, { name: 'a', age: 1 }), true)
+    U.deepStrictEqual(E.equals({ name: 'a', age: 1 }, { name: 'a', age: 2 }), false)
+    U.deepStrictEqual(E.equals({ name: 'a', age: 1 }, { name: 'b', age: 1 }), false)
+  })
+
+  it('getSemigroup', () => {
+    // should ignore non own properties
+    const S = _.getSemigroup(Object.create({ a: 1 }))
+    U.deepStrictEqual(S.concat({}, {}), {})
+  })
+
   it('getAssignSemigroup', () => {
     type T = {
       readonly foo?: number
@@ -16,5 +47,12 @@ describe('struct', () => {
     }
     const S = _.getAssignSemigroup<T>()
     U.deepStrictEqual(S.concat(foo, bar), Object.assign({}, foo, bar))
+  })
+
+  it('getMonoid', () => {
+    // should ignore non own properties
+    const monoids = Object.create({ a: 1 })
+    const s = _.getMonoid(monoids)
+    U.deepStrictEqual(s.empty, {})
   })
 })


### PR DESCRIPTION
This PR relocates `Show.struct`, `Eq.struct`, `Semigroup.struct` and `Monoid.struct` into the new `struct.ts` module.

The deprecated `getStruct*` functions are implemented separately to avoid a circular dependency