### PR TITLE
Add Date.fromString constructor

### DIFF
--- a/docs/modules/Date.ts.md
+++ b/docs/modules/Date.ts.md
@@ -14,12 +14,15 @@ Added in v2.0.0
 
 - [constructors](#constructors)
   - [create](#create)
+  - [fromString](#fromstring)
 - [instances](#instances)
   - [Eq](#eq)
   - [Ord](#ord)
   - [eqDate](#eqdate)
   - [eqMonth](#eqmonth)
   - [eqYear](#eqyear)
+- [refinements](#refinements)
+  - [isValid](#isvalid)
 - [utils](#utils)
   - [now](#now)
 
@@ -39,6 +42,18 @@ export declare const create: IO<Date>
 
 Added in v2.0.0
 
+## fromString
+
+Returns a `Date` if the input is a valid date time string.
+
+**Signature**
+
+```ts
+export declare const fromString: (value: string) => O.Option<Date>
+```
+
+Added in v2.11.0
+
 # instances
 
 ## Eq
@@ -56,7 +71,7 @@ Added in v2.10.0
 **Signature**
 
 ```ts
-export declare const Ord: O.Ord<Date>
+export declare const Ord: Ord_<Date>
 ```
 
 **Example**
@@ -98,6 +113,20 @@ export declare const eqYear: E.Eq<Date>
 ```
 
 Added in v2.6.0
+
+# refinements
+
+## isValid
+
+Returns `true` if the input is a valid Date, `false` otherwise.
+
+**Signature**
+
+```ts
+export declare const isValid: Predicate<Date>
+```
+
+Added in v2.11.0
 
 # utils
 

--- a/dtslint/ts3.5/Date.ts
+++ b/dtslint/ts3.5/Date.ts
@@ -1,0 +1,19 @@
+import * as _ from '../../src/Date';
+import { pipe } from '../../src/function';
+
+declare const d: Date
+declare const s: string
+
+//
+// isValid
+//
+
+// $ExpectType boolean
+pipe(d, _.isValid)
+
+//
+// fromString
+//
+
+// $ExpectType Option<Date>
+pipe(s, _.fromString)

--- a/src/Date.ts
+++ b/src/Date.ts
@@ -2,8 +2,11 @@
  * @since 2.0.0
  */
 import * as E from './Eq'
+import { flow } from './function'
 import { IO } from './IO'
-import * as O from './Ord'
+import * as O from './Option'
+import { Ord as Ord_, ordDate } from './Ord'
+import { not, Predicate } from './Predicate'
 
 // -------------------------------------------------------------------------------------
 // instances
@@ -50,11 +53,27 @@ export const eqYear: E.Eq<Date> = {
  * @since 2.10.0
  */
 // tslint:disable-next-line: deprecation
-export const Ord: O.Ord<Date> = O.ordDate
+export const Ord: Ord_<Date> = ordDate
 
 // -------------------------------------------------------------------------------------
 // utils
 // -------------------------------------------------------------------------------------
+
+/**
+ * Returns `true` if the input is a valid Date, `false` otherwise.
+ *
+ * @category refinements
+ * @since 2.11.0
+ */
+export const isValid: Predicate<Date> = flow((date) => date.getTime(), not(isNaN))
+
+/**
+ * Returns a `Date` if the input is a valid date time string.
+ *
+ * @category constructors
+ * @since 2.11.0
+ */
+export const fromString: (value: string) => O.Option<Date> = flow((value) => new Date(value), O.fromPredicate(isValid))
 
 /**
  * Returns the current `Date`

--- a/test/Date.ts
+++ b/test/Date.ts
@@ -1,3 +1,5 @@
+import { pipe } from '../src/function'
+import * as O from '../src/Option'
 import * as U from './util'
 import * as _ from '../src/Date'
 
@@ -36,6 +38,16 @@ describe('Date', () => {
   // -------------------------------------------------------------------------------------
   // utils
   // -------------------------------------------------------------------------------------
+
+  it('isValid', () => {
+    U.deepStrictEqual(pipe(new Date('2000-10-01'), _.isValid), true)
+    U.deepStrictEqual(pipe(new Date('not a date'), _.isValid), false)
+  })
+
+  it('fromString', () => {
+    U.deepStrictEqual(pipe('2000-10-01', _.fromString), O.some(new Date('2000-10-01')))
+    U.deepStrictEqual(pipe('not a date', _.fromString), O.none)
+  })
 
   it('create', () => {
     const d1 = _.create()


### PR DESCRIPTION
As `new Date('not a date')` is valid only for its usage to fail badly, this adds a `Date.fromString` constructor (along with `Date.isValid`).