### PR TITLE
Use Error to replace unknown for the parse and stringify method of Json

### DIFF
--- a/src/Json.ts
+++ b/src/Json.ts
@@ -1,8 +1,7 @@
 /**
  * @since 2.10.0
  */
-import { Either, parseJSON, stringifyJSON } from './Either'
-import { identity } from './function'
+import { Either, parseJSON, stringifyJSON, toError } from './Either'
 
 /**
  * @since 2.10.0
@@ -35,7 +34,7 @@ export interface JsonArray extends ReadonlyArray<Json> {}
  * @since 2.10.0
  */
 // tslint:disable-next-line: deprecation
-export const parse = (s: string): Either<unknown, Json> => parseJSON(s, identity)
+export const parse = (s: string): Either<Error, Json> => parseJSON(s, toError)
 
 /**
  * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
@@ -59,4 +58,4 @@ export const parse = (s: string): Either<unknown, Json> => parseJSON(s, identity
  *  @since 2.10.0
  */
 // tslint:disable-next-line: deprecation
-export const stringify = <A>(a: A): Either<unknown, string> => stringifyJSON(a, identity)
+export const stringify = <A>(a: A): Either<Error, string> => stringifyJSON(a, toError)


### PR DESCRIPTION
# WHAT

The underlying method `parse` and `stringify` of [JSON](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON) will throw an error if the [JSON is invalid](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#exceptions) or [failed to stringify](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#exceptions). 

In most use cases, we will pipe the `Json.parse` into `Either<Error, Xxx>`, like below:
![Screen Shot 2021-06-03 at 14 10 08](https://user-images.githubusercontent.com/6265479/120595772-7ea6a400-c475-11eb-8282-9edb444f5f79.png)

So I think we can change the return type from `Either<unknown, Xxx>` to `Either<Error, Xxx>` 


