### PR TITLE
Backport SK

### DIFF
--- a/docs/modules/function.ts.md
+++ b/docs/modules/function.ts.md
@@ -25,6 +25,7 @@ Added in v2.0.0
   - [Lazy (interface)](#lazy-interface)
   - [Predicate (interface)](#predicate-interface)
   - [Refinement (interface)](#refinement-interface)
+  - [SK](#sk)
   - [absurd](#absurd)
   - [constFalse](#constfalse)
   - [constNull](#constnull)
@@ -226,6 +227,16 @@ export interface Refinement<A, B extends A> {
 ```
 
 Added in v2.0.0
+
+## SK
+
+**Signature**
+
+```ts
+export declare const SK: <A, B>(_: A, b: B) => B
+```
+
+Added in v2.11.0
 
 ## absurd
 

--- a/src/ReadonlyMap.ts
+++ b/src/ReadonlyMap.ts
@@ -9,7 +9,7 @@ import { Filterable2 } from './Filterable'
 import { FilterableWithIndex2C } from './FilterableWithIndex'
 import { Foldable, Foldable1, Foldable2, Foldable2C, Foldable3 } from './Foldable'
 import { FoldableWithIndex2C } from './FoldableWithIndex'
-import { pipe, Predicate, Refinement } from './function'
+import { pipe, Predicate, Refinement, SK } from './function'
 import { flap as flap_, Functor2 } from './Functor'
 import { FunctorWithIndex2C } from './FunctorWithIndex'
 import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3 } from './HKT'
@@ -937,7 +937,7 @@ export const getTraversableWithIndex = <K>(O: Ord<K>): TraversableWithIndex2C<UR
 
   const sequence = <F>(F: Applicative<F>): (<A>(ta: ReadonlyMap<K, HKT<F, A>>) => HKT<F, ReadonlyMap<K, A>>) => {
     const traverseWithIndexF = traverseWithIndex(F)
-    return (ta) => traverseWithIndexF(ta, (_, a) => a)
+    return (ta) => traverseWithIndexF(ta, SK)
   }
   return {
     URI,

--- a/src/ReadonlyNonEmptyArray.ts
+++ b/src/ReadonlyNonEmptyArray.ts
@@ -21,7 +21,7 @@ import { Eq, fromEquals } from './Eq'
 import { Extend1 } from './Extend'
 import { Foldable1 } from './Foldable'
 import { FoldableWithIndex1 } from './FoldableWithIndex'
-import { Endomorphism, identity, Lazy, pipe, Predicate, Refinement } from './function'
+import { Endomorphism, identity, Lazy, pipe, Predicate, Refinement, SK } from './function'
 import { bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import { FunctorWithIndex1 } from './FunctorWithIndex'
 import { HKT } from './HKT'
@@ -749,7 +749,7 @@ export const traverse: PipeableTraverse1<URI> = <F>(
  */
 export const sequence: Traversable1<URI>['sequence'] = <F>(
   F: ApplicativeHKT<F>
-): (<A>(as: ReadonlyNonEmptyArray<HKT<F, A>>) => HKT<F, ReadonlyNonEmptyArray<A>>) => traverseWithIndex(F)((_, a) => a)
+): (<A>(as: ReadonlyNonEmptyArray<HKT<F, A>>) => HKT<F, ReadonlyNonEmptyArray<A>>) => traverseWithIndex(F)(SK)
 
 /**
  * @category TraversableWithIndex

--- a/src/ReadonlyRecord.ts
+++ b/src/ReadonlyRecord.ts
@@ -9,7 +9,7 @@ import { Filterable1 } from './Filterable'
 import { FilterableWithIndex1, PredicateWithIndex, RefinementWithIndex } from './FilterableWithIndex'
 import { Foldable as FoldableHKT, Foldable1, Foldable2, Foldable3 } from './Foldable'
 import { FoldableWithIndex1 } from './FoldableWithIndex'
-import { identity, pipe, Predicate, Refinement } from './function'
+import { identity, pipe, Predicate, Refinement, SK } from './function'
 import { flap as flap_, Functor1 } from './Functor'
 import { FunctorWithIndex1 } from './FunctorWithIndex'
 import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3 } from './HKT'
@@ -508,7 +508,7 @@ export function sequence<F>(
 export function sequence<F>(
   F: Applicative<F>
 ): <A>(ta: ReadonlyRecord<string, HKT<F, A>>) => HKT<F, ReadonlyRecord<string, A>> {
-  return traverseWithIndex(F)((_, a) => a)
+  return traverseWithIndex(F)(SK)
 }
 
 /**

--- a/src/function.ts
+++ b/src/function.ts
@@ -748,3 +748,8 @@ export function pipe(
  * @since 2.7.0
  */
 export const hole: <T>() => T = absurd as any
+
+/**
+ * @since 2.11.0
+ */
+export const SK = <A, B>(_: A, b: B): B => b


### PR DESCRIPTION
Backports `SK` from 3.0.0 to 2.11 based on the v2.11 roadmap https://github.com/gcanti/fp-ts/issues/1446
