### PR TITLE
Additional 3.x Functor.map overloads

### DIFF
--- a/src/Functor.ts
+++ b/src/Functor.ts
@@ -113,10 +113,72 @@ export function flap<F>(F: Functor<F>): <A>(a: A) => <B>(fab: HKT<F, (a: A) => B
  * @category combinators
  * @since 3.0.0
  */
+export function map<F extends URIS4, G extends URIS4>(
+  F: Functor4<F>,
+  G: Functor4<G>
+): <A, B>(
+  f: (a: A) => B
+) => <S, R, E>(fa: Kind4<F, S, R, E, Kind4<G, S, R, E, A>>) => Kind4<F, S, R, E, Kind4<G, S, R, E, B>>
+export function map<F extends URIS4, G extends URIS3>(
+  F: Functor4<F>,
+  G: Functor3<G>
+): <A, B>(f: (a: A) => B) => <S, R, E>(fa: Kind4<F, S, R, E, Kind3<G, R, E, A>>) => Kind4<F, S, R, E, Kind3<G, R, E, B>>
+export function map<F extends URIS4, G extends URIS2>(
+  F: Functor4<F>,
+  G: Functor2<G>
+): <A, B>(f: (a: A) => B) => <S, R, E>(fa: Kind4<F, S, R, E, Kind2<G, E, A>>) => Kind4<F, S, R, E, Kind2<G, E, B>>
+export function map<F extends URIS4, G extends URIS>(
+  F: Functor4<F>,
+  G: Functor1<G>
+): <A, B>(f: (a: A) => B) => <S, R, E>(fa: Kind4<F, S, R, E, Kind<G, A>>) => Kind4<F, S, R, E, Kind<G, B>>
+export function map<F extends URIS3, G extends URIS4>(
+  F: Functor3<F>,
+  G: Functor4<G>
+): <A, B>(f: (a: A) => B) => <S, R, E>(fa: Kind3<F, R, E, Kind4<G, S, R, E, A>>) => Kind3<F, R, E, Kind4<G, S, R, E, B>>
+export function map<F extends URIS3, G extends URIS3>(
+  F: Functor3<F>,
+  G: Functor3<G>
+): <A, B>(f: (a: A) => B) => <R, E>(fa: Kind3<F, R, E, Kind3<G, R, E, A>>) => Kind3<F, R, E, Kind3<G, R, E, B>>
+export function map<F extends URIS3, G extends URIS2>(
+  F: Functor3<F>,
+  G: Functor2<G>
+): <A, B>(f: (a: A) => B) => <R, E>(fa: Kind3<F, R, E, Kind2<G, E, A>>) => Kind3<F, R, E, Kind2<G, E, B>>
+export function map<F extends URIS3, G extends URIS>(
+  F: Functor3<F>,
+  G: Functor1<G>
+): <A, B>(f: (a: A) => B) => <R, E>(fa: Kind3<F, R, E, Kind<G, A>>) => Kind3<F, R, E, Kind<G, B>>
+export function map<F extends URIS2, G extends URIS4>(
+  F: Functor2<F>,
+  G: Functor4<G>
+): <A, B>(f: (a: A) => B) => <S, R, E>(fa: Kind2<F, E, Kind4<G, S, R, E, A>>) => Kind2<F, E, Kind4<G, S, R, E, B>>
+export function map<F extends URIS2, G extends URIS3>(
+  F: Functor2<F>,
+  G: Functor3<G>
+): <A, B>(f: (a: A) => B) => <R, E>(fa: Kind2<F, E, Kind3<G, R, E, A>>) => Kind2<F, E, Kind3<G, R, E, B>>
+export function map<F extends URIS2, G extends URIS2>(
+  F: Functor2<F>,
+  G: Functor2<G>
+): <A, B>(f: (a: A) => B) => <E>(fa: Kind2<F, E, Kind2<G, E, A>>) => Kind2<F, E, Kind2<G, E, B>>
+export function map<F extends URIS2, G extends URIS>(
+  F: Functor2<F>,
+  G: Functor1<G>
+): <A, B>(f: (a: A) => B) => <E>(fa: Kind2<F, E, Kind<G, A>>) => Kind2<F, E, Kind<G, B>>
+export function map<F extends URIS, G extends URIS4>(
+  F: Functor1<F>,
+  G: Functor4<G>
+): <A, B>(f: (a: A) => B) => <S, R, E>(fa: Kind<F, Kind4<G, S, R, E, A>>) => Kind<F, Kind4<G, S, R, E, B>>
+export function map<F extends URIS, G extends URIS3>(
+  F: Functor1<F>,
+  G: Functor3<G>
+): <A, B>(f: (a: A) => B) => <R, E>(fa: Kind<F, Kind3<G, R, E, A>>) => Kind<F, Kind3<G, R, E, B>>
 export function map<F extends URIS, G extends URIS2>(
   F: Functor1<F>,
   G: Functor2<G>
 ): <A, B>(f: (a: A) => B) => <E>(fa: Kind<F, Kind2<G, E, A>>) => Kind<F, Kind2<G, E, B>>
+export function map<F extends URIS, G extends URIS>(
+  F: Functor1<F>,
+  G: Functor1<G>
+): <A, B>(f: (a: A) => B) => (fa: Kind<F, Kind<G, A>>) => Kind<F, Kind<G, B>>
 export function map<F, G extends URIS2>(
   F: Functor<F>,
   G: Functor2<G>

--- a/src/Functor.ts
+++ b/src/Functor.ts
@@ -118,15 +118,15 @@ export function map<F extends URIS4, G extends URIS4>(
   G: Functor4<G>
 ): <A, B>(
   f: (a: A) => B
-) => <S, R, E>(fa: Kind4<F, S, R, E, Kind4<G, S, R, E, A>>) => Kind4<F, S, R, E, Kind4<G, S, R, E, B>>
+) => <SF, RF, EF, SG, RG, EG>(fa: Kind4<F, SF, RF, EF, Kind4<G, SG, RG, EG, A>>) => Kind4<F, SF, RF, EF, Kind4<G, SG, RG, EG, B>>
 export function map<F extends URIS4, G extends URIS3>(
   F: Functor4<F>,
   G: Functor3<G>
-): <A, B>(f: (a: A) => B) => <S, R, E>(fa: Kind4<F, S, R, E, Kind3<G, R, E, A>>) => Kind4<F, S, R, E, Kind3<G, R, E, B>>
+): <A, B>(f: (a: A) => B) => <SF, RF, EF, RG, EG>(fa: Kind4<F, SF, RF, EF, Kind3<G, RG, EG, A>>) => Kind4<F, SF, RF, EF, Kind3<G, RF, EF, B>>
 export function map<F extends URIS4, G extends URIS2>(
   F: Functor4<F>,
   G: Functor2<G>
-): <A, B>(f: (a: A) => B) => <S, R, E>(fa: Kind4<F, S, R, E, Kind2<G, E, A>>) => Kind4<F, S, R, E, Kind2<G, E, B>>
+): <A, B>(f: (a: A) => B) => <SF, RF, EF, EG>(fa: Kind4<F, SF, RF, EF, Kind2<G, EG, A>>) => Kind4<F, SF, RF, EF, Kind2<G, EG, B>>
 export function map<F extends URIS4, G extends URIS>(
   F: Functor4<F>,
   G: Functor1<G>
@@ -134,15 +134,15 @@ export function map<F extends URIS4, G extends URIS>(
 export function map<F extends URIS3, G extends URIS4>(
   F: Functor3<F>,
   G: Functor4<G>
-): <A, B>(f: (a: A) => B) => <S, R, E>(fa: Kind3<F, R, E, Kind4<G, S, R, E, A>>) => Kind3<F, R, E, Kind4<G, S, R, E, B>>
+): <A, B>(f: (a: A) => B) => <RF, EF, SG, RG, EG>(fa: Kind3<F, RF, EF, Kind4<G, SG, RG, EG, A>>) => Kind3<F, RF, EF, Kind4<G, SG, RG, EG, B>>
 export function map<F extends URIS3, G extends URIS3>(
   F: Functor3<F>,
   G: Functor3<G>
-): <A, B>(f: (a: A) => B) => <R, E>(fa: Kind3<F, R, E, Kind3<G, R, E, A>>) => Kind3<F, R, E, Kind3<G, R, E, B>>
+): <A, B>(f: (a: A) => B) => <RF, EF, RG, EG>(fa: Kind3<F, RF, EF, Kind3<G, RG, EG, A>>) => Kind3<F, RF, EF, Kind3<G, RG, EG, B>>
 export function map<F extends URIS3, G extends URIS2>(
   F: Functor3<F>,
   G: Functor2<G>
-): <A, B>(f: (a: A) => B) => <R, E>(fa: Kind3<F, R, E, Kind2<G, E, A>>) => Kind3<F, R, E, Kind2<G, E, B>>
+): <A, B>(f: (a: A) => B) => <R, EF, EG>(fa: Kind3<F, R, EF, Kind2<G, EG, A>>) => Kind3<F, R, EF, Kind2<G, EG, B>>
 export function map<F extends URIS3, G extends URIS>(
   F: Functor3<F>,
   G: Functor1<G>
@@ -150,15 +150,15 @@ export function map<F extends URIS3, G extends URIS>(
 export function map<F extends URIS2, G extends URIS4>(
   F: Functor2<F>,
   G: Functor4<G>
-): <A, B>(f: (a: A) => B) => <S, R, E>(fa: Kind2<F, E, Kind4<G, S, R, E, A>>) => Kind2<F, E, Kind4<G, S, R, E, B>>
+): <A, B>(f: (a: A) => B) => <EF, SG, RG, EG>(fa: Kind2<F, EF, Kind4<G, SG, RG, EG, A>>) => Kind2<F, EF, Kind4<G, SG, RG, EG, B>>
 export function map<F extends URIS2, G extends URIS3>(
   F: Functor2<F>,
   G: Functor3<G>
-): <A, B>(f: (a: A) => B) => <R, E>(fa: Kind2<F, E, Kind3<G, R, E, A>>) => Kind2<F, E, Kind3<G, R, E, B>>
+): <A, B>(f: (a: A) => B) => <EF, RG, EG>(fa: Kind2<F, EF, Kind3<G, RG, EG, A>>) => Kind2<F, EF, Kind3<G, RG, EG, B>>
 export function map<F extends URIS2, G extends URIS2>(
   F: Functor2<F>,
   G: Functor2<G>
-): <A, B>(f: (a: A) => B) => <E>(fa: Kind2<F, E, Kind2<G, E, A>>) => Kind2<F, E, Kind2<G, E, B>>
+): <A, B>(f: (a: A) => B) => <EF, EG>(fa: Kind2<F, EF, Kind2<G, EG, A>>) => Kind2<F, EF, Kind2<G, EG, B>>
 export function map<F extends URIS2, G extends URIS>(
   F: Functor2<F>,
   G: Functor1<G>

--- a/src/Functor.ts
+++ b/src/Functor.ts
@@ -113,6 +113,10 @@ export function flap<F>(F: Functor<F>): <A>(a: A) => <B>(fab: HKT<F, (a: A) => B
  * @category combinators
  * @since 3.0.0
  */
+export function map<F extends URIS, G extends URIS2>(
+  F: Functor1<F>,
+  G: Functor2<G>
+): <A, B>(f: (a: A) => B) => <E>(fa: Kind<F, Kind2<G, E, A>>) => Kind<F, Kind2<G, E, B>>
 export function map<F, G extends URIS2>(
   F: Functor<F>,
   G: Functor2<G>


### PR DESCRIPTION
Adds missing overloads to `Functor.map` for Kind(2/3/4) in the 3.0.0 branch
