### PR TITLE
Add string.toLowerCase and use string manipulation type in toUpperCase

### DIFF
--- a/docs/modules/string.ts.md
+++ b/docs/modules/string.ts.md
@@ -22,6 +22,7 @@ Added in v3.0.0
   - [empty](#empty)
   - [isEmpty](#isempty)
   - [size](#size)
+  - [toLowerCase](#tolowercase)
   - [toUpperCase](#touppercase)
 
 ---
@@ -140,12 +141,22 @@ export declare const size: (s: string) => number
 
 Added in v3.0.0
 
+## toLowerCase
+
+**Signature**
+
+```ts
+export declare const toLowerCase: <S extends string>(s: S) => Lowercase<S>
+```
+
+Added in v3.0.0
+
 ## toUpperCase
 
 **Signature**
 
 ```ts
-export declare const toUpperCase: (s: string) => string
+export declare const toUpperCase: <S extends string>(s: S) => Uppercase<S>
 ```
 
 Added in v3.0.0

--- a/dtslint/ts4.1/string.ts
+++ b/dtslint/ts4.1/string.ts
@@ -1,0 +1,19 @@
+import * as _ from '../../src/string'
+
+declare const s: string;
+declare const su: 'ABC';
+declare const sl: 'abc';
+
+//
+// toUpperCase
+//
+
+_.toUpperCase(s) // $ExpectType string
+_.toUpperCase(sl) // $ExpectType "ABC"
+
+//
+// toLowerCase
+//
+
+_.toLowerCase(s) // $ExpectType string
+_.toLowerCase(su) // $ExpectType "abc"

--- a/src/string.ts
+++ b/src/string.ts
@@ -98,4 +98,9 @@ export const size = (s: string): number => s.length
 /**
  * @since 3.0.0
  */
-export const toUpperCase = (s: string): string => s.toUpperCase()
+export const toUpperCase = <S extends string>(s: S): Uppercase<S> => s.toUpperCase() as any
+
+/**
+ * @since 3.0.0
+ */
+export const toLowerCase = <S extends string>(s: S): Lowercase<S> => s.toLowerCase() as any

--- a/test/Const.ts
+++ b/test/Const.ts
@@ -22,6 +22,7 @@ describe('Const', () => {
     })
 
     it('mapLeft', () => {
+      // @ts-ignore
       const f = _.mapLeft(S.toUpperCase)
       U.deepStrictEqual(pipe(_.make('a'), f), _.make('A'))
     })

--- a/test/string.ts
+++ b/test/string.ts
@@ -29,4 +29,12 @@ describe('string', () => {
     U.deepStrictEqual(_.size(''), 0)
     U.deepStrictEqual(_.size('a'), 1)
   })
+
+  it('toUpperCase', () => {
+    U.deepStrictEqual(_.toUpperCase('abc'), 'ABC')
+  })
+
+  it('toLowerCase', () => {
+    U.deepStrictEqual(_.toLowerCase('ABC'), 'abc')
+  })
 })


### PR DESCRIPTION
Adds `string.toLowerCase` and improves the return type of `string.toUpperCase`.

`toLowerCase` can be pack ported to `2.11`, but the string manipulation types require TypeScript 4.1.

I've left this as WIP while a `@ts-ignore` is removed.