### PR TITLE
fix: Name Reader variable correct in promap type signature

### DIFF
--- a/src/Reader.ts
+++ b/src/Reader.ts
@@ -150,7 +150,7 @@ export const compose: <A, B>(ab: Reader<A, B>) => <C>(bc: Reader<B, C>) => Reade
  * @category Profunctor
  * @since 2.0.0
  */
-export const promap: <E, A, D, B>(f: (d: D) => E, g: (a: A) => B) => (fbc: Reader<E, A>) => Reader<D, B> = (f, g) => (
+export const promap: <E, A, D, B>(f: (d: D) => E, g: (a: A) => B) => (fea: Reader<E, A>) => Reader<D, B> = (f, g) => (
   fea
 ) => (a) => g(fea(f(a)))
 


### PR DESCRIPTION
Name the Reader variable in the promap type signature `fea` instead of `fbc`. 