### PR TITLE
Add/fix pure comments

### DIFF
--- a/src/Array.ts
+++ b/src/Array.ts
@@ -1852,7 +1852,7 @@ export const Functor: Functor1<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/Const.ts
+++ b/src/Const.ts
@@ -218,7 +218,7 @@ export const Functor: Functor2<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -1295,7 +1295,9 @@ export const apSW: <A, N extends string, E2, B>(
 /**
  * @since 2.11.0
  */
-export const ApT: Either<never, readonly []> = of(_.emptyReadonlyArray)
+export const ApT: Either<never, readonly []> =
+  /*#__PURE__*/
+  of(_.emptyReadonlyArray)
 
 // -------------------------------------------------------------------------------------
 // array utils

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -911,7 +911,7 @@ export const getOrElse: <E, A>(onLeft: (e: E) => A) => (ma: Either<E, A>) => A =
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/IO.ts
+++ b/src/IO.ts
@@ -137,7 +137,7 @@ export const Functor: Functor1<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/IO.ts
+++ b/src/IO.ts
@@ -314,7 +314,9 @@ export const apS =
 /**
  * @since 2.11.0
  */
-export const ApT: IO<readonly []> = of(_.emptyReadonlyArray)
+export const ApT: IO<readonly []> =
+  /*#__PURE__*/
+  of(_.emptyReadonlyArray)
 
 // -------------------------------------------------------------------------------------
 // array utils

--- a/src/IOEither.ts
+++ b/src/IOEither.ts
@@ -924,7 +924,9 @@ export const apSW: <A, N extends string, E2, B>(
 /**
  * @since 2.11.0
  */
-export const ApT: IOEither<never, readonly []> = of(_.emptyReadonlyArray)
+export const ApT: IOEither<never, readonly []> =
+  /*#__PURE__*/
+  of(_.emptyReadonlyArray)
 
 // -------------------------------------------------------------------------------------
 // array utils

--- a/src/IOEither.ts
+++ b/src/IOEither.ts
@@ -533,7 +533,7 @@ export const Functor: Functor2<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/Identity.ts
+++ b/src/Identity.ts
@@ -224,7 +224,7 @@ export const Functor: Functor1<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -831,7 +831,7 @@ export const Functor: Functor2<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/NonEmptyArray.ts
+++ b/src/NonEmptyArray.ts
@@ -900,7 +900,7 @@ export const Functor: Functor1<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -1202,7 +1202,9 @@ export const apS =
 /**
  * @since 2.11.0
  */
-export const ApT: Option<readonly []> = of(_.emptyReadonlyArray)
+export const ApT: Option<readonly []> =
+  /*#__PURE__*/
+  of(_.emptyReadonlyArray)
 
 // -------------------------------------------------------------------------------------
 // array utils

--- a/src/Ord.ts
+++ b/src/Ord.ts
@@ -233,7 +233,7 @@ export const Contravariant: Contravariant1<URI> = {
  */
 export const trivial: Ord<unknown> = {
   equals: constTrue,
-  compare: constant(0)
+  compare: /*#__PURE__*/ constant(0)
 }
 
 /**

--- a/src/Reader.ts
+++ b/src/Reader.ts
@@ -249,7 +249,7 @@ export const Functor: Functor2<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/Reader.ts
+++ b/src/Reader.ts
@@ -461,7 +461,9 @@ export const apSW: <A, N extends string, R2, B>(
 /**
  * @since 2.11.0
  */
-export const ApT: Reader<unknown, readonly []> = of(_.emptyReadonlyArray)
+export const ApT: Reader<unknown, readonly []> =
+  /*#__PURE__*/
+  of(_.emptyReadonlyArray)
 
 // -------------------------------------------------------------------------------------
 // array utils

--- a/src/ReaderEither.ts
+++ b/src/ReaderEither.ts
@@ -562,7 +562,7 @@ export const Functor: Functor3<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/ReaderEither.ts
+++ b/src/ReaderEither.ts
@@ -953,7 +953,9 @@ export const apSW: <A, N extends string, R2, E2, B>(
 /**
  * @since 2.11.0
  */
-export const ApT: ReaderEither<unknown, never, readonly []> = of(_.emptyReadonlyArray)
+export const ApT: ReaderEither<unknown, never, readonly []> =
+  /*#__PURE__*/
+  of(_.emptyReadonlyArray)
 
 // -------------------------------------------------------------------------------------
 // array utils

--- a/src/ReaderTask.ts
+++ b/src/ReaderTask.ts
@@ -238,7 +238,7 @@ export const Functor: Functor2<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/ReaderTask.ts
+++ b/src/ReaderTask.ts
@@ -594,7 +594,9 @@ export const apSW: <A, N extends string, R2, B>(
 /**
  * @since 2.11.0
  */
-export const ApT: ReaderTask<unknown, readonly []> = of(_.emptyReadonlyArray)
+export const ApT: ReaderTask<unknown, readonly []> =
+  /*#__PURE__*/
+  of(_.emptyReadonlyArray)
 
 // -------------------------------------------------------------------------------------
 // array utils

--- a/src/ReaderTaskEither.ts
+++ b/src/ReaderTaskEither.ts
@@ -790,7 +790,7 @@ export const Functor: Functor3<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/ReaderTaskEither.ts
+++ b/src/ReaderTaskEither.ts
@@ -1367,7 +1367,9 @@ export const apSW: <A, N extends string, R2, E2, B>(
 /**
  * @since 2.11.0
  */
-export const ApT: ReaderTaskEither<unknown, never, readonly []> = of(_.emptyReadonlyArray)
+export const ApT: ReaderTaskEither<unknown, never, readonly []> =
+  /*#__PURE__*/
+  of(_.emptyReadonlyArray)
 
 // -------------------------------------------------------------------------------------
 // array utils

--- a/src/ReadonlyArray.ts
+++ b/src/ReadonlyArray.ts
@@ -1976,7 +1976,7 @@ export const Functor: Functor1<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/ReadonlyMap.ts
+++ b/src/ReadonlyMap.ts
@@ -842,7 +842,7 @@ export const Functor: Functor2<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/ReadonlyNonEmptyArray.ts
+++ b/src/ReadonlyNonEmptyArray.ts
@@ -955,7 +955,7 @@ export const Functor: Functor1<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/ReadonlyRecord.ts
+++ b/src/ReadonlyRecord.ts
@@ -1322,7 +1322,7 @@ export const Functor: Functor1<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/ReadonlyRecord.ts
+++ b/src/ReadonlyRecord.ts
@@ -1517,9 +1517,9 @@ export const getDifferenceMagma = <A>(): Magma<ReadonlyRecord<string, A>> => ({
  */
 export const Foldable: Foldable1<URI> = {
   URI,
-  reduce: _reduce(S.Ord),
-  foldMap: _foldMap(S.Ord),
-  reduceRight: _reduceRight(S.Ord)
+  reduce: /*#__PURE__*/ _reduce(S.Ord),
+  foldMap: /*#__PURE__*/ _foldMap(S.Ord),
+  reduceRight: /*#__PURE__*/ _reduceRight(S.Ord)
 }
 
 /**
@@ -1531,12 +1531,12 @@ export const Foldable: Foldable1<URI> = {
  */
 export const FoldableWithIndex: FoldableWithIndex1<URI, string> = {
   URI,
-  reduce: _reduce(S.Ord),
-  foldMap: _foldMap(S.Ord),
-  reduceRight: _reduceRight(S.Ord),
-  reduceWithIndex: _reduceWithIndex(S.Ord),
-  foldMapWithIndex: _foldMapWithIndex(S.Ord),
-  reduceRightWithIndex: _reduceRightWithIndex(S.Ord)
+  reduce: /*#__PURE__*/ _reduce(S.Ord),
+  foldMap: /*#__PURE__*/ _foldMap(S.Ord),
+  reduceRight: /*#__PURE__*/ _reduceRight(S.Ord),
+  reduceWithIndex: /*#__PURE__*/ _reduceWithIndex(S.Ord),
+  foldMapWithIndex: /*#__PURE__*/ _foldMapWithIndex(S.Ord),
+  reduceRightWithIndex: /*#__PURE__*/ _reduceRightWithIndex(S.Ord)
 }
 
 /**
@@ -1549,10 +1549,10 @@ export const FoldableWithIndex: FoldableWithIndex1<URI, string> = {
 export const Traversable: Traversable1<URI> = {
   URI,
   map: _map,
-  reduce: _reduce(S.Ord),
-  foldMap: _foldMap(S.Ord),
-  reduceRight: _reduceRight(S.Ord),
-  traverse: _traverse(S.Ord),
+  reduce: /*#__PURE__*/ _reduce(S.Ord),
+  foldMap: /*#__PURE__*/ _foldMap(S.Ord),
+  reduceRight: /*#__PURE__*/ _reduceRight(S.Ord),
+  traverse: /*#__PURE__*/ _traverse(S.Ord),
   sequence
 }
 
@@ -1567,19 +1567,19 @@ export const TraversableWithIndex: TraversableWithIndex1<URI, string> = {
   URI,
   map: _map,
   mapWithIndex: _mapWithIndex,
-  reduce: _reduce(S.Ord),
-  foldMap: _foldMap(S.Ord),
-  reduceRight: _reduceRight(S.Ord),
-  reduceWithIndex: _reduceWithIndex(S.Ord),
-  foldMapWithIndex: _foldMapWithIndex(S.Ord),
-  reduceRightWithIndex: _reduceRightWithIndex(S.Ord),
-  traverse: _traverse(S.Ord),
+  reduce: /*#__PURE__*/ _reduce(S.Ord),
+  foldMap: /*#__PURE__*/ _foldMap(S.Ord),
+  reduceRight: /*#__PURE__*/ _reduceRight(S.Ord),
+  reduceWithIndex: /*#__PURE__*/ _reduceWithIndex(S.Ord),
+  foldMapWithIndex: /*#__PURE__*/ _foldMapWithIndex(S.Ord),
+  reduceRightWithIndex: /*#__PURE__*/ _reduceRightWithIndex(S.Ord),
+  traverse: /*#__PURE__*/ _traverse(S.Ord),
   sequence,
-  traverseWithIndex: _traverseWithIndex(S.Ord)
+  traverseWithIndex: /*#__PURE__*/ _traverseWithIndex(S.Ord)
 }
 
-const _wither = witherDefault(Traversable, Compactable)
-const _wilt = wiltDefault(Traversable, Compactable)
+const _wither = /*#__PURE__*/ witherDefault(Traversable, Compactable)
+const _wilt = /*#__PURE__*/ wiltDefault(Traversable, Compactable)
 
 /**
  * Use `getWitherable` instead.
@@ -1591,10 +1591,10 @@ const _wilt = wiltDefault(Traversable, Compactable)
 export const Witherable: Witherable1<URI> = {
   URI,
   map: _map,
-  reduce: _reduce(S.Ord),
-  foldMap: _foldMap(S.Ord),
-  reduceRight: _reduceRight(S.Ord),
-  traverse: _traverse(S.Ord),
+  reduce: /*#__PURE__*/ _reduce(S.Ord),
+  foldMap: /*#__PURE__*/ _foldMap(S.Ord),
+  reduceRight: /*#__PURE__*/ _reduceRight(S.Ord),
+  traverse: /*#__PURE__*/ _traverse(S.Ord),
   sequence,
   compact,
   separate,
@@ -1640,10 +1640,10 @@ export const readonlyRecord: FunctorWithIndex1<URI, string> &
   Witherable1<URI> = {
   URI,
   map: _map,
-  reduce: _reduce(S.Ord),
-  foldMap: _foldMap(S.Ord),
-  reduceRight: _reduceRight(S.Ord),
-  traverse: _traverse(S.Ord),
+  reduce: /*#__PURE__*/ _reduce(S.Ord),
+  foldMap: /*#__PURE__*/ _foldMap(S.Ord),
+  reduceRight: /*#__PURE__*/ _reduceRight(S.Ord),
+  traverse: /*#__PURE__*/ _traverse(S.Ord),
   sequence,
   compact,
   separate,
@@ -1652,14 +1652,14 @@ export const readonlyRecord: FunctorWithIndex1<URI, string> &
   partition: _partition,
   partitionMap: _partitionMap,
   mapWithIndex: _mapWithIndex,
-  reduceWithIndex: _reduceWithIndex(S.Ord),
-  foldMapWithIndex: _foldMapWithIndex(S.Ord),
-  reduceRightWithIndex: _reduceRightWithIndex(S.Ord),
+  reduceWithIndex: /*#__PURE__*/ _reduceWithIndex(S.Ord),
+  foldMapWithIndex: /*#__PURE__*/ _foldMapWithIndex(S.Ord),
+  reduceRightWithIndex: /*#__PURE__*/ _reduceRightWithIndex(S.Ord),
   filterMapWithIndex: _filterMapWithIndex,
   filterWithIndex: _filterWithIndex,
   partitionMapWithIndex: _partitionMapWithIndex,
   partitionWithIndex: _partitionWithIndex,
-  traverseWithIndex: _traverseWithIndex(S.Ord),
+  traverseWithIndex: /*#__PURE__*/ _traverseWithIndex(S.Ord),
   wither: _wither,
   wilt: _wilt
 }

--- a/src/ReadonlyTuple.ts
+++ b/src/ReadonlyTuple.ts
@@ -322,7 +322,7 @@ export const Functor: Functor2<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -1024,9 +1024,9 @@ export const getDifferenceMagma = <A>(): Magma<Record<string, A>> => ({
  */
 export const Foldable: Foldable1<URI> = {
   URI,
-  reduce: _reduce(S.Ord),
-  foldMap: _foldMap(S.Ord),
-  reduceRight: _reduceRight(S.Ord)
+  reduce: /*#__PURE__*/ _reduce(S.Ord),
+  foldMap: /*#__PURE__*/ _foldMap(S.Ord),
+  reduceRight: /*#__PURE__*/ _reduceRight(S.Ord)
 }
 
 /**
@@ -1038,12 +1038,12 @@ export const Foldable: Foldable1<URI> = {
  */
 export const FoldableWithIndex: FoldableWithIndex1<URI, string> = {
   URI,
-  reduce: _reduce(S.Ord),
-  foldMap: _foldMap(S.Ord),
-  reduceRight: _reduceRight(S.Ord),
-  reduceWithIndex: _reduceWithIndex(S.Ord),
-  foldMapWithIndex: _foldMapWithIndex(S.Ord),
-  reduceRightWithIndex: _reduceRightWithIndex(S.Ord)
+  reduce: /*#__PURE__*/ _reduce(S.Ord),
+  foldMap: /*#__PURE__*/ _foldMap(S.Ord),
+  reduceRight: /*#__PURE__*/ _reduceRight(S.Ord),
+  reduceWithIndex: /*#__PURE__*/ _reduceWithIndex(S.Ord),
+  foldMapWithIndex: /*#__PURE__*/ _foldMapWithIndex(S.Ord),
+  reduceRightWithIndex: /*#__PURE__*/ _reduceRightWithIndex(S.Ord)
 }
 
 /**
@@ -1056,10 +1056,10 @@ export const FoldableWithIndex: FoldableWithIndex1<URI, string> = {
 export const Traversable: Traversable1<URI> = {
   URI,
   map: _map,
-  reduce: _reduce(S.Ord),
-  foldMap: _foldMap(S.Ord),
-  reduceRight: _reduceRight(S.Ord),
-  traverse: _traverse(S.Ord),
+  reduce: /*#__PURE__*/ _reduce(S.Ord),
+  foldMap: /*#__PURE__*/ _foldMap(S.Ord),
+  reduceRight: /*#__PURE__*/ _reduceRight(S.Ord),
+  traverse: /*#__PURE__*/ _traverse(S.Ord),
   sequence
 }
 
@@ -1074,19 +1074,19 @@ export const TraversableWithIndex: TraversableWithIndex1<URI, string> = {
   URI,
   map: _map,
   mapWithIndex: _mapWithIndex,
-  reduce: _reduce(S.Ord),
-  foldMap: _foldMap(S.Ord),
-  reduceRight: _reduceRight(S.Ord),
-  reduceWithIndex: _reduceWithIndex(S.Ord),
-  foldMapWithIndex: _foldMapWithIndex(S.Ord),
-  reduceRightWithIndex: _reduceRightWithIndex(S.Ord),
-  traverse: _traverse(S.Ord),
+  reduce: /*#__PURE__*/ _reduce(S.Ord),
+  foldMap: /*#__PURE__*/ _foldMap(S.Ord),
+  reduceRight: /*#__PURE__*/ _reduceRight(S.Ord),
+  reduceWithIndex: /*#__PURE__*/ _reduceWithIndex(S.Ord),
+  foldMapWithIndex: /*#__PURE__*/ _foldMapWithIndex(S.Ord),
+  reduceRightWithIndex: /*#__PURE__*/ _reduceRightWithIndex(S.Ord),
+  traverse: /*#__PURE__*/ _traverse(S.Ord),
   sequence,
-  traverseWithIndex: _traverseWithIndex(S.Ord)
+  traverseWithIndex: /*#__PURE__*/ _traverseWithIndex(S.Ord)
 }
 
-const _wither = witherDefault(Traversable, Compactable)
-const _wilt = wiltDefault(Traversable, Compactable)
+const _wither = /*#__PURE__*/ witherDefault(Traversable, Compactable)
+const _wilt = /*#__PURE__*/ wiltDefault(Traversable, Compactable)
 
 /**
  * Use `getWitherable` instead.
@@ -1098,10 +1098,10 @@ const _wilt = wiltDefault(Traversable, Compactable)
 export const Witherable: Witherable1<URI> = {
   URI,
   map: _map,
-  reduce: _reduce(S.Ord),
-  foldMap: _foldMap(S.Ord),
-  reduceRight: _reduceRight(S.Ord),
-  traverse: _traverse(S.Ord),
+  reduce: /*#__PURE__*/ _reduce(S.Ord),
+  foldMap: /*#__PURE__*/ _foldMap(S.Ord),
+  reduceRight: /*#__PURE__*/ _reduceRight(S.Ord),
+  traverse: /*#__PURE__*/ _traverse(S.Ord),
   sequence,
   compact,
   separate,
@@ -1151,10 +1151,10 @@ export const record: FunctorWithIndex1<URI, string> &
   Witherable1<URI> = {
   URI,
   map: _map,
-  reduce: _reduce(S.Ord),
-  foldMap: _foldMap(S.Ord),
-  reduceRight: _reduceRight(S.Ord),
-  traverse: _traverse(S.Ord),
+  reduce: /*#__PURE__*/ _reduce(S.Ord),
+  foldMap: /*#__PURE__*/ _foldMap(S.Ord),
+  reduceRight: /*#__PURE__*/ _reduceRight(S.Ord),
+  traverse: /*#__PURE__*/ _traverse(S.Ord),
   sequence,
   compact,
   separate,
@@ -1163,14 +1163,14 @@ export const record: FunctorWithIndex1<URI, string> &
   partition: _partition,
   partitionMap: _partitionMap,
   mapWithIndex: _mapWithIndex,
-  reduceWithIndex: _reduceWithIndex(S.Ord),
-  foldMapWithIndex: _foldMapWithIndex(S.Ord),
-  reduceRightWithIndex: _reduceRightWithIndex(S.Ord),
+  reduceWithIndex: /*#__PURE__*/ _reduceWithIndex(S.Ord),
+  foldMapWithIndex: /*#__PURE__*/ _foldMapWithIndex(S.Ord),
+  reduceRightWithIndex: /*#__PURE__*/ _reduceRightWithIndex(S.Ord),
   filterMapWithIndex: _filterMapWithIndex,
   filterWithIndex: _filterWithIndex,
   partitionMapWithIndex: _partitionMapWithIndex,
   partitionWithIndex: _partitionWithIndex,
-  traverseWithIndex: _traverseWithIndex(S.Ord),
+  traverseWithIndex: /*#__PURE__*/ _traverseWithIndex(S.Ord),
   wither: _wither,
   wilt: _wilt
 }

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -829,7 +829,7 @@ export const Functor: Functor1<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/Separated.ts
+++ b/src/Separated.ts
@@ -128,7 +128,7 @@ export const Functor: Functor2<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 // -------------------------------------------------------------------------------------

--- a/src/State.ts
+++ b/src/State.ts
@@ -165,7 +165,7 @@ export const Functor: Functor2<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/StateReaderTaskEither.ts
+++ b/src/StateReaderTaskEither.ts
@@ -557,7 +557,7 @@ export const Functor: Functor4<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -161,7 +161,7 @@ export const Functor: Functor2<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -220,7 +220,7 @@ export const Functor: Functor1<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -465,7 +465,9 @@ export const apS =
 /**
  * @since 2.11.0
  */
-export const ApT: Task<readonly []> = of(_.emptyReadonlyArray)
+export const ApT: Task<readonly []> =
+  /*#__PURE__*/
+  of(_.emptyReadonlyArray)
 
 // -------------------------------------------------------------------------------------
 // array utils

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -698,7 +698,7 @@ export const Functor: Functor2<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -1201,7 +1201,9 @@ export const apSW: <A, N extends string, E2, B>(
 /**
  * @since 2.11.0
  */
-export const ApT: TaskEither<never, readonly []> = of(_.emptyReadonlyArray)
+export const ApT: TaskEither<never, readonly []> =
+  /*#__PURE__*/
+  of(_.emptyReadonlyArray)
 
 // -------------------------------------------------------------------------------------
 // array utils

--- a/src/TaskOption.ts
+++ b/src/TaskOption.ts
@@ -796,7 +796,9 @@ export const apS =
 /**
  * @since 2.11.0
  */
-export const ApT: TaskOption<readonly []> = of(_.emptyReadonlyArray)
+export const ApT: TaskOption<readonly []> =
+  /*#__PURE__*/
+  of(_.emptyReadonlyArray)
 
 // -------------------------------------------------------------------------------------
 // array utils

--- a/src/TaskOption.ts
+++ b/src/TaskOption.ts
@@ -465,7 +465,7 @@ export const Functor: Functor1<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/TaskThese.ts
+++ b/src/TaskThese.ts
@@ -493,7 +493,9 @@ export const toTuple2: <E, A>(e: Lazy<E>, a: Lazy<A>) => (fa: TaskThese<E, A>) =
 /**
  * @since 2.11.0
  */
-export const ApT: TaskThese<never, readonly []> = of(_.emptyReadonlyArray)
+export const ApT: TaskThese<never, readonly []> =
+  /*#__PURE__*/
+  of(_.emptyReadonlyArray)
 
 // -------------------------------------------------------------------------------------
 // array utils

--- a/src/TaskThese.ts
+++ b/src/TaskThese.ts
@@ -368,7 +368,7 @@ export const Functor: Functor2<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/These.ts
+++ b/src/These.ts
@@ -587,7 +587,7 @@ export const Functor: Functor2<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/These.ts
+++ b/src/These.ts
@@ -720,7 +720,9 @@ export const toTuple = <E, A>(e: E, a: A): ((fa: These<E, A>) => [E, A]) =>
 /**
  * @since 2.11.0
  */
-export const ApT: These<never, readonly []> = of(_.emptyReadonlyArray)
+export const ApT: These<never, readonly []> =
+  /*#__PURE__*/
+  of(_.emptyReadonlyArray)
 
 // -------------------------------------------------------------------------------------
 // array utils

--- a/src/Traced.ts
+++ b/src/Traced.ts
@@ -135,7 +135,7 @@ export const Functor: Functor2<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 // -------------------------------------------------------------------------------------

--- a/src/Tree.ts
+++ b/src/Tree.ts
@@ -458,7 +458,7 @@ export const Functor: Functor1<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/Tuple.ts
+++ b/src/Tuple.ts
@@ -301,7 +301,7 @@ export const Functor: Functor2<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 /**

--- a/src/Writer.ts
+++ b/src/Writer.ts
@@ -217,7 +217,7 @@ export const Functor: Functor2<URI> = {
  * @since 2.10.0
  */
 export const flap =
-  /*#_PURE_*/
+  /*#__PURE__*/
   flap_(Functor)
 
 // -------------------------------------------------------------------------------------


### PR DESCRIPTION
After upgrading from 2.10.4 to 2.11.0, our bundle size increased by ~2 KB gzipped. I ran a comparison to see which bundled modules contributed to this change. This inspired me to investigate whether we had any missing or broken pure comments.