### PR TITLE
Add `struct` functions

### DIFF
--- a/docs/modules/struct.ts.md
+++ b/docs/modules/struct.ts.md
@@ -6,18 +6,969 @@ parent: Modules
 
 ## struct overview
 
-Added in v3.0.0
+A 'struct' is a heterogeneous `ReadonlyRecord`, often an `interface`.
+Many of these functions have a `Record._WithIndex` counterpart.
+e.g. struct.mapS <-> Record.mapWithIndex
+
+Added in v2.10.0
 
 ---
 
 <h2 class="text-delta">Table of contents</h2>
 
+- [combinators](#combinators)
+  - [compactS](#compacts)
+  - [filterMapS](#filtermaps)
+  - [filterS](#filters)
+  - [foldMapS](#foldmaps)
+  - [mapS](#maps)
+  - [partitionMapS](#partitionmaps)
+  - [partitionS](#partitions)
+  - [reduceS](#reduces)
+  - [separateS](#separates)
+  - [traverseS](#traverses)
+  - [traverseS\_](#traverses_)
+  - [unCompact](#uncompact)
+  - [wiltS](#wilts)
+  - [witherS](#withers)
+- [destructors](#destructors)
+  - [keys](#keys)
 - [instances](#instances)
   - [getAssignSemigroup](#getassignsemigroup)
-- [utils](#utils)
-  - [evolve](#evolve)
 
 ---
+
+# combinators
+
+## compactS
+
+Given a heterogeneous struct of Options, eliminate
+all keys that are `None` & return a struct of the
+existing values.
+
+**Signature**
+
+```ts
+export declare const compactS: <A>(r: { [K in keyof A]: Option<A[K]> }) => Partial<A>
+```
+
+**Example**
+
+```ts
+import { compactS } from 'fp-ts/struct'
+import * as O from 'fp-ts/Option'
+
+assert.deepStrictEqual(
+  compactS({
+    foo: O.some(123),
+    bar: O.none,
+    baz: O.some('abc'),
+  }),
+  { foo: 123, baz: 'abc' }
+)
+```
+
+Added in v2.10.0
+
+## filterMapS
+
+Given a struct mapping to heterogeneous Optional values,
+filter & trasform a corresponding struct of values.
+
+**Signature**
+
+```ts
+export declare const filterMapS: <A, C extends { [K in keyof A]: (v: A[K]) => Option<unknown> }>(
+  f: C
+) => (fa: NonEmpty<A>) => { [K in keyof A]?: (ReturnType<C[K]> extends Option<infer A> ? A : never) | undefined }
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/function'
+import { filterMapS } from 'fp-ts/struct'
+import * as O from 'fp-ts/Option'
+
+assert.deepStrictEqual(
+  pipe(
+    { a: 'a', b: 1 },
+    filterMapS({
+      a: () => O.none,
+      b: (n) => (n === 1 ? O.some(n + 1) : O.none),
+    })
+  ),
+  { b: 2 }
+)
+```
+
+Added in v2.10.0
+
+## filterS
+
+Given a struct of predicates, filter & potentially refine
+a corresponding struct of values.
+
+**Signature**
+
+```ts
+export declare const filterS: <A, B extends { [K in keyof A]: Predicate<A[K]> | Refinement<A[K], any> }>(
+  predicates: B
+) => (fa: NonEmpty<A>) => { [K in keyof A]?: (B[K] extends (a: any) => a is infer C ? C : A[K]) | undefined }
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/function'
+import { filterS } from 'fp-ts/struct'
+
+assert.deepStrictEqual(
+  pipe(
+    { a: 'a', b: 1 },
+    filterS({
+      a: (a) => a === 'b',
+      b: (b): b is 1 => b === 1,
+    })
+  ),
+  { b: 1 } as const
+)
+```
+
+Added in v2.10.0
+
+## foldMapS
+
+Given a monoid and a struct of functions outputting its type parameter,
+fold a corresponding struct of values into a single value.
+
+**Signature**
+
+```ts
+export declare const foldMapS: (
+  O: Ord<string>
+) => <M>(M: Monoid<M>) => <A>(f: { [key in keyof A]: (a: A[key]) => M }) => (fa: NonEmpty<A>) => M
+```
+
+**Example**
+
+```ts
+import { pipe, identity } from 'fp-ts/function'
+import { foldMapS } from 'fp-ts/struct'
+import * as S from 'fp-ts/string'
+
+assert.deepStrictEqual(
+  pipe(
+    { a: 'a', b: 1 },
+    foldMapS(S.Ord)(S.Monoid)({
+      a: identity,
+      b: (b) => b.toString(),
+    })
+  ),
+  'a1'
+)
+```
+
+Added in v2.10.0
+
+## mapS
+
+Given a struct of functions map a corresponding struct of values.
+
+**Signature**
+
+```ts
+export declare const mapS: <A, B extends { [k in keyof A]: (val: A[k]) => unknown }>(
+  f: B
+) => (a: NonEmpty<A>) => { [key in keyof A]: ReturnType<B[key]> }
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/function'
+import { mapS } from 'fp-ts/struct'
+
+assert.deepStrictEqual(
+  pipe(
+    { a: 'a', b: 1 },
+    mapS({
+      a: (a) => a.length,
+      b: (b) => b * 2,
+    })
+  ),
+  { a: 1, b: 2 }
+)
+```
+
+Added in v2.10.0
+
+## partitionMapS
+
+Given a struct mapping to heterogeneous Optional values,
+trasform & split a corresponding struct of values
+into a failing `left` struct and a passing `right` struct.
+
+**Signature**
+
+```ts
+export declare const partitionMapS: <R, B extends { [K in keyof R]: (val: R[K]) => Either<unknown, unknown> }>(
+  f: B
+) => (
+  fa: NonEmpty<R>
+) => Separated<
+  { [K in keyof R]?: (ReturnType<B[K]> extends Either<infer E, unknown> ? E : never) | undefined },
+  { [K in keyof R]?: (ReturnType<B[K]> extends Either<unknown, infer A> ? A : never) | undefined }
+>
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/function'
+import { partitionMapS } from 'fp-ts/struct'
+import * as E from 'fp-ts/Either'
+import { separated } from 'fp-ts/Separated'
+
+assert.deepStrictEqual(
+  pipe(
+    { a: 'a', b: 1 },
+    partitionMapS({
+      a: () => E.left('fail'),
+      b: (n) => (n === 1 ? E.right(n + 1) : E.left(n - 1)),
+    })
+  ),
+  separated({ a: 'fail' }, { b: 2 })
+)
+```
+
+Added in v2.10.0
+
+## partitionS
+
+Given a struct of predicates, split & potentially refine
+a corresponding struct of values into a failing `left` struct
+and a passing `right` struct.
+
+**Signature**
+
+```ts
+export declare const partitionS: <R, B extends { [K in keyof R]: Predicate<R[K]> | Refinement<R[K], any> }>(
+  f: B
+) => (
+  fa: NonEmpty<R>
+) => Separated<Partial<R>, { [K in keyof R]?: (B[K] extends (a: any) => a is infer C ? C : R[K]) | undefined }>
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/function'
+import { partitionS } from 'fp-ts/struct'
+import { separated } from 'fp-ts/Separated'
+
+assert.deepStrictEqual(
+  pipe(
+    { a: 'b', b: 1 },
+    partitionS({
+      a: (s) => s === 'a',
+      b: (n): n is 1 => n === 1,
+    })
+  ),
+  separated({ a: 'b' }, { b: 1 } as const)
+)
+```
+
+Added in v2.10.0
+
+## reduceS
+
+Given a struct of functions reduce a corresponding struct of values
+down to a single value.
+
+**Signature**
+
+```ts
+export declare const reduceS: (
+  O: Ord<string>
+) => <A, B>(b: B, f: { [K in keyof A]: (b: B, a: A[K]) => B }) => (fa: NonEmpty<A>) => B
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/function'
+import { reduceS } from 'fp-ts/struct'
+import { Ord } from 'fp-ts/string'
+import { reverse } from 'fp-ts/Ord'
+
+assert.deepStrictEqual(
+  pipe(
+    { a: 'a', b: 1 },
+    reduceS(Ord)('', {
+      a: (acc, cur) => acc + cur,
+      b: (acc, cur) => acc + cur.toString(),
+    })
+  ),
+  'a1'
+)
+
+assert.deepStrictEqual(
+  pipe(
+    { a: 'a', b: 1 },
+    reduceS(reverse(Ord))('', {
+      a: (acc, cur) => acc + cur,
+      b: (acc, cur) => acc + cur.toString(),
+    })
+  ),
+  '1a'
+)
+```
+
+Added in v2.10.0
+
+## separateS
+
+Split a heterogeneous struct of Either values into a failing
+struct of its `lefts` and a struct of its `rights`.
+
+**Signature**
+
+```ts
+export declare const separateS: <R extends Readonly<Record<string, Either<unknown, unknown>>>>(
+  r: R
+) => Separated<
+  { [K in keyof R]?: (R[K] extends Either<infer E, unknown> ? E : never) | undefined },
+  { [K in keyof R]?: (R[K] extends Either<unknown, infer A> ? A : never) | undefined }
+>
+```
+
+**Example**
+
+```ts
+import { separateS } from 'fp-ts/struct'
+import * as E from 'fp-ts/Either'
+import { separated } from 'fp-ts/Separated'
+
+assert.deepStrictEqual(
+  separateS({ foo: E.right(123), bar: E.left('fail'), baz: E.right('abc') }),
+  separated({ bar: 'fail' }, { foo: 123, baz: 'abc' })
+)
+```
+
+Added in v2.10.0
+
+## traverseS
+
+Runs an separate action for each value in a struct, and accumulates the results.
+
+A pipeable version of `traverseS_`
+
+**Signature**
+
+```ts
+export declare function traverseS(
+  O: Ord<string>
+): {
+  <F extends URIS4>(F: Apply4<F>): <
+    S,
+    R,
+    E,
+    A,
+    B extends { [key in keyof A]: (val: A[key]) => Kind4<F, S, R, E, unknown> }
+  >(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => Kind4<
+    F,
+    S,
+    R,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind4<F, S, R, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS3>(F: Apply3<F>): <R, E, A, B extends { [key in keyof A]: (val: A[key]) => Kind3<F, R, E, unknown> }>(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => Kind3<
+    F,
+    R,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind3<F, R, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS3, E>(F: Apply3C<F, E>): <
+    R,
+    A,
+    B extends { [key in keyof A]: (val: A[key]) => Kind3<F, R, E, unknown> }
+  >(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => Kind3<
+    F,
+    R,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind3<F, R, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS2>(F: Apply2<F>): <E, A, B extends { [key in keyof A]: (val: A[key]) => Kind2<F, E, unknown> }>(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => Kind2<
+    F,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind2<F, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS2, E>(F: Apply2C<F, E>): <A, B extends { [key in keyof A]: (val: A[key]) => Kind2<F, E, unknown> }>(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => Kind2<
+    F,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind2<F, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS>(F: Apply1<F>): <A, B extends { [key in keyof A]: (val: A[key]) => Kind<F, unknown> }>(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => Kind<
+    F,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind<F, infer C> ? C : never
+    }
+  >
+  <F>(F: Apply<F>): <A, B extends { [key in keyof A]: (val: A[key]) => HKT<F, unknown> }>(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => HKT<
+    F,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends HKT<F, infer C> ? C : never
+    }
+  >
+}
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/function'
+import { traverseS } from 'fp-ts/struct'
+import { Ord } from 'fp-ts/string'
+import * as O from 'fp-ts/Option'
+
+assert.deepStrictEqual(
+  pipe(
+    { a: 1, b: 'b' },
+    traverseS(Ord)(O.Apply)({
+      a: (n) => (n <= 2 ? O.some(n.toString()) : O.none),
+      b: (b) => (b.length <= 2 ? O.some(b.length) : O.none),
+    })
+  ),
+  O.some({ a: '1', b: 1 })
+)
+```
+
+Added in v2.10.0
+
+## traverseS\_
+
+Runs an separate action for each value in a struct, and accumulates the results.
+
+A non-pipeable version of `traverseS`
+
+**Signature**
+
+```ts
+export declare function traverseS_(
+  O: Ord<string>
+): {
+  <F extends URIS4>(F: Apply4<F>): <
+    S,
+    R,
+    E,
+    B extends R.ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => Kind4<
+    F,
+    S,
+    R,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind4<F, S, R, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS3>(F: Apply3<F>): <
+    R,
+    E,
+    B extends R.ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => Kind3<
+    F,
+    R,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind3<F, R, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS3, E>(F: Apply3C<F, E>): <
+    R,
+    B extends R.ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => Kind3<
+    F,
+    R,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind3<F, R, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS2>(F: Apply2<F>): <
+    E,
+    B extends R.ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => Kind2<
+    F,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind2<F, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS2, E>(F: Apply2C<F, E>): <
+    B extends R.ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => Kind2<
+    F,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind2<F, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS>(F: Apply1<F>): <
+    B extends R.ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => Kind<
+    F,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind<F, infer C> ? C : never
+    }
+  >
+  <F>(F: Apply<F>): <
+    B extends R.ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => HKT<
+    F,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends HKT<F, infer C> ? C : never
+    }
+  >
+}
+```
+
+**Example**
+
+```ts
+import { traverseS_ } from 'fp-ts/struct'
+import { Ord } from 'fp-ts/string'
+import * as O from 'fp-ts/Option'
+
+const f = {
+  a: (n: number) => (n <= 2 ? O.some(n.toString()) : O.none),
+  b: (b: string) => (b.length <= 2 ? O.some(b.length) : O.none),
+}
+
+assert.deepStrictEqual(traverseS_(Ord)(O.Apply)({ a: 1, b: 'b' }, f), O.some({ a: '1', b: 1 }))
+assert.deepStrictEqual(traverseS_(Ord)(O.Apply)({ a: 3, b: '2' }, f), O.none)
+```
+
+Added in v2.10.0
+
+## unCompact
+
+Wrap each key in heterogeneous struct of nullable values in `Option`.
+
+Note: cannot properly wrap optional/partial keys.
+
+**Signature**
+
+```ts
+export declare const unCompact: <A>(a: NonEmpty<A>) => { [K in keyof A]: Option<NonNullable<A[K]>> }
+```
+
+**Example**
+
+```ts
+import { unCompact } from 'fp-ts/struct'
+import * as O from 'fp-ts/Option'
+
+assert.deepStrictEqual(unCompact({ foo: 123, bar: undefined, baz: 'abc' }), {
+  foo: O.some(123),
+  bar: O.none,
+  baz: O.some('abc'),
+})
+```
+
+Added in v2.10.0
+
+## wiltS
+
+Applies a `traverseS` and a `partitionMap` as a single combined operation.
+
+**Signature**
+
+```ts
+export declare const wiltS: (
+  O: Ord<string>
+) => {
+  <F extends 'ReaderEither' | 'ReaderTaskEither'>(F: Apply3<F>): <
+    R,
+    E,
+    A,
+    B extends { [K in keyof A]: (val: A[K]) => Kind3<F, R, E, Either<unknown, unknown>> }
+  >(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind3<
+    F,
+    R,
+    E,
+    Separated<
+      { [K in keyof A]?: (ReturnType<B[K]> extends Kind3<F, R, E, Either<infer L, unknown>> ? L : never) | undefined },
+      { [K in keyof A]?: (ReturnType<B[K]> extends Kind3<F, R, E, Either<unknown, infer R>> ? R : never) | undefined }
+    >
+  >
+  <F extends 'ReaderEither' | 'ReaderTaskEither', E>(F: Apply3C<F, E>): <
+    R,
+    A,
+    B extends { [K in keyof A]: (val: A[K]) => Kind3<F, R, E, Either<unknown, unknown>> }
+  >(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind3<
+    F,
+    R,
+    E,
+    Separated<
+      { [K in keyof A]?: (ReturnType<B[K]> extends Kind3<F, R, E, Either<infer L, unknown>> ? L : never) | undefined },
+      { [K in keyof A]?: (ReturnType<B[K]> extends Kind3<F, R, E, Either<unknown, infer R>> ? R : never) | undefined }
+    >
+  >
+  <
+    F extends
+      | 'Const'
+      | 'Separated'
+      | 'Either'
+      | 'Reader'
+      | 'State'
+      | 'These'
+      | 'IOEither'
+      | 'ReaderTask'
+      | 'TaskEither'
+      | 'Tuple2'
+      | 'ReadonlyMap'
+      | 'Store'
+      | 'TaskThese'
+      | 'Traced'
+      | 'Writer'
+  >(
+    F: Apply2<F>
+  ): <E, A, B extends { [K in keyof A]: (val: A[K]) => Kind2<F, E, Either<unknown, unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind2<
+    F,
+    E,
+    Separated<
+      { [K in keyof A]?: (ReturnType<B[K]> extends Kind2<F, E, Either<infer L, unknown>> ? L : never) | undefined },
+      { [K in keyof A]?: (ReturnType<B[K]> extends Kind2<F, E, Either<unknown, infer R>> ? R : never) | undefined }
+    >
+  >
+  <
+    F extends
+      | 'Const'
+      | 'Separated'
+      | 'Either'
+      | 'Reader'
+      | 'State'
+      | 'These'
+      | 'IOEither'
+      | 'ReaderTask'
+      | 'TaskEither'
+      | 'Tuple2'
+      | 'ReadonlyMap'
+      | 'Store'
+      | 'TaskThese'
+      | 'Traced'
+      | 'Writer',
+    E
+  >(
+    F: Apply2C<F, E>
+  ): <A, B extends { [K in keyof A]: (val: A[K]) => Kind2<F, E, Either<unknown, unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind2<
+    F,
+    E,
+    Separated<
+      { [K in keyof A]?: (ReturnType<B[K]> extends Kind2<F, E, Either<infer L, unknown>> ? L : never) | undefined },
+      { [K in keyof A]?: (ReturnType<B[K]> extends Kind2<F, E, Either<unknown, infer R>> ? R : never) | undefined }
+    >
+  >
+  <
+    F extends
+      | 'Eq'
+      | 'TaskOption'
+      | 'Predicate'
+      | 'ReadonlyRecord'
+      | 'ReadonlyNonEmptyArray'
+      | 'Option'
+      | 'Ord'
+      | 'IO'
+      | 'Task'
+      | 'Identity'
+      | 'ReadonlyArray'
+      | 'Tree'
+  >(
+    F: Apply1<F>
+  ): <A, B extends { [K in keyof A]: (val: A[K]) => Kind<F, Either<unknown, unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind<
+    F,
+    Separated<
+      { [K in keyof A]?: (ReturnType<B[K]> extends Kind<F, Either<infer L, unknown>> ? L : never) | undefined },
+      { [K in keyof A]?: (ReturnType<B[K]> extends Kind<F, Either<unknown, infer R>> ? R : never) | undefined }
+    >
+  >
+  <F>(F: Apply<F>): <A, B extends { [K in keyof A]: (val: A[K]) => HKT<F, Either<unknown, unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => HKT<
+    F,
+    Separated<
+      { [K in keyof A]?: (ReturnType<B[K]> extends HKT<F, Either<infer L, unknown>> ? L : never) | undefined },
+      { [K in keyof A]?: (ReturnType<B[K]> extends HKT<F, Either<unknown, infer R>> ? R : never) | undefined }
+    >
+  >
+}
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/function'
+import { wiltS } from 'fp-ts/struct'
+import * as Tr from 'fp-ts/Tree'
+import * as E from 'fp-ts/Either'
+import { separated } from 'fp-ts/Separated'
+import * as S from 'fp-ts/string'
+
+assert.deepStrictEqual(
+  pipe(
+    { a: 2, b: 'a' },
+    wiltS(S.Ord)(Tr.Apply)({
+      a: (n) => Tr.of(n === 1 ? E.right(n.toString()) : E.left(n - 1)),
+      b: (n) => Tr.of(n === 'a' ? E.right(n.length) : E.left('fail')),
+    })
+  ),
+  Tr.of(separated({ a: 1 }, { b: 1 }))
+)
+```
+
+Added in v2.10.0
+
+## witherS
+
+Applies a traverseS and a filterMap as a single combined operation.
+
+**Signature**
+
+```ts
+export declare const witherS: (
+  O: Ord<string>
+) => {
+  <F extends 'ReaderEither' | 'ReaderTaskEither'>(F: Apply3<F>): <
+    R,
+    E,
+    A,
+    B extends { [K in keyof A]: (val: A[K]) => Kind3<F, R, E, Option<unknown>> }
+  >(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind3<
+    F,
+    R,
+    E,
+    { [K in keyof A]?: (ReturnType<B[K]> extends Kind3<F, R, E, Option<infer C>> ? C : never) | undefined }
+  >
+  <F extends 'ReaderEither' | 'ReaderTaskEither', E>(F: Apply3C<F, E>): <
+    R,
+    A,
+    B extends { [K in keyof A]: (val: A[K]) => Kind3<F, R, E, Option<unknown>> }
+  >(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind3<
+    F,
+    R,
+    E,
+    { [K in keyof A]?: (ReturnType<B[K]> extends Kind3<F, R, E, Option<infer C>> ? C : never) | undefined }
+  >
+  <
+    F extends
+      | 'Const'
+      | 'Separated'
+      | 'Either'
+      | 'Reader'
+      | 'State'
+      | 'These'
+      | 'IOEither'
+      | 'ReaderTask'
+      | 'TaskEither'
+      | 'Tuple2'
+      | 'ReadonlyMap'
+      | 'Store'
+      | 'TaskThese'
+      | 'Traced'
+      | 'Writer',
+    E
+  >(
+    F: Apply2<F>
+  ): <E, A, B extends { [K in keyof A]: (val: A[K]) => Kind2<F, E, Option<unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind2<F, E, { [K in keyof A]?: (ReturnType<B[K]> extends Kind2<F, E, Option<infer C>> ? C : never) | undefined }>
+  <
+    F extends
+      | 'Const'
+      | 'Separated'
+      | 'Either'
+      | 'Reader'
+      | 'State'
+      | 'These'
+      | 'IOEither'
+      | 'ReaderTask'
+      | 'TaskEither'
+      | 'Tuple2'
+      | 'ReadonlyMap'
+      | 'Store'
+      | 'TaskThese'
+      | 'Traced'
+      | 'Writer',
+    E
+  >(
+    F: Apply2C<F, E>
+  ): <A, B extends { [K in keyof A]: (val: A[K]) => Kind2<F, E, Option<unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind2<F, E, { [K in keyof A]?: (ReturnType<B[K]> extends Kind2<F, E, Option<infer C>> ? C : never) | undefined }>
+  <
+    F extends
+      | 'Eq'
+      | 'TaskOption'
+      | 'Predicate'
+      | 'ReadonlyRecord'
+      | 'ReadonlyNonEmptyArray'
+      | 'Option'
+      | 'Ord'
+      | 'IO'
+      | 'Task'
+      | 'Identity'
+      | 'ReadonlyArray'
+      | 'Tree'
+  >(
+    F: Apply1<F>
+  ): <A, B extends { [K in keyof A]: (val: A[K]) => Kind<F, Option<unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind<F, { [K in keyof A]?: (ReturnType<B[K]> extends Kind<F, Option<infer C>> ? C : never) | undefined }>
+  <F>(F: Apply<F>): <A, B extends { [K in keyof A]: (val: A[K]) => HKT<F, Option<unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => HKT<F, { [K in keyof A]?: (ReturnType<B[K]> extends HKT<F, Option<infer C>> ? C : never) | undefined }>
+}
+```
+
+**Example**
+
+```ts
+import { pipe } from 'fp-ts/function'
+import { witherS } from 'fp-ts/struct'
+import * as Tr from 'fp-ts/Tree'
+import * as O from 'fp-ts/Option'
+import * as S from 'fp-ts/string'
+
+assert.deepStrictEqual(
+  pipe(
+    { a: 2, b: 'a' },
+    witherS(S.Ord)(Tr.Apply)({
+      a: (n) => Tr.of(n === 1 ? O.some(n.toString()) : O.none),
+      b: (n) => Tr.of(n === 'a' ? O.some(n.length) : O.none),
+    })
+  ),
+  Tr.of({ b: 1 })
+)
+```
+
+Added in v2.10.0
+
+# destructors
+
+## keys
+
+**Signature**
+
+```ts
+export declare const keys: (O: Ord<string>) => <A>(r: A) => readonly (keyof A)[]
+```
+
+Added in v2.10.0
 
 # instances
 
@@ -44,40 +995,6 @@ interface Person {
 
 const S = getAssignSemigroup<Person>()
 assert.deepStrictEqual(pipe({ name: 'name', age: 23 }, S.concat({ name: 'name', age: 24 })), { name: 'name', age: 24 })
-```
-
-Added in v3.0.0
-
-# utils
-
-## evolve
-
-Creates a new object by recursively evolving a shallow copy of `a`, according to the `transformation` functions.
-
-**Signature**
-
-```ts
-export declare const evolve: <A, F extends { [K in keyof A]: (a: A[K]) => unknown }>(
-  transformations: F
-) => (a: A) => { [K in keyof F]: ReturnType<F[K]> }
-```
-
-**Example**
-
-```ts
-import { pipe } from 'fp-ts/function'
-import { evolve } from 'fp-ts/struct'
-
-assert.deepStrictEqual(
-  pipe(
-    { a: 'a', b: 1 },
-    evolve({
-      a: (a) => a.length,
-      b: (b) => b * 2,
-    })
-  ),
-  { a: 1, b: 2 }
-)
 ```
 
 Added in v3.0.0

--- a/dtslint/ts4.1/struct.ts
+++ b/dtslint/ts4.1/struct.ts
@@ -1,7 +1,6 @@
 import { pipe, identity } from '../../src/function'
 import * as _ from '../../src/struct'
 import * as O from '../../src/Option'
-import * as N from '../../src/number'
 import * as S from '../../src/string'
 import * as E from '../../src/Either'
 import * as Tr from '../../src/Tree'

--- a/dtslint/ts4.1/struct.ts
+++ b/dtslint/ts4.1/struct.ts
@@ -1,0 +1,69 @@
+import { pipe, identity } from '../../src/function'
+import * as _ from '../../src/struct'
+import * as O from '../../src/Option'
+import * as N from '../../src/number'
+import * as S from '../../src/string'
+import * as E from '../../src/Either'
+import * as Tr from '../../src/Tree'
+
+declare const r1: { a: number, b: string }
+
+//
+// mapS
+//
+
+pipe(r1, _.mapS({ a: n => n > 2, b: n => n.length })) // $ExpectType { a: boolean; b: number; }
+
+//
+// reduceS
+//
+
+pipe(r1, _.reduceS(S.Ord)('', { a: (acc, cur) => acc + cur.toString(), b: (acc, cur) => acc + cur })) // $ExpectType string
+
+pipe(r1, _.foldMapS(S.Ord)(S.Monoid)({ a: k => k.toString(), b: identity })) // $ExpectType string
+
+pipe(r1, _.filterS({ a: (k): k is 1 => k === 1, b: () => false })) // $ExpectType { a?: 1 | undefined; b?: string | undefined; }
+
+pipe(r1, _.filterMapS({ a: (n) => (n === 1 ? O.some(n + 1) : O.none), b: () => O.none })) // $ExpectType { a?: number | undefined; b?: undefined; }
+
+pipe(r1, _.partitionS({ a: (k): k is 1 => k === 1, b: () => false })) // $ExpectType Separated<Partial<{ a: number; b: string; }>, { a?: 1 | undefined; b?: string | undefined; }>
+
+const a = pipe(
+  r1,
+  _.partitionMapS({
+    a: (n): E.Either<number, number> => n === 1 ? E.right(n + 1) : E.left(n - 1),
+    b: () => E.left('fail')
+  })
+)
+a // $ExpectType Separated<{ a?: number | undefined; b?: string | undefined; }, { a?: number | undefined; b?: unknown; }>
+
+_.compactS({ a: O.some(1), b: O.some('a') }) // $ExpectType Partial<{ a: number; b: string; }>
+
+_.unCompact({ a: 1, b: undefined }) // $ExpectType { a: Option<number>; b: Option<never>; }
+
+const b = _.separateS({
+  foo: E.right(123), bar: E.left('fail'), baz: E.right('abc')
+})
+b // $ExpectType Separated<{ foo?: unknown; bar?: string | undefined; baz?: unknown; }, { foo?: number | undefined; bar?: unknown; baz?: string | undefined; }>
+
+pipe(r1, _.traverseS(S.Ord)(O.Apply)({ a: (n) => O.some(n), b: (n) => O.some(n)})) // $ExpectType Option<{ a: number; b: string; }>
+
+const c = pipe(
+  r1,
+  _.witherS(S.Ord)(Tr.Apply)({
+    a: (n) => Tr.of(n === 1 ? O.some(n.toString()) : O.none),
+    b: (n) => Tr.of(n === 'a' ? O.some(n.length) : O.none)
+  })
+)
+c // $ExpectType Tree<{ a?: string | undefined; b?: number | undefined; }>
+
+const d = pipe(
+  r1,
+  _.wiltS(S.Ord)(Tr.Apply)({
+    a: (n) => Tr.of<E.Either<number, string>>(n === 1 ? E.right(n.toString()) : E.left(n - 1)),
+    b: (n) => Tr.of<E.Either<string, number>>(n === 'a' ? E.right(n.length) : E.left('fail'))
+  })
+)
+d // $ExpectType Tree<Separated<{ a?: number | undefined; b?: string | undefined; }, { a?: string | undefined; b?: number | undefined; }>>
+
+_.traverseS_(S.Ord)(O.Apply)(r1, { a: (n: number) => O.some(n), b: (n: string) => O.some(n)}) // $ExpectType Option<{ a: number; b: string; }>

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -1,8 +1,857 @@
 /**
- * @since 3.0.0
+ *
+ * A 'struct' is a heterogeneous `ReadonlyRecord`, often an `interface`.
+ * Many of these functions have a `Record._WithIndex` counterpart.
+ * e.g. struct.mapS <-> Record.mapWithIndex
+ *
+ * @since 2.10.0
  */
-import type { Semigroup } from './Semigroup'
+import { pipe } from './function'
+import { URIS3, Kind3, URIS2, Kind2, URIS, Kind, URIS4, Kind4, HKT } from './HKT'
+import * as R from './ReadonlyRecord'
+import { Option, fromNullable } from './Option'
+import { Monoid } from './Monoid'
+import { Either } from './Either'
+import { Separated } from './Separated'
+import { Ord } from './Ord'
+import { Ord as StringOrd } from './string'
+import { Apply4, Apply3, Apply3C, Apply2, Apply2C, Apply1, Apply } from './Apply'
+import { Semigroup } from './Semigroup'
 import * as _ from './internal'
+import { Predicate } from './Predicate'
+import { Refinement } from './Refinement'
+
+type NonEmpty<R> = keyof R extends never ? never : R extends object ? R : never
+type RR = Readonly<Record<string, unknown>>
+
+/**
+ * @category destructors
+ * @since 2.10.0
+ */
+export const keys = (O: Ord<string>) => <A>(r: A): ReadonlyArray<keyof A> =>
+  Object.keys(r).sort((first, second) => O.compare(second)(first)) as Array<keyof A>
+
+/**
+ * Given a struct of functions map a corresponding struct of values.
+ *
+ * @example
+ * import { pipe } from 'fp-ts/function'
+ * import { mapS } from 'fp-ts/struct'
+ *
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     { a: 'a', b: 1 },
+ *     mapS({
+ *       a: (a) => a.length,
+ *       b: (b) => b * 2
+ *     })
+ *   ),
+ *   { a: 1, b: 2 }
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const mapS = <A, B extends { [k in keyof A]: (val: A[k]) => unknown }>(f: B) => (
+  a: NonEmpty<A>
+): { [key in keyof A]: ReturnType<B[key]> } => R.mapWithIndex((k, r) => f[k as keyof A](r as any))(a as RR) as any
+
+/**
+ * Given a struct of functions reduce a corresponding struct of values
+ * down to a single value.
+ *
+ * @example
+ * import { pipe } from 'fp-ts/function'
+ * import { reduceS } from 'fp-ts/struct'
+ * import { Ord } from 'fp-ts/string'
+ * import { reverse } from 'fp-ts/Ord'
+ *
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     { a: 'a', b: 1 },
+ *     reduceS(Ord)('', {
+ *       a: (acc, cur) => acc + cur,
+ *       b: (acc, cur) => acc + cur.toString()
+ *     })
+ *   ),
+ *   'a1'
+ * )
+ *
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     { a: 'a', b: 1 },
+ *     reduceS(reverse(Ord))('', {
+ *       a: (acc, cur) => acc + cur,
+ *       b: (acc, cur) => acc + cur.toString()
+ *     })
+ *   ),
+ *   '1a'
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const reduceS = (O: Ord<string>) => <A, B>(b: B, f: { [K in keyof A]: (b: B, a: A[K]) => B }) => (
+  fa: NonEmpty<A>
+): B => R.reduceWithIndex(O)(b, (k, b, v) => f[k as keyof A](b, v as any))(fa as RR)
+
+/**
+ * Given a monoid and a struct of functions outputting its type parameter,
+ * fold a corresponding struct of values into a single value.
+ *
+ * @example
+ * import { pipe, identity } from 'fp-ts/function'
+ * import { foldMapS } from 'fp-ts/struct'
+ * import * as S from 'fp-ts/string'
+ *
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     { a: 'a', b: 1 },
+ *     foldMapS(S.Ord)(S.Monoid)({
+ *       a: identity,
+ *       b: (b) => b.toString()
+ *     })
+ *   ),
+ *   'a1'
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const foldMapS = (O: Ord<string>) => <M>(M: Monoid<M>) => <A>(
+  f: {
+    [key in keyof A]: (a: A[key]) => M
+  }
+) => (fa: NonEmpty<A>): M => R.foldMapWithIndex(O)(M)((k, v) => f[k as keyof A](v as any))(fa as RR)
+
+/**
+ * Given a struct of predicates, filter & potentially refine
+ * a corresponding struct of values.
+ *
+ * @example
+ * import { pipe } from 'fp-ts/function'
+ * import { filterS } from 'fp-ts/struct'
+ *
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     { a: 'a', b: 1 },
+ *     filterS({
+ *       a: (a) => a === 'b',
+ *       b: (b): b is 1 => b === 1
+ *     })
+ *   ),
+ *   { b: 1 } as const
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const filterS = <A, B extends { [K in keyof A]: Predicate<A[K]> | Refinement<A[K], any> }>(predicates: B) => (
+  fa: NonEmpty<A>
+): {
+  [K in keyof A]?: B[K] extends (a: any) => a is infer C ? C : A[K]
+} => R.filterWithIndex((k, v) => predicates[k as keyof A](v as any))(fa as RR) as any
+
+/**
+ * Given a struct mapping to heterogeneous Optional values,
+ * filter & trasform a corresponding struct of values.
+ *
+ * @example
+ * import { pipe } from 'fp-ts/function'
+ * import { filterMapS } from 'fp-ts/struct'
+ * import * as O from 'fp-ts/Option'
+ *
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     { a: 'a', b: 1 },
+ *     filterMapS({
+ *       a: () => O.none,
+ *       b: (n) => n === 1 ? O.some(n + 1) : O.none
+ *     })
+ *   ),
+ *   { b: 2 }
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const filterMapS = <A, C extends { [K in keyof A]: (v: A[K]) => Option<unknown> }>(f: C) => (
+  fa: NonEmpty<A>
+): {
+  [K in keyof A]?: ReturnType<C[K]> extends Option<infer A> ? A : never
+} => R.filterMapWithIndex((k, v) => f[k as keyof A](v as any))(fa as RR) as any
+
+/**
+ * Given a struct of predicates, split & potentially refine
+ * a corresponding struct of values into a failing `left` struct
+ * and a passing `right` struct.
+ *
+ * @example
+ * import { pipe } from 'fp-ts/function'
+ * import { partitionS } from 'fp-ts/struct'
+ * import { separated } from 'fp-ts/Separated'
+ *
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     { a: 'b', b: 1 },
+ *     partitionS({
+ *       a: (s) => s === 'a',
+ *       b: (n): n is 1 => n === 1,
+ *     })
+ *   ),
+ *   separated({ a: 'b' }, { b: 1 } as const)
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const partitionS = <R, B extends { [K in keyof R]: Predicate<R[K]> | Refinement<R[K], any> }>(f: B) => (
+  fa: NonEmpty<R>
+): Separated<Partial<R>, { [K in keyof R]?: B[K] extends (a: any) => a is infer C ? C : R[K] }> =>
+  R.partitionWithIndex((k, v) => f[k as keyof R](v as any))(fa as RR) as any
+
+/**
+ * Given a struct mapping to heterogeneous Optional values,
+ * trasform & split a corresponding struct of values
+ * into a failing `left` struct and a passing `right` struct.
+ *
+ * @example
+ * import { pipe } from 'fp-ts/function'
+ * import { partitionMapS } from 'fp-ts/struct'
+ * import * as E from 'fp-ts/Either'
+ * import { separated } from 'fp-ts/Separated'
+ *
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     { a: 'a', b: 1 },
+ *     partitionMapS({
+ *       a: () => E.left('fail'),
+ *       b: (n) => n === 1 ? E.right(n + 1) : E.left(n - 1)
+ *     })
+ *   ),
+ *   separated({ a: 'fail' }, { b: 2 })
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const partitionMapS = <R, B extends { [K in keyof R]: (val: R[K]) => Either<unknown, unknown> }>(f: B) => (
+  fa: NonEmpty<R>
+): Separated<
+  { [K in keyof R]?: ReturnType<B[K]> extends Either<infer E, unknown> ? E : never },
+  { [K in keyof R]?: ReturnType<B[K]> extends Either<unknown, infer A> ? A : never }
+> => R.partitionMapWithIndex((k, v) => f[k as keyof R](v as any))(fa as RR) as any
+
+/**
+ * Given a heterogeneous struct of Options, eliminate
+ * all keys that are `None` & return a struct of the
+ * existing values.
+ *
+ * @example
+ * import { compactS } from 'fp-ts/struct'
+ * import * as O from 'fp-ts/Option'
+ *
+ * assert.deepStrictEqual(
+ *   compactS({
+ *     foo: O.some(123),
+ *     bar: O.none,
+ *     baz: O.some('abc')
+ *   }),
+ *   { foo: 123, baz: 'abc' }
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const compactS: <A>(r: { [K in keyof A]: Option<A[K]> }) => Partial<A> = R.compact as any
+
+/**
+ * Wrap each key in heterogeneous struct of nullable values in `Option`.
+ *
+ * Note: cannot properly wrap optional/partial keys.
+ *
+ * @example
+ * import { unCompact } from 'fp-ts/struct'
+ * import * as O from 'fp-ts/Option'
+ *
+ * assert.deepStrictEqual(
+ *   unCompact({ foo: 123, bar: undefined, baz: 'abc' }),
+ *   { foo: O.some(123), bar: O.none, baz: O.some('abc') }
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const unCompact = <A>(
+  a: NonEmpty<A>
+): {
+  [K in keyof A]: Option<NonNullable<A[K]>>
+} => {
+  const ks = keys(StringOrd)(a) as Array<keyof A>
+  const ops = {} as { [K in keyof A]: Option<NonNullable<A[K]>> }
+  for (const key of ks) {
+    ops[key] = fromNullable(a[key])
+  }
+  return ops
+}
+
+/**
+ * Split a heterogeneous struct of Either values into a failing
+ * struct of its `lefts` and a struct of its `rights`.
+ *
+ * @example
+ * import { separateS } from 'fp-ts/struct'
+ * import * as E from 'fp-ts/Either'
+ * import { separated } from 'fp-ts/Separated'
+ *
+ * assert.deepStrictEqual(
+ *   separateS({ foo: E.right(123), bar: E.left('fail'), baz: E.right('abc') }),
+ *   separated({ bar: 'fail' }, { foo: 123, baz: 'abc' })
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const separateS: <R extends R.ReadonlyRecord<string, Either<unknown, unknown>>>(
+  r: R
+) => Separated<
+  { [K in keyof R]?: R[K] extends Either<infer E, unknown> ? E : never },
+  { [K in keyof R]?: R[K] extends Either<unknown, infer A> ? A : never }
+> = R.separate as any
+
+/**
+ * Runs an separate action for each value in a struct, and accumulates the results.
+ *
+ * A pipeable version of `traverseS_`
+ *
+ * @example
+ * import { pipe } from 'fp-ts/function'
+ * import { traverseS } from 'fp-ts/struct'
+ * import { Ord } from 'fp-ts/string'
+ * import * as O from 'fp-ts/Option'
+ *
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     { a: 1, b: 'b' },
+ *     traverseS(Ord)(O.Apply)({
+ *       a: (n) => n <= 2 ? O.some(n.toString()) : O.none,
+ *       b: (b) => b.length <= 2 ? O.some(b.length) : O.none
+ *     })
+ *   ),
+ *   O.some({ a: '1', b: 1 })
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export function traverseS(
+  O: Ord<string>
+): {
+  <F extends URIS4>(F: Apply4<F>): <
+    S,
+    R,
+    E,
+    A,
+    B extends { [key in keyof A]: (val: A[key]) => Kind4<F, S, R, E, unknown> }
+  >(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => Kind4<
+    F,
+    S,
+    R,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind4<F, S, R, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS3>(F: Apply3<F>): <R, E, A, B extends { [key in keyof A]: (val: A[key]) => Kind3<F, R, E, unknown> }>(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => Kind3<
+    F,
+    R,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind3<F, R, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS3, E>(F: Apply3C<F, E>): <
+    R,
+    A,
+    B extends { [key in keyof A]: (val: A[key]) => Kind3<F, R, E, unknown> }
+  >(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => Kind3<
+    F,
+    R,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind3<F, R, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS2>(F: Apply2<F>): <E, A, B extends { [key in keyof A]: (val: A[key]) => Kind2<F, E, unknown> }>(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => Kind2<
+    F,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind2<F, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS2, E>(F: Apply2C<F, E>): <A, B extends { [key in keyof A]: (val: A[key]) => Kind2<F, E, unknown> }>(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => Kind2<
+    F,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind2<F, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS>(F: Apply1<F>): <A, B extends { [key in keyof A]: (val: A[key]) => Kind<F, unknown> }>(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => Kind<
+    F,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind<F, infer C> ? C : never
+    }
+  >
+  <F>(F: Apply<F>): <A, B extends { [key in keyof A]: (val: A[key]) => HKT<F, unknown> }>(
+    f: B
+  ) => (
+    ta: NonEmpty<A>
+  ) => HKT<
+    F,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends HKT<F, infer C> ? C : never
+    }
+  >
+}
+export function traverseS(
+  O: Ord<string>
+): <F>(
+  F: Apply<F>
+) => <A extends R.ReadonlyRecord<string, unknown>, B extends { [key in keyof A]: (val: A[key]) => HKT<F, unknown> }>(
+  f: B
+) => (
+  ta: NonEmpty<A>
+) => HKT<
+  F,
+  {
+    [key in keyof B]: ReturnType<B[key]> extends HKT<F, infer C> ? C : never
+  }
+> {
+  return <F>(F: Apply<F>) => <A, B extends { [key in keyof A]: (val: A[key]) => HKT<F, unknown> }>(f: B) => (
+    ta: NonEmpty<A>
+  ) => {
+    const ks = keys(O)(ta) as Array<keyof A>
+    const length = ks.length
+    let fr = F.map((r) => ({ [ks[0]]: r }))(f[ks[0]](ta[ks[0]] as any)) as HKT<
+      F,
+      {
+        [key in keyof B]: ReturnType<B[key]> extends HKT<F, infer C> ? C : never
+      }
+    >
+    for (let i = 1; i < length; i++) {
+      fr = F.ap(f[ks[i]](ta[ks[i]] as any))(
+        F.map((r: any) => (b: any) => {
+          r[ks[i]] = b
+          return r
+        })(fr)
+      )
+    }
+    return fr as any
+  }
+}
+
+/**
+ * Runs an separate action for each value in a struct, and accumulates the results.
+ *
+ * A non-pipeable version of `traverseS`
+ *
+ * @example
+ * import { traverseS_ } from 'fp-ts/struct'
+ * import { Ord } from 'fp-ts/string'
+ * import * as O from 'fp-ts/Option'
+ *
+ * const f = {
+ *   a: (n: number) => n <= 2 ? O.some(n.toString()) : O.none,
+ *   b: (b: string) => b.length <= 2 ? O.some(b.length) : O.none
+ * }
+ *
+ * assert.deepStrictEqual(
+ *   traverseS_(Ord)(O.Apply)({a: 1, b: 'b' }, f),
+ *   O.some({ a: '1', b: 1 })
+ * )
+ * assert.deepStrictEqual(
+ *   traverseS_(Ord)(O.Apply)({ a: 3, b: '2' }, f),
+ *   O.none
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export function traverseS_(
+  O: Ord<string>
+): {
+  <F extends URIS4>(F: Apply4<F>): <
+    S,
+    R,
+    E,
+    B extends R.ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => Kind4<
+    F,
+    S,
+    R,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind4<F, S, R, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS3>(F: Apply3<F>): <
+    R,
+    E,
+    B extends R.ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => Kind3<
+    F,
+    R,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind3<F, R, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS3, E>(F: Apply3C<F, E>): <
+    R,
+    B extends R.ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => Kind3<
+    F,
+    R,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind3<F, R, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS2>(F: Apply2<F>): <
+    E,
+    B extends R.ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => Kind2<
+    F,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind2<F, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS2, E>(F: Apply2C<F, E>): <
+    B extends R.ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => Kind2<
+    F,
+    E,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind2<F, E, infer C> ? C : never
+    }
+  >
+  <F extends URIS>(F: Apply1<F>): <
+    B extends R.ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => Kind<
+    F,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends Kind<F, infer C> ? C : never
+    }
+  >
+  <F>(F: Apply<F>): <
+    B extends R.ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    fa: NonEmpty<A>,
+    f: B
+  ) => HKT<
+    F,
+    {
+      [key in keyof B]: ReturnType<B[key]> extends HKT<F, infer C> ? C : never
+    }
+  >
+}
+export function traverseS_(
+  O: Ord<string>
+): <F>(
+  F: Apply<F>
+) => <B extends R.ReadonlyRecord<string, (v: never) => unknown>, A extends { [K in keyof B]: Parameters<B[K]>[0] }>(
+  fa: NonEmpty<A>,
+  f: B
+) => HKT<
+  F,
+  {
+    [key in keyof B]: ReturnType<B[key]> extends HKT<F, infer C> ? C : never
+  }
+> {
+  return <F>(F: Apply<F>) => <
+    B extends R.ReadonlyRecord<string, (v: never) => unknown>,
+    A extends { [K in keyof B]: Parameters<B[K]>[0] }
+  >(
+    ta: NonEmpty<A>,
+    f: B
+  ) => traverseS(O)(F)(f as any)(ta as never) as any
+}
+
+/**
+ * Applies a traverseS and a filterMap as a single combined operation.
+ *
+ * @example
+ * import { pipe } from 'fp-ts/function'
+ * import { witherS } from 'fp-ts/struct'
+ * import * as Tr from 'fp-ts/Tree'
+ * import * as O from 'fp-ts/Option'
+ * import * as S from 'fp-ts/string'
+ *
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     { a: 2, b: 'a' },
+ *     witherS(S.Ord)(Tr.Apply)({
+ *       a: (n) => Tr.of(n === 1 ? O.some(n.toString()) : O.none),
+ *       b: (n) => Tr.of(n === 'a' ? O.some(n.length) : O.none)
+ *     })
+ *   ),
+ *   Tr.of({ b: 1 })
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const witherS = (
+  O: Ord<string>
+): {
+  <F extends URIS3>(F: Apply3<F>): <
+    R,
+    E,
+    A,
+    B extends { [K in keyof A]: (val: A[K]) => Kind3<F, R, E, Option<unknown>> }
+  >(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind3<
+    F,
+    R,
+    E,
+    {
+      [K in keyof A]?: ReturnType<B[K]> extends Kind3<F, R, E, Option<infer C>> ? C : never
+    }
+  >
+  <F extends URIS3, E>(F: Apply3C<F, E>): <
+    R,
+    A,
+    B extends { [K in keyof A]: (val: A[K]) => Kind3<F, R, E, Option<unknown>> }
+  >(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind3<
+    F,
+    R,
+    E,
+    {
+      [K in keyof A]?: ReturnType<B[K]> extends Kind3<F, R, E, Option<infer C>> ? C : never
+    }
+  >
+  <F extends URIS2, E>(F: Apply2<F>): <E, A, B extends { [K in keyof A]: (val: A[K]) => Kind2<F, E, Option<unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind2<
+    F,
+    E,
+    {
+      [K in keyof A]?: ReturnType<B[K]> extends Kind2<F, E, Option<infer C>> ? C : never
+    }
+  >
+  <F extends URIS2, E>(F: Apply2C<F, E>): <
+    A,
+    B extends { [K in keyof A]: (val: A[K]) => Kind2<F, E, Option<unknown>> }
+  >(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind2<
+    F,
+    E,
+    {
+      [K in keyof A]?: ReturnType<B[K]> extends Kind2<F, E, Option<infer C>> ? C : never
+    }
+  >
+  <F extends URIS>(F: Apply1<F>): <A, B extends { [K in keyof A]: (val: A[K]) => Kind<F, Option<unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind<
+    F,
+    {
+      [K in keyof A]?: ReturnType<B[K]> extends Kind<F, Option<infer C>> ? C : never
+    }
+  >
+  <F>(F: Apply<F>): <A, B extends { [K in keyof A]: (val: A[K]) => HKT<F, Option<unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => HKT<
+    F,
+    {
+      [K in keyof A]?: ReturnType<B[K]> extends HKT<F, Option<infer C>> ? C : never
+    }
+  >
+} => <F>(F: Apply<F>) => <A>(f: any) => (fa: NonEmpty<A>) => F.map(compactS as any)(pipe(fa, traverseS(O)(F)(f))) as any
+
+/**
+ * Applies a `traverseS` and a `partitionMap` as a single combined operation.
+ *
+ * @example
+ * import { pipe } from 'fp-ts/function'
+ * import { wiltS } from 'fp-ts/struct'
+ * import * as Tr from 'fp-ts/Tree'
+ * import * as E from 'fp-ts/Either'
+ * import { separated } from 'fp-ts/Separated'
+ * import * as S from 'fp-ts/string'
+ *
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     { a: 2, b: 'a' },
+ *     wiltS(S.Ord)(Tr.Apply)({
+ *       a: (n) => Tr.of(n === 1 ? E.right(n.toString()) : E.left(n - 1)),
+ *       b: (n) => Tr.of(n === 'a' ? E.right(n.length) : E.left('fail'))
+ *     })
+ *   ),
+ *   Tr.of(separated({ a: 1 }, { b: 1 }))
+ * )
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export const wiltS = (
+  O: Ord<string>
+): {
+  <F extends URIS3>(F: Apply3<F>): <
+    R,
+    E,
+    A,
+    B extends { [K in keyof A]: (val: A[K]) => Kind3<F, R, E, Either<unknown, unknown>> }
+  >(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind3<
+    F,
+    R,
+    E,
+    Separated<
+      { [K in keyof A]?: ReturnType<B[K]> extends Kind3<F, R, E, Either<infer L, unknown>> ? L : never },
+      { [K in keyof A]?: ReturnType<B[K]> extends Kind3<F, R, E, Either<unknown, infer R>> ? R : never }
+    >
+  >
+  <F extends URIS3, E>(F: Apply3C<F, E>): <
+    R,
+    A,
+    B extends { [K in keyof A]: (val: A[K]) => Kind3<F, R, E, Either<unknown, unknown>> }
+  >(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind3<
+    F,
+    R,
+    E,
+    Separated<
+      { [K in keyof A]?: ReturnType<B[K]> extends Kind3<F, R, E, Either<infer L, unknown>> ? L : never },
+      { [K in keyof A]?: ReturnType<B[K]> extends Kind3<F, R, E, Either<unknown, infer R>> ? R : never }
+    >
+  >
+  <F extends URIS2>(F: Apply2<F>): <
+    E,
+    A,
+    B extends { [K in keyof A]: (val: A[K]) => Kind2<F, E, Either<unknown, unknown>> }
+  >(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind2<
+    F,
+    E,
+    Separated<
+      { [K in keyof A]?: ReturnType<B[K]> extends Kind2<F, E, Either<infer L, unknown>> ? L : never },
+      { [K in keyof A]?: ReturnType<B[K]> extends Kind2<F, E, Either<unknown, infer R>> ? R : never }
+    >
+  >
+  <F extends URIS2, E>(F: Apply2C<F, E>): <
+    A,
+    B extends { [K in keyof A]: (val: A[K]) => Kind2<F, E, Either<unknown, unknown>> }
+  >(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind2<
+    F,
+    E,
+    Separated<
+      { [K in keyof A]?: ReturnType<B[K]> extends Kind2<F, E, Either<infer L, unknown>> ? L : never },
+      { [K in keyof A]?: ReturnType<B[K]> extends Kind2<F, E, Either<unknown, infer R>> ? R : never }
+    >
+  >
+  <F extends URIS>(F: Apply1<F>): <A, B extends { [K in keyof A]: (val: A[K]) => Kind<F, Either<unknown, unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => Kind<
+    F,
+    Separated<
+      { [K in keyof A]?: ReturnType<B[K]> extends Kind<F, Either<infer L, unknown>> ? L : never },
+      { [K in keyof A]?: ReturnType<B[K]> extends Kind<F, Either<unknown, infer R>> ? R : never }
+    >
+  >
+  <F>(F: Apply<F>): <A, B extends { [K in keyof A]: (val: A[K]) => HKT<F, Either<unknown, unknown>> }>(
+    f: B
+  ) => (
+    fa: NonEmpty<A>
+  ) => HKT<
+    F,
+    Separated<
+      { [K in keyof A]?: ReturnType<B[K]> extends HKT<F, Either<infer L, unknown>> ? L : never },
+      { [K in keyof A]?: ReturnType<B[K]> extends HKT<F, Either<unknown, infer R>> ? R : never }
+    >
+  >
+} => <F>(F: Apply<F>) => <A>(f: any) => (fa: NonEmpty<A>) =>
+  F.map(separateS as any)(pipe(fa, traverseS(O)(F)(f))) as any
 
 // -------------------------------------------------------------------------------------
 // instances
@@ -29,39 +878,3 @@ import * as _ from './internal'
 export const getAssignSemigroup = <A = never>(): Semigroup<A> => ({
   concat: (second) => (first) => Object.assign({}, first, second)
 })
-
-// -------------------------------------------------------------------------------------
-// utils
-// -------------------------------------------------------------------------------------
-
-/**
- * Creates a new object by recursively evolving a shallow copy of `a`, according to the `transformation` functions.
- *
- * @example
- * import { pipe } from 'fp-ts/function'
- * import { evolve } from 'fp-ts/struct'
- *
- * assert.deepStrictEqual(
- *   pipe(
- *     { a: 'a', b: 1 },
- *     evolve({
- *       a: (a) => a.length,
- *       b: (b) => b * 2
- *     })
- *   ),
- *   { a: 1, b: 2 }
- * )
- *
- * @since 3.0.0
- */
-export const evolve = <A, F extends { [K in keyof A]: (a: A[K]) => unknown }>(transformations: F) => (
-  a: A
-): { [K in keyof F]: ReturnType<F[K]> } => {
-  const out: Record<string, unknown> = {}
-  for (const k in a) {
-    if (_.hasOwnProperty.call(a, k)) {
-      out[k] = transformations[k](a[k])
-    }
-  }
-  return out as any
-}

--- a/test/struct.ts
+++ b/test/struct.ts
@@ -1,39 +1,268 @@
-import { pipe } from '../src/function'
+import * as E from '../src/Either'
+import { flow, identity, pipe } from '../src/function'
+import * as O from '../src/Option'
 import * as _ from '../src/struct'
+import { separated } from '../src/Separated'
+import * as S from '../src/string'
+import * as T from '../src/Task'
 import * as U from './util'
+import { reverse } from '../src/Ord'
+
+const sp = (s: string): s is 'a' => s === 'a'
+const np = (n: number): n is 1 => n === 1
+
+const noPrototype = Object.create(null)
 
 describe('struct', () => {
-  it('getAssignSemigroup', () => {
-    type T = {
-      readonly foo?: number
-      readonly bar: string
-    }
-    const foo: T = {
-      foo: 123,
-      bar: '456'
-    }
-    const bar: T = {
-      bar: '123'
-    }
-    const S = _.getAssignSemigroup<T>()
-    U.deepStrictEqual(pipe(foo, S.concat(bar)), Object.assign({}, foo, bar))
+  describe('pipeables', () => {
+    it('mapS', () => {
+      U.deepStrictEqual(
+        pipe(
+          { a: 'a', b: 1, c: true },
+          _.mapS({
+            a: (s) => s.length,
+            b: (b) => b > 0,
+            c: (c) => !c
+          })
+        ),
+        { a: 1, b: true, c: false }
+      )
+      // should ignore non own properties
+      const x: Record<'b', number> = Object.create({ a: 1 })
+      x.b = 1
+      U.deepStrictEqual(pipe(x, _.mapS({ b: (b) => b > 0 })), { b: true })
+    })
+
+    it('reduceS', () => {
+      U.deepStrictEqual(
+        pipe(
+          { a: 'a', b: 1 },
+          _.reduceS(S.Ord)('', {
+            a: (acc, cur) => acc + cur,
+            b: (acc, cur) => acc + cur.toString()
+          })
+        ),
+        'a1'
+      )
+      U.deepStrictEqual(
+        pipe(
+          { b: 1, a: 'a' },
+          _.reduceS(S.Ord)('', {
+            a: (acc, cur) => acc + cur,
+            b: (acc, cur) => acc + cur.toString()
+          })
+        ),
+        'a1'
+      )
+      U.deepStrictEqual(
+        pipe(
+          { a: 'a', b: 1 },
+          _.reduceS(reverse(S.Ord))('', {
+            a: (acc, cur) => acc + cur,
+            b: (acc, cur) => acc + cur.toString()
+          })
+        ),
+        '1a'
+      )
+    })
+
+    it('foldMapS', () => {
+      U.deepStrictEqual(
+        pipe({ a: 'a', b: 1 }, _.foldMapS(S.Ord)(S.Monoid)({ a: identity, b: (b) => b.toString() })),
+        'a1'
+      )
+    })
+
+    it('filterS', () => {
+      const d = { a: 'a', b: 1 }
+      U.deepStrictEqual(pipe(d, _.filterS({ a: (a) => a === 'b', b: (b) => b === 1 })), { b: 1 })
+      U.deepStrictEqual(pipe({ a: 1, b: 'foo' }, _.filterS({ a: np, b: sp })), { a: 1 })
+
+      const pass = { a: 1, b: 'a' } as const
+      U.deepStrictEqual(pipe(pass, _.filterS({ a: np, b: sp })), pass)
+
+      const x: { readonly a: 1; readonly b: 'foo' } = Object.assign(Object.create({ c: true }), { a: 1, b: 'foo' })
+      U.deepStrictEqual(pipe(x, _.filterS({ a: np, b: sp })), { a: 1 })
+      U.deepStrictEqual(pipe(noPrototype, _.filterS({})), noPrototype)
+    })
+
+    it('filterMapS', () => {
+      U.deepStrictEqual(
+        pipe(
+          { a: 'a', b: 1 },
+          _.filterMapS({
+            a: () => O.none,
+            b: (n) => (np(n) ? O.some(n + 1) : O.none)
+          })
+        ),
+        { b: 2 }
+      )
+
+      const x: { readonly a: number; readonly b: string } = Object.assign(Object.create({ c: true }), {
+        a: 1,
+        b: 'foo'
+      })
+      U.deepStrictEqual(pipe(x, _.filterMapS({ a: O.fromPredicate(np), b: O.fromPredicate(sp) })), { a: 1 })
+    })
+
+    it('partitionS', () => {
+      U.deepStrictEqual(
+        pipe({ a: 'b', b: 1 }, _.partitionS({ a: sp, b: np })),
+        separated({ a: 'b' }, { b: 1 } as const)
+      )
+
+      const x: { readonly a: number; readonly b: string } = Object.assign(Object.create({ c: true }), {
+        a: 1,
+        b: 'foo'
+      })
+      U.deepStrictEqual(pipe(x, _.partitionS({ a: np, b: sp })), separated({ b: 'foo' }, { a: 1 } as const))
+      U.deepStrictEqual(pipe(noPrototype, _.partitionS({})), separated({}, {}))
+    })
+
+    it('partitionMapS', () => {
+      const f = (n: number) => (np(n) ? E.right(n + 1) : E.left(n - 1))
+      U.deepStrictEqual(
+        pipe(
+          { a: 'a', b: 1 },
+          _.partitionMapS({
+            a: () => E.left('fail'),
+            b: f
+          })
+        ),
+        separated({ a: 'fail' }, { b: 2 })
+      )
+
+      const x: { readonly a: number; readonly b: string } = Object.assign(Object.create({ c: true }), {
+        a: 1,
+        b: 'foo'
+      })
+      U.deepStrictEqual(
+        pipe(
+          x,
+          _.partitionMapS({
+            a: flow(
+              E.fromPredicate(np),
+              E.mapLeft(() => 'fail')
+            ),
+            b: flow(
+              E.fromPredicate(sp),
+              E.mapLeft(() => 'fail')
+            )
+          })
+        ),
+        separated({ b: 'fail' }, { a: 1 } as const)
+      )
+      U.deepStrictEqual(pipe(noPrototype, _.partitionMapS({})), separated({}, {}))
+    })
+
+    it('compactS', () => {
+      U.deepStrictEqual(
+        _.compactS({
+          foo: O.some(123),
+          bar: O.none,
+          baz: O.some('abc')
+        }),
+        { foo: 123, baz: 'abc' }
+      )
+      // should ignore non own properties
+      const o: { readonly b: O.Option<number> } = Object.create({ a: 1 })
+      U.deepStrictEqual(pipe(o, _.compactS), {})
+    })
+
+    it('unCompactS', () => {
+      U.deepStrictEqual(_.unCompact({ foo: 123, bar: undefined, baz: 'abc' }), {
+        foo: O.some(123),
+        bar: O.none,
+        baz: O.some('abc')
+      })
+    })
+
+    it('separateS', () => {
+      U.deepStrictEqual(
+        _.separateS({ foo: E.right(123), bar: E.left('fail'), baz: E.right('abc') }),
+        separated({ bar: 'fail' }, { foo: 123, baz: 'abc' })
+      )
+      // should ignore non own properties
+      const o: { readonly b: E.Either<string, number> } = Object.create({ a: 1 })
+      U.deepStrictEqual(pipe(o, _.separateS), separated({}, {}))
+    })
+
+    it('traverseS', () => {
+      U.deepStrictEqual(
+        pipe(
+          { a: 1, b: 'b' },
+          _.traverseS(S.Ord)(O.Apply)({
+            a: (n) => (n <= 2 ? O.some(n.toString()) : O.none),
+            b: (b) => (b.length <= 2 ? O.some(b.length) : O.none)
+          })
+        ),
+        O.some({ a: '1', b: 1 })
+      )
+      U.deepStrictEqual(
+        pipe(
+          { a: 1, b: '2' },
+          _.traverseS(S.Ord)(O.Apply)({
+            a: (n) => (n >= 2 ? O.some(n.toString()) : O.none),
+            b: () => O.some(3)
+          })
+        ),
+        O.none
+      )
+    })
+
+    it('witherS', async () => {
+      U.deepStrictEqual(
+        await pipe(
+          { a: 2, b: 'a' },
+          _.witherS(S.Ord)(T.ApplyPar)({
+            a: (n) => T.of(np(n) ? O.some(n.toString()) : O.none),
+            b: (n) => T.of(sp(n) ? O.some(n.length) : O.none)
+          })
+        )(),
+        { b: 1 }
+      )
+    })
+
+    it('wiltS', async () => {
+      U.deepStrictEqual(
+        await pipe(
+          { a: 2, b: 'a' },
+          _.wiltS(S.Ord)(T.ApplyPar)({
+            a: (n) => T.of(np(n) ? E.right(n.toString()) : E.left(n - 1)),
+            b: (n) => T.of(sp(n) ? E.right(n.length) : E.left('fail'))
+          })
+        )(),
+        separated({ a: 1 }, { b: 1 })
+      )
+    })
   })
 
-  it('evolve', () => {
-    U.deepStrictEqual(
-      pipe(
-        { a: 'a', b: 1, c: true },
-        _.evolve({
-          a: (s) => s.length,
-          b: (b) => b > 0,
-          c: (c) => !c
-        })
-      ),
-      { a: 1, b: true, c: false }
-    )
-    // should ignore non own properties
-    const x: Record<'b', number> = Object.create({ a: 1 })
-    x.b = 1
-    U.deepStrictEqual(pipe(x, _.evolve({ b: (b) => b > 0 })), { b: true })
+  describe('Non-pipeables', () => {
+    it('traverseS_', () => {
+      const f = {
+        a: (n: number) => (n <= 2 ? O.some(n.toString()) : O.none),
+        b: (b: string) => (b.length <= 2 ? O.some(b.length) : O.none)
+      }
+      U.deepStrictEqual(_.traverseS_(S.Ord)(O.Apply)({ a: 1, b: 'b' }, f), O.some({ a: '1', b: 1 }))
+      U.deepStrictEqual(_.traverseS_(S.Ord)(O.Apply)({ a: 3, b: '2' }, f), O.none)
+    })
+  })
+
+  describe('instances', () => {
+    it('getAssignSemigroup', () => {
+      type T = {
+        readonly foo?: number
+        readonly bar: string
+      }
+      const foo: T = {
+        foo: 123,
+        bar: '456'
+      }
+      const bar: T = {
+        bar: '123'
+      }
+      const S = _.getAssignSemigroup<T>()
+      U.deepStrictEqual(pipe(foo, S.concat(bar)), Object.assign({}, foo, bar))
+    })
   })
 })


### PR DESCRIPTION
This PR adds a few functions to the `struct` module, mostly with an `S` suffix (taking inspiration from `sequenceS`)
 
Notes:
- `traverseS_` is an un-curried version of `traverseS` where the transformation struct can be defined separately. It's named after `Foldable.traverse_`, which looks a bit similar. We can remove this if desired, since `Foldable.traverse_` is deprecated, but I thought it might be useful since `traverseS` won't work outside of `pipe`
- [evolve](https://github.com/gcanti/fp-ts/blob/f1884ce7f064bc62002acbacd6bc51019934771e/src/struct.ts#L57) has been renamed to `mapS` - I'm certainly willing to keep `evolve`, but `mapS` seems to fit the conventions of the module
- Most importantly - `Struct` is not a HKT, so it doesn't necessarily fit the ethos of fp-ts. It's _almost_ a member of many typeclasses (Functor, Traversable, Witherable), but it doesn't fit any of the traditional function signatures. For this reason, it might not be a great fit

Ideas:
- could we add [pick & omit](https://github.com/samhh/fp-ts-std/blob/e5f465778d984f6618d92b3ac419cae8e03551a7/src/Record.ts#L58) from `fp-ts-std`?
- maybe there could be similar functions for `tuple` (e.g. `tuple.evolve` -> `tuple.mapT`)?