### PR TITLE
add Ix{Apply,Chain,StateT,State}

### DIFF
--- a/src/IxApply.ts
+++ b/src/IxApply.ts
@@ -1,0 +1,78 @@
+/**
+ * @since 2.10.0
+ */
+import { pipe } from './function'
+import { Functor3, Functor4 } from './Functor'
+import { HKT3, Kind3, Kind4, URIS3, URIS4 } from './HKT'
+
+/**
+ * @category type classes
+ * @since 2.10.0
+ */
+export interface IxApply4<F extends URIS4> extends Functor4<F> {
+  readonly iap: <O, Z, E, A>(
+    fa: Kind4<F, O, Z, E, A>
+  ) => <I, B>(fab: Kind4<F, I, O, E, (a: A) => B>) => Kind4<F, I, Z, E, B>
+}
+
+/**
+ * @category type classes
+ * @since 2.10.0
+ */
+export interface IxApply3<F extends URIS3> extends Functor3<F> {
+  readonly iap: <O, Z, A>(fa: Kind3<F, O, Z, A>) => <I, B>(fab: Kind3<F, I, O, (a: A) => B>) => Kind3<F, I, Z, B>
+}
+
+/**
+ * @category type classes
+ * @since 2.10.0
+ */
+export interface IxApply<F> {
+  readonly URI: F
+  readonly map: <I, O, A, B>(fa: HKT3<F, I, O, A>, f: (a: A) => B) => HKT3<F, I, O, B>
+  readonly iap: <O, Z, A>(fa: HKT3<F, O, Z, A>) => <I, B>(fab: HKT3<F, I, O, (a: A) => B>) => HKT3<F, I, Z, B>
+}
+
+/**
+ * @category Combinators
+ * @since 2.10.0
+ */
+export function iapFirst<F extends URIS4>(
+  F: IxApply4<F>
+): <O, Z, E, B>(second: Kind4<F, O, Z, E, B>) => <I, A>(first: Kind4<F, I, O, E, A>) => Kind4<F, I, Z, E, A>
+export function iapFirst<F extends URIS3>(
+  F: IxApply3<F>
+): <O, Z, B>(second: Kind3<F, O, Z, B>) => <I, A>(first: Kind3<F, I, O, A>) => Kind3<F, I, Z, A>
+export function iapFirst<F>(
+  F: IxApply<F>
+): <O, Z, B>(second: HKT3<F, O, Z, B>) => <I, A>(first: HKT3<F, I, O, A>) => HKT3<F, I, Z, A>
+export function iapFirst<F>(
+  F: IxApply<F>
+): <O, Z, B>(second: HKT3<F, O, Z, B>) => <I, A>(first: HKT3<F, I, O, A>) => HKT3<F, I, Z, A> {
+  return (second) => (first) =>
+    pipe(
+      F.map(first, (a) => () => a),
+      F.iap(second)
+    )
+}
+
+/**
+ * @category Combinators
+ * @since 2.10.0
+ */
+export function iapSecond<F extends URIS4>(
+  F: IxApply4<F>
+): <O, Z, E, B>(second: Kind4<F, O, Z, E, B>) => <I, A>(first: Kind4<F, I, O, E, A>) => Kind4<F, I, Z, E, B>
+export function iapSecond<F extends URIS3>(
+  F: IxApply3<F>
+): <O, Z, B>(second: Kind3<F, O, Z, B>) => <I, A>(first: Kind3<F, I, O, A>) => Kind3<F, I, Z, B>
+export function iapSecond<F>(
+  F: IxApply<F>
+): <O, Z, B>(second: HKT3<F, O, Z, B>) => <I, A>(first: HKT3<F, I, O, A>) => HKT3<F, I, Z, B>
+export function iapSecond<F>(F: IxApply<F>) {
+  return <O, Z, B>(second: HKT3<F, O, Z, B>) => <I, A>(first: HKT3<F, I, O, A>): HKT3<F, I, Z, B> =>
+    pipe(
+      F.map(first, () => (b: B) => b),
+      F.iap(second)
+    )
+}

--- a/src/IxChain.ts
+++ b/src/IxChain.ts
@@ -1,0 +1,98 @@
+/**
+ * @since 2.10.0
+ */
+import { HKT2, HKT3, Kind2, Kind3, Kind4, URIS2, URIS3, URIS4 } from './HKT'
+import { IxApply, IxApply3, IxApply4 } from './IxApply'
+import { Pointed, Pointed2, Pointed3, Pointed4 } from './Pointed'
+
+/**
+ * @category type classes
+ * @since 2.10.0
+ */
+export interface IxChain4<F extends URIS4> extends IxApply4<F> {
+  readonly ichain: <R1, R2, E, A, B>(
+    f: (a: A) => Kind4<F, R1, R2, E, B>
+  ) => <S>(fa: Kind4<F, S, R1, E, A>) => Kind4<F, S, R2, E, B>
+}
+
+/**
+ * @category type classes
+ * @since 2.10.0
+ */
+export interface IxChain3<F extends URIS3> extends IxApply3<F> {
+  readonly ichain: <E1, E2, A1, A2>(
+    f: (a: A1) => Kind3<F, E1, E2, A2>
+  ) => <R>(fa: Kind3<F, R, E1, A1>) => Kind3<F, R, E2, A2>
+}
+
+/**
+ * @category type classes
+ * @since 2.10.0
+ */
+export interface IxChain<F> extends IxApply<F> {
+  readonly ichain: <O, Z, A1, B>(f: (a: A1) => HKT3<F, O, Z, B>) => <I>(fa: HKT3<F, I, O, A1>) => HKT3<F, I, Z, B>
+}
+
+/**
+ * @category Combinators
+ * @since 2.10.0
+ */
+export function ichainFirst<F extends URIS4>(
+  F: IxChain4<F>
+): <R1, R2, E, A1, A2>(
+  f: (a: A1) => Kind4<F, R1, R2, E, A2>
+) => <S>(fa: Kind4<F, S, R1, E, A1>) => Kind4<F, S, R2, E, A1>
+export function ichainFirst<F extends URIS3>(
+  F: IxChain3<F>
+): <E1, E2, A1, A2>(f: (a: A1) => Kind3<F, E1, E2, A2>) => <R>(fa: Kind3<F, R, E1, A1>) => Kind3<F, R, E2, A1>
+export function ichainFirst<F>(
+  F: IxChain<F>
+): <E1, E2, A1, A2>(f: (a: A1) => HKT3<F, E1, E2, A2>) => <R>(fa: HKT3<F, R, E1, A1>) => HKT3<F, R, E2, A1>
+export function ichainFirst<F>(
+  F: IxChain<F>
+): <O, Z, A, B>(f: (a: A) => HKT3<F, O, Z, B>) => <I>(fa: HKT3<F, I, O, A>) => HKT3<F, I, Z, A> {
+  return (f) => F.ichain((a) => F.map(f(a), () => a))
+}
+
+/**
+ * @category Combinators
+ * @since 2.10.0
+ */
+export function iDo<F extends URIS4>(F: Pointed4<F>): <I, R, E>() => Kind4<F, I, R, E, {}>
+export function iDo<F extends URIS3>(F: Pointed3<F>): <I, E>() => Kind3<F, I, E, {}>
+export function iDo<F extends URIS2>(F: Pointed2<F>): <I>() => Kind2<F, I, {}>
+export function iDo<F>(F: Pointed<F>): <I>() => HKT2<F, I, {}>
+export function iDo<F>(F: Pointed<F>): <I>() => HKT2<F, I, {}> {
+  return () => F.of({}) as any
+}
+
+/**
+ * @category Combinators
+ * @since 2.10.0
+ */
+export function ibind<F extends URIS4>(
+  F: IxChain4<F>
+): <N extends string, A, O, Z, E, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => Kind4<F, O, Z, E, B>
+) => <I>(ma: Kind4<F, I, O, E, A>) => Kind4<F, I, Z, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+export function ibind<F extends URIS3>(
+  F: IxChain3<F>
+): <N extends string, A, O, Z, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => Kind3<F, O, Z, B>
+) => <I>(ma: Kind3<F, I, O, A>) => Kind3<F, I, Z, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+export function ibind<F>(
+  F: IxChain<F>
+): <N extends string, A, O, Z, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => HKT3<F, O, Z, B>
+) => <I>(ma: HKT3<F, I, O, A>) => HKT3<F, I, Z, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+export function ibind<F>(
+  F: IxChain<F>
+): <N extends string, A, O, Z, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => HKT3<F, O, Z, B>
+) => <I>(ma: HKT3<F, I, O, A>) => HKT3<F, I, Z, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }> {
+  return (name, f) => F.ichain((a) => F.map(f(a), (b) => Object.assign({}, a, { [name]: b }) as any))
+}

--- a/src/IxState.ts
+++ b/src/IxState.ts
@@ -1,0 +1,215 @@
+/**
+ * `IxState` (Indexed State) is a derivation of `State`, that may have **polymorphic** states;
+ * The input may be of a different type than the output.
+ *
+ * State changes are kept track of by the generics `I`, `O`, `X` and `Z`.
+ * - `I` indicates the current input state
+ * - `O` indicates the current output state
+ * - `Z` indicates the next input state
+ * - `Z` indicates the next output state
+ *
+ * When composing `IxState` where the indexes are polymorhpic, functions `ichain` and `iap` can be
+ * used to compose `<I, O>` with `<O, Z>` to return `<I, Z>`.
+ *
+ * Intuitively this is function composition on the indexes.
+ *
+ *
+ * `IxState` derived by applying the `Identity` monad to the transformer `IxStateT`.
+ * @since 2.10.0
+ */
+import { ixStateT } from '.'
+import { Functor3 } from './Functor'
+import * as I from './Identity'
+import * as ixApply from './IxApply'
+import * as ixChain from './IxChain'
+import * as IxStateT from './IxStateT'
+import { Pointed2 } from './Pointed'
+import { State } from './State'
+
+/**
+ * @category Model
+ * @since 2.10.0
+ */
+export interface IxState<I, O, A> {
+  (i: I): [A, O]
+}
+
+/**
+ * @category Model
+ * @since 2.10.0
+ */
+export const URI = 'IxState'
+
+/**
+ * @category Model
+ * @since 2.10.0
+ */
+export type URI = typeof URI
+
+declare module './HKT' {
+  export interface URItoKind3<R, E, A> {
+    readonly [URI]: IxState<R, E, A>
+  }
+
+  // Allows usage with `ap, `chain` and `of`: Isomorphic state.
+  export interface URItoKind2<E, A> {
+    readonly [URI]: IxState<E, E, A>
+  }
+}
+
+/**
+ * `map` can be used to turn functions `(a: A) => B` into functions `(fa: F<A>) => F<B>` whose argument and return types
+ * use the type constructor `F` to represent some computational context.
+ *
+ * @category Functor
+ * @since 2.10.0
+ */
+export const map = IxStateT.map(I.Functor)
+
+/**
+ * @category Pointed
+ * @since 2.10.0
+ */
+export const of: <S = unknown, A = never>(a: A) => IxState<S, S, A> = IxStateT.of(I.Pointed)
+
+/**
+ * Apply a function to an argument under a type constructor.
+ *
+ * @category IxApply
+ * @since 2.10.0
+ */
+export const iap = IxStateT.iap(I.Chain)
+
+/**
+ * Composes computations in sequence, using the return value of one computation to determine the next computation.
+ *
+ * @category IxChain
+ *
+ * @since 2.10.0
+ */
+export const ichain = IxStateT.ichain(I.Chain)
+
+/**
+ * @category Instances
+ * @since 2.10.0
+ */
+export const Pointed: Pointed2<URI> = { URI, of }
+
+/**
+ * @category Instances
+ * @since 2.10.0
+ */
+export const Functor: Functor3<URI> = {
+  URI,
+  map: (fa, f) => map(f)(fa)
+}
+
+/**
+ * @category Instances
+ * @since 2.10.0
+ */
+export const IxApply: ixApply.IxApply3<URI> = {
+  ...Functor,
+  iap
+}
+
+/**
+ * @category Instances
+ * @since 2.10.0
+ */
+export const IxChain: ixChain.IxChain3<URI> = {
+  ...IxApply,
+  ichain
+}
+
+/**
+ * @category Combinators
+ *
+ * @since 2.10.0
+ */
+export const iapFirst = ixApply.iapFirst(IxApply)
+
+/**
+ * @category Combinators
+ * @since 2.10.0
+ */
+export const iapSecond = ixApply.iapSecond(IxApply)
+
+/**
+ * @category Combinators
+ * @since 2.10.0
+ */
+export const ichainFirst = ixChain.ichainFirst(IxChain)
+
+/**
+ * @summary
+ * Apply a function to the state, polymorphically changing the resulting state.
+ *
+ * @category Constructors
+ * @since 2.10.0
+ */
+export const imodify: <I, O>(f: (i: I) => O) => IxState<I, O, void> = IxStateT.imodify(I.Pointed)
+
+/**
+ * @category Constructor
+ * @since 2.10.0
+ */
+export const put: <I>(fi: I) => IxState<I, I, void> = IxStateT.put(I.Pointed)
+
+/**
+ * @category Destructors
+ * @since 2.10.0
+ */
+export const toState: <I, A>(fa: IxState<I, I, A>) => State<I, A> = IxStateT.toStateF<I.URI>()
+
+/**
+ * @category Constructors
+ * @since 2.10.0
+ */
+
+export const fromState: <I, A>(fa: State<I, A>) => IxState<I, I, A> = IxStateT.fromStateF<I.URI>()
+
+/**
+ * Changes the value of the local context during the execution of the action `ma` (similar to `Contravariant`'s
+ * `contramap`).
+ *
+ * @category Combinators
+ * @since 2.10.0
+ */
+export const local = ixStateT.local<I.URI>()
+
+/**
+ * @category Constructor
+ * @since 2.10.0
+ */
+export const iDo = ixChain.iDo(Pointed)
+
+/**
+ * @category Combinator
+ * @since 2.10.0
+ */
+export const bind = ixChain.ibind(IxChain)
+
+/**
+ * @category Destructors
+ * @since 2.10.0
+ */
+export const execute = ixStateT.iexecute(I.Functor)
+
+/**
+ * @category Destructors
+ * @since 2.10.0
+ */
+export const evaluate = ixStateT.evaluate(I.Functor)
+
+/**
+ * @category Constructors
+ * @since 2.10.0
+ */
+export const get = IxStateT.get(I.Pointed)
+
+/**
+ * @category Constructors
+ * @since 2.10.0
+ */
+export const gets = IxStateT.gets(I.Pointed)

--- a/src/IxStateT.ts
+++ b/src/IxStateT.ts
@@ -1,0 +1,237 @@
+/**
+ * When applying module augmentation when creating types,
+ * ensure that there are 2 declarations.
+ *
+ * See `IxState` for more details.
+ *
+ *
+ * @since 2.10.0
+ * @todo chain2, ap2
+ *
+ */
+import { Chain, Chain1, Chain2 } from './Chain'
+import { constVoid, pipe } from './function'
+import { Functor, Functor1, Functor2 } from './Functor'
+import { HKT, Kind, Kind2, URIS, URIS2 } from './HKT'
+import { Pointed, Pointed1, Pointed2 } from './Pointed'
+import { StateT, StateT1, StateT2 } from './StateT'
+
+/**
+ * @category Model
+ * @since 2.10.0
+ */
+export interface IxStateT<F, R, E, A> {
+  (i: R): HKT<F, [A, E]>
+}
+
+/**
+ * @category Model
+ * @since 2.10.0
+ */
+export interface IxStateT1<F extends URIS, R, E, A> {
+  (i: R): Kind<F, [A, E]>
+}
+
+/**
+ * @category Model
+ * @since 2.10.0
+ */
+export interface IxStateT2<F extends URIS2, S, R, E, A> {
+  (i: S): Kind2<F, E, [A, R]>
+}
+
+/**
+ * @category Pointed
+ * @since 2.10.0
+ */
+export function of<F extends URIS2>(F: Pointed2<F>): <S, E, A>(a: A) => IxStateT2<F, S, S, E, A>
+export function of<F extends URIS>(F: Pointed1<F>): <S, A>(a: A) => IxStateT1<F, S, S, A>
+export function of<F>(F: Pointed<F>): <S, A>(a: A) => IxStateT<F, S, S, A>
+export function of<F>(F: Pointed<F>): <I, A>(a: A) => IxStateT<F, I, I, A> {
+  return (a) => (i) => F.of([a, i])
+}
+
+/**
+ * `map` can be used to turn functions `(a: A) => B` into functions `(fa: F<A>) => F<B>` whose argument and return types
+ * use the type constructor `F` to represent some computational context.
+ *
+ * @category Functor
+ * @since 2.10.0
+ */
+export function map<F extends URIS2>(
+  F: Functor2<F>
+): <A, B>(f: (a: A) => B) => <I, O, E>(fa: IxStateT2<F, I, O, E, A>) => IxStateT2<F, I, O, E, B>
+export function map<F extends URIS>(
+  F: Functor1<F>
+): <A, B>(f: (a: A) => B) => <I, O>(fa: IxStateT1<F, I, O, A>) => IxStateT1<F, I, O, B>
+export function map<F>(
+  F: Functor<F>
+): <A, B>(f: (a: A) => B) => <I, O>(fa: IxStateT<F, I, O, A>) => IxStateT<F, I, O, B>
+export function map<F>(
+  F: Functor<F>
+): <A, B>(f: (a: A) => B) => <I, O>(fa: IxStateT<F, I, O, A>) => IxStateT<F, I, O, B> {
+  return (f) => (fa) => (i) => F.map(fa(i), ([a, o]) => [f(a), o])
+}
+
+/**
+ * Apply a function to an argument under a type constructor.
+ *
+ * @category IxApply
+ * @since 2.10.0
+ */
+export function iap<F extends URIS2>(
+  F: Chain2<F>
+): <O, Z, E, A>(
+  fa: IxStateT2<F, O, Z, E, A>
+) => <I, B>(fab: IxStateT2<F, I, O, E, (a: A) => B>) => IxStateT2<F, I, Z, E, B>
+export function iap<F extends URIS>(
+  F: Chain1<F>
+): <O, Z, A>(fa: IxStateT1<F, O, Z, A>) => <I, B>(fab: IxStateT1<F, I, O, (a: A) => B>) => IxStateT1<F, I, Z, B>
+export function iap<F>(
+  F: Chain<F>
+): <O, Z, A>(fa: IxStateT<F, O, Z, A>) => <I, B>(fab: IxStateT<F, I, O, (a: A) => B>) => IxStateT<F, I, Z, B>
+export function iap<F>(
+  F: Chain<F>
+): <O, Z, A>(fa: IxStateT<F, O, Z, A>) => <I, B>(fab: IxStateT<F, I, O, (a: A) => B>) => IxStateT<F, I, Z, B> {
+  return (fa) => (fab) =>
+    pipe(
+      fab,
+      ichain(F)((f) => map(F)(f)(fa))
+    )
+}
+
+/**
+ * Composes computations in sequence, using the return value of one computation to determine the next computation.
+ *
+ * @category IxChain
+ * @since 2.10.0
+ */
+export function ichain<F extends URIS2>(
+  F: Chain2<F>
+): <O, Z, E, A, B>(
+  f: (a: A) => IxStateT2<F, O, Z, E, B>
+) => <I>(fa: IxStateT2<F, I, O, E, A>) => IxStateT2<F, I, Z, E, B>
+export function ichain<F extends URIS>(
+  F: Chain1<F>
+): <O, Z, A, B>(f: (a: A) => IxStateT1<F, O, Z, B>) => <I>(fa: IxStateT1<F, I, O, A>) => IxStateT1<F, I, Z, B>
+export function ichain<F>(
+  F: Chain<F>
+): <O, Z, A, B>(f: (a: A) => IxStateT<F, O, Z, B>) => <I>(fa: IxStateT<F, I, O, A>) => IxStateT<F, I, Z, B>
+export function ichain<F>(
+  F: Chain<F>
+): <O, Z, A, B>(f: (a: A) => IxStateT<F, O, Z, B>) => <I>(fa: IxStateT<F, I, O, A>) => IxStateT<F, I, Z, B> {
+  return (f) => (fa) => (i) => F.chain(fa(i), ([a, o]) => f(a)(o))
+}
+
+/**
+ * @category Constructor
+ * @since 2.10.0
+ */
+export function put<F extends URIS2>(F: Pointed2<F>): <I, E>(i: I) => IxStateT2<F, I, I, E, void>
+export function put<F extends URIS>(F: Pointed1<F>): <I>(i: I) => IxStateT1<F, I, I, void>
+export function put<F>(F: Pointed<F>): <I>(i: I) => IxStateT<F, I, I, void>
+export function put<F>(F: Pointed<F>): <I>(i: I) => IxStateT<F, I, I, void> {
+  return (i) => () => F.of([constVoid(), i])
+}
+
+/**
+ * @summary
+ * Apply a function to the state, polymorphically changing the resulting state.
+ *
+ * @category Constructors
+ * @since 2.10.0
+ */
+export function imodify<F extends URIS2>(F: Pointed2<F>): <S, R, E>(f: (i: S) => R) => IxStateT2<F, S, R, E, void>
+export function imodify<F extends URIS>(F: Pointed1<F>): <R, E>(f: (i: R) => E) => IxStateT1<F, R, E, void>
+export function imodify<F>(F: Pointed<F>): <R, E>(f: (i: R) => E) => IxStateT<F, R, E, void>
+export function imodify<F>(F: Pointed<F>): <R, E>(f: (i: R) => E) => IxStateT<F, R, E, void> {
+  return (f) => (i) => F.of([constVoid(), f(i)])
+}
+
+/**
+ * @category Destructors
+ * @since 2.10.0
+ */
+export function toStateF<F extends URIS2>(): <R, E, A>(fa: IxStateT2<F, R, R, E, A>) => StateT2<F, R, E, A>
+export function toStateF<F extends URIS>(): <E, A>(fa: IxStateT1<F, E, E, A>) => StateT1<F, E, A>
+export function toStateF<F>(): <E, A>(fa: IxStateT<F, E, E, A>) => StateT<F, E, A>
+export function toStateF<F>(): <E, A>(fa: IxStateT<F, E, E, A>) => StateT<F, E, A> {
+  return (fa) => fa
+}
+
+/**
+ * @category Constructors
+ * @since 2.10.0
+ */
+export function fromStateF<F extends URIS2>(): <S, E, A>(fa: StateT2<F, S, E, A>) => IxStateT2<F, S, S, E, A>
+export function fromStateF<F extends URIS>(): <S, A>(fa: StateT1<F, S, A>) => IxStateT1<F, S, S, A>
+export function fromStateF<F>(): <R, A>(fa: StateT<F, R, A>) => IxStateT<F, R, R, A>
+export function fromStateF<F>(): <R, A>(fa: StateT<F, R, A>) => IxStateT<F, R, R, A> {
+  return (fa) => fa
+}
+
+/**
+ * Changes the value of the local context during the execution of the action `ma` (similar to `Contravariant`'s
+ * `contramap`).
+ *
+ * @category combinators
+ * @since 2.10.0
+ */
+export function local<F extends URIS2>(): <I, X>(
+  f: (x: X) => I
+) => <O, E, A>(fa: IxStateT2<F, I, O, E, A>) => IxStateT2<F, X, O, E, A>
+export function local<F extends URIS>(): <I, X>(
+  f: (x: X) => I
+) => <O, A>(fa: IxStateT1<F, I, O, A>) => IxStateT1<F, X, O, A>
+export function local<F>(): <I, X>(f: (x: X) => I) => <O, A>(fa: IxStateT<F, I, O, A>) => IxStateT<F, X, O, A>
+export function local<F>(): <I, X>(f: (x: X) => I) => <O, A>(fa: IxStateT<F, I, O, A>) => IxStateT<F, X, O, A> {
+  return (f) => (fa) => (x) => fa(f(x))
+}
+
+/**
+ * @category Constructors
+ * @since 2.10.0
+ */
+export function get<F extends URIS2>(F: Pointed2<F>): <I, E>() => IxStateT2<F, I, I, E, I>
+export function get<F extends URIS>(F: Pointed1<F>): <I>() => IxStateT1<F, I, I, I>
+export function get<F>(F: Pointed<F>): <I>() => IxStateT<F, I, I, I>
+export function get<F>(F: Pointed<F>): <I>() => IxStateT<F, I, I, I> {
+  return () => (i) => F.of([i, i])
+}
+
+/**
+ * @category Constructors
+ * @since 2.10.0
+ */
+export function gets<F extends URIS2>(F: Pointed2<F>): <I, E, A>(f: (i: I) => A) => IxStateT2<F, I, I, E, A>
+export function gets<F extends URIS>(F: Pointed1<F>): <I, A>(f: (i: I) => A) => IxStateT1<F, I, I, A>
+export function gets<F>(F: Pointed<F>): <I, A>(f: (i: I) => A) => IxStateT<F, I, I, A>
+export function gets<F>(F: Pointed<F>): <I, A>(f: (i: I) => A) => IxStateT<F, I, I, A> {
+  return (f) => (i) => F.of([f(i), i])
+}
+
+/**
+ * @category Destructors
+ * @since 2.10.0
+ */
+export function iexecute<F extends URIS2>(
+  F: Functor2<F>
+): <I, E>(i: I) => <O, A>(fa: IxStateT2<F, I, O, E, A>) => Kind2<F, E, O>
+export function iexecute<F extends URIS>(F: Functor1<F>): <I>(i: I) => <O, A>(fa: IxStateT1<F, I, O, A>) => Kind<F, O>
+export function iexecute<F>(F: Functor<F>): <I>(i: I) => <O, A>(fa: IxStateT<F, I, O, A>) => HKT<F, O>
+export function iexecute<F>(F: Functor<F>): <I>(i: I) => <O, A>(fa: IxStateT<F, I, O, A>) => HKT<F, O> {
+  return (i) => (fa) => F.map(fa(i), (ao) => ao[1])
+}
+
+/**
+ * @category Destructors
+ * @since 2.10.0
+ */
+export function evaluate<F extends URIS2>(
+  F: Functor2<F>
+): <I>(i: I) => <O, E, A>(fa: IxStateT2<F, I, O, E, A>) => Kind2<F, E, A>
+export function evaluate<F extends URIS>(F: Functor1<F>): <I>(i: I) => <O, A>(fa: IxStateT1<F, I, O, A>) => Kind<F, A>
+export function evaluate<F>(F: Functor<F>): <I>(i: I) => <O, A>(fa: IxStateT<F, I, O, A>) => HKT<F, A>
+export function evaluate<F>(F: Functor<F>): <I>(i: I) => <O, A>(fa: IxStateT<F, I, O, A>) => HKT<F, A> {
+  return (i) => (fa) => F.map(fa(i), (ao) => ao[0])
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -307,6 +307,10 @@ export {
    */
   ixChain,
   /**
+   * @since 2.10.0
+   */
+  ixStateT,
+  /**
    * @since 2.0.0
    */
   joinSemilattice,

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,6 +112,7 @@ import * as validationT from './ValidationT'
 import * as witherable from './Witherable'
 import * as writer from './Writer'
 import * as writerT from './WriterT'
+import * as ixApply from './IxApply'
 export {
   /**
    * @since 2.0.0
@@ -297,6 +298,10 @@ export {
    * @since 2.0.0
    */
   ioRef,
+  /**
+   * @since 2.10.0
+   */
+  ixApply,
   /**
    * @since 2.0.0
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -303,6 +303,10 @@ export {
    */
   ixApply,
   /**
+   * @since 2.10.0
+   */
+  ixChain,
+  /**
    * @since 2.0.0
    */
   joinSemilattice,

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,9 @@ import * as witherable from './Witherable'
 import * as writer from './Writer'
 import * as writerT from './WriterT'
 import * as ixApply from './IxApply'
+import * as ixChain from './IxChain'
+import * as ixStateT from './IxStateT'
+import * as ixState from './IxState'
 export {
   /**
    * @since 2.0.0
@@ -310,6 +313,10 @@ export {
    * @since 2.10.0
    */
   ixStateT,
+  /**
+   * @since 2.10.0
+   */
+  ixState,
   /**
    * @since 2.0.0
    */

--- a/test/IxState.ts
+++ b/test/IxState.ts
@@ -1,0 +1,141 @@
+import { ixState as M } from '../src'
+import { constVoid, pipe } from '../src/function'
+import { deepStrictEqual, double } from './util'
+import * as State from '../src/State'
+
+describe('IxState', () => {
+  it('map', () => {
+    deepStrictEqual(pipe(M.of(4), M.map(double))(9), [8, 9])
+  })
+
+  it('put', () => {
+    deepStrictEqual(M.put(9)(8), [constVoid(), 9])
+  })
+
+  it('ichainFirst', () => {
+    deepStrictEqual(
+      pipe(
+        M.of<number, string>('answer'),
+        M.ichainFirst(() => M.imodify(String))
+      )(42),
+      ['answer', '42']
+    )
+  })
+
+  it('toState', () => {
+    const state = M.of<number, number>(4)
+    deepStrictEqual(pipe(state, M.toState)(42), state(42))
+  })
+
+  it('fromState', () => {
+    const state = State.of<number, number>(4)
+    deepStrictEqual(pipe(state, M.fromState)(42), state(42))
+  })
+
+  describe('do notation', () => {
+    it('Do', () => {
+      deepStrictEqual(M.iDo()(4), [{}, 4])
+    })
+
+    it('bind', () => {
+      deepStrictEqual(
+        pipe(
+          M.iDo(),
+          M.bind('answer', () => M.of(42))
+        )(constVoid()),
+        [{ answer: 42 }, constVoid()]
+      )
+    })
+  })
+
+  test('evaluate', () => {
+    deepStrictEqual(pipe(M.of(42), M.evaluate(6)), 42)
+  })
+
+  test('execute', () => {
+    deepStrictEqual(pipe(M.imodify(double), M.execute(42)), 84)
+  })
+
+  test('get', () => {
+    deepStrictEqual(M.get<number>()(42), [42, 42])
+  })
+
+  test('gets', () => {
+    deepStrictEqual(M.gets<number, string>(String)(42), ['42', 42])
+  })
+
+  test('imodify', () => {
+    deepStrictEqual(M.imodify(String)(42), [constVoid(), '42'])
+  })
+
+  test('ichain', () => {
+    deepStrictEqual(
+      pipe(
+        M.of<number, void>(constVoid()),
+        M.ichain(() => M.imodify<number, string>(String)),
+        M.ichain(() => M.imodify<string, Array<string>>((a) => a.split('')))
+      )(42),
+      [constVoid(), ['4', '2']]
+    )
+  })
+
+  test('of', () => {
+    deepStrictEqual(M.of<number, string>('The Answer')(42), ['The Answer', 42])
+  })
+
+  test('iap', () => {
+    deepStrictEqual(
+      pipe(
+        M.of<string, (a: number) => number>(double),
+        M.iap(
+          pipe(
+            M.of<string, number>(42),
+            M.ichainFirst(() => M.imodify((a) => a.split(', ')))
+          )
+        )
+      )('Hello, World!'),
+      [84, ['Hello', 'World!']]
+    )
+  })
+
+  test('iapFirst', () => {
+    deepStrictEqual(
+      pipe(
+        M.of<number, number>(4),
+        M.iapFirst(
+          pipe(
+            M.of<number, number>(2),
+            M.ichainFirst(() => M.imodify<number, string>(String))
+          )
+        )
+      )(42),
+      [4, '42']
+    )
+  })
+
+  test('iapSecond', () => {
+    deepStrictEqual(
+      pipe(
+        M.of<number, number>(4),
+        M.iapSecond(
+          pipe(
+            M.of<number, number>(2),
+            M.ichainFirst(() => M.imodify<number, string>(String))
+          )
+        )
+      )(42),
+      [2, '42']
+    )
+  })
+
+  test('local', () => {
+    deepStrictEqual(
+      pipe(
+        M.of<number, void>(constVoid()),
+        M.local<number, string>(Number),
+        M.ichain(() => M.imodify(double))
+      )('42'),
+      [constVoid(), 84]
+    )
+  })
+})


### PR DESCRIPTION
# Indexed Monads

I've been looking at indexed state monads and decided to try implement it as a typeclass. This is largely inspired by gcanti's hyper-ts.


In depth explanation of Indexed Monads https://stackoverflow.com/questions/28690448/what-is-indexed-monad

### IxApply

A typeclass has a function `iap` which acts similarly to `ap`, but keeps track of the index.

Also has transformers for `iapFirst` and `iapSecond`.

### IxChain
A typeclass that has a function `ichain`, which acts simarly to `chain` but keeps track of the index.
It also inherits `iap` from `IxApply`.

Also has transformers for Do notation and `ichainFirst`

## IxStateT (IndexedState)

Polymorphic state values, with state tracked via an index.

Included are transformers for the IxChain and IxApply, as well as transformers for `IxState`


## Questions

- I've done two overloads in `declare module './HKT` so `Pointed` works correctly for `StateT`. Is this allowable?

commits can be rebasable instead of merged.