### PR TITLE
The bracket should ignore releasing type on the right

### DIFF
--- a/docs/modules/IOEither.ts.md
+++ b/docs/modules/IOEither.ts.md
@@ -1177,10 +1177,10 @@ whether the body action throws (\*) or returns.
 **Signature**
 
 ```ts
-export declare const bracket: <E, A, B>(
+export declare const bracket: <E, A, B, C>(
   acquire: IOEither<E, A>,
   use: (a: A) => IOEither<E, B>,
-  release: (a: A, e: E.Either<E, B>) => IOEither<E, void>
+  release: (a: A, e: E.Either<E, B>) => IOEither<E, C>
 ) => IOEither<E, B>
 ```
 

--- a/docs/modules/ReaderTaskEither.ts.md
+++ b/docs/modules/ReaderTaskEither.ts.md
@@ -1802,10 +1802,10 @@ whether the body action throws (\*) or returns.
 **Signature**
 
 ```ts
-export declare function bracket<R, E, A, B>(
+export declare function bracket<R, E, A, B, C>(
   aquire: ReaderTaskEither<R, E, A>,
   use: (a: A) => ReaderTaskEither<R, E, B>,
-  release: (a: A, e: Either<E, B>) => ReaderTaskEither<R, E, void>
+  release: (a: A, e: Either<E, B>) => ReaderTaskEither<R, E, C>
 ): ReaderTaskEither<R, E, B>
 ```
 

--- a/docs/modules/TaskEither.ts.md
+++ b/docs/modules/TaskEither.ts.md
@@ -1454,10 +1454,10 @@ whether the body action throws (\*) or returns.
 **Signature**
 
 ```ts
-export declare const bracket: <E, A, B>(
+export declare const bracket: <E, A, B, C>(
   acquire: TaskEither<E, A>,
   use: (a: A) => TaskEither<E, B>,
-  release: (a: A, e: E.Either<E, B>) => TaskEither<E, void>
+  release: (a: A, e: E.Either<E, B>) => TaskEither<E, C>
 ) => TaskEither<E, B>
 ```
 

--- a/src/IOEither.ts
+++ b/src/IOEither.ts
@@ -841,10 +841,10 @@ export const fromEitherK: <E, A extends ReadonlyArray<unknown>, B>(
  *
  * @since 2.0.0
  */
-export const bracket = <E, A, B>(
+export const bracket = <E, A, B, C>(
   acquire: IOEither<E, A>,
   use: (a: A) => IOEither<E, B>,
-  release: (a: A, e: Either<E, B>) => IOEither<E, void>
+  release: (a: A, e: Either<E, B>) => IOEither<E, C>
 ): IOEither<E, B> =>
   pipe(
     acquire,

--- a/src/ReaderTaskEither.ts
+++ b/src/ReaderTaskEither.ts
@@ -1291,10 +1291,10 @@ export const chainFirstTaskK =
  *
  * @since 2.0.4
  */
-export function bracket<R, E, A, B>(
+export function bracket<R, E, A, B, C>(
   aquire: ReaderTaskEither<R, E, A>,
   use: (a: A) => ReaderTaskEither<R, E, B>,
-  release: (a: A, e: Either<E, B>) => ReaderTaskEither<R, E, void>
+  release: (a: A, e: Either<E, B>) => ReaderTaskEither<R, E, C>
 ): ReaderTaskEither<R, E, B> {
   return (r) =>
     TE.bracket(

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -1118,10 +1118,10 @@ export function taskify<L, R>(f: Function): () => TaskEither<L, R> {
  *
  * @since 2.0.0
  */
-export const bracket = <E, A, B>(
+export const bracket = <E, A, B, C>(
   acquire: TaskEither<E, A>,
   use: (a: A) => TaskEither<E, B>,
-  release: (a: A, e: Either<E, B>) => TaskEither<E, void>
+  release: (a: A, e: Either<E, B>) => TaskEither<E, C>
 ): TaskEither<E, B> =>
   pipe(
     acquire,


### PR DESCRIPTION
Set to `unknown` would avoid unnecessarily aligning to `void`, so this works:

```ts
import {
    task as T,
    taskEither as TE,
} from 'fp-ts'



const foobar = TE.bracket(
    TE.of(42),
    (a   ) => TE.of(a + 1),
    (_, e) =>  T.of(e),
)

```