### PR TITLE
StateReaderTaskEither: `traverseArrayWithIndex` does not pass the out…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
 **Note**: A feature tagged as Experimental is in a
 high state of flux, you're at risk of it changing without notice.
 
+# 2.10.3
+
+- **Bug Fix**
+  - `StateReaderTaskEither`
+    - `traverseArrayWithIndex` does not pass the output state from each step to the subsequent step, #1486
+
 # 2.10.2
 
 - **Bug Fix**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fp-ts",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "description": "Functional programming in TypeScript",
   "main": "lib/index.js",
   "module": "es6/index.js",

--- a/src/StateReaderTaskEither.ts
+++ b/src/StateReaderTaskEither.ts
@@ -965,7 +965,7 @@ export const traverseArrayWithIndex = <S, R, E, A, B>(
           : f(
               i,
               a
-            )(s)(r)().then((eb) => {
+            )(ebs.right[1])(r)().then((eb) => {
               if (E.isLeft(eb)) {
                 return eb
               }

--- a/test/StateReaderTaskEither.ts
+++ b/test/StateReaderTaskEither.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert'
 import * as A from '../src/Array'
 import * as E from '../src/Either'
-import { pipe } from '../src/function'
+import { pipe, tuple } from '../src/function'
 import * as I from '../src/IO'
 import * as IE from '../src/IOEither'
 import * as O from '../src/Option'
@@ -354,5 +354,18 @@ describe('StateReaderTaskEither', () => {
     const s: State<unknown, number> = (s) => [1, s]
     const e = await pipe(_.fromState(s), _.evaluate(state))({})()
     U.deepStrictEqual(e, E.right(1))
+  })
+
+  it('#1486', async () => {
+    const append = (n: number): _.StateReaderTaskEither<ReadonlyArray<number>, {}, Error, void> =>
+      _.modify((a) => [...a, n])
+    U.deepStrictEqual(
+      await pipe(
+        [1, 2, 3],
+        _.traverseArray(append),
+        _.map(() => undefined)
+      )([])({})(),
+      E.right(tuple(undefined, [1, 2, 3]))
+    )
   })
 })


### PR DESCRIPTION
…put state from each step to the subsequent step, fix #1486
