### PR TITLE
Add spectacles-ts to Ecosystem

### DIFF
--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -20,6 +20,7 @@ has_toc: false
 - [io-ts](https://github.com/gcanti/io-ts) - TypeScript compatible runtime type system for IO validation
 - [monocle-ts](https://github.com/gcanti/monocle-ts) - Functional optics: a (partial) porting of scala monocle to
   TypeScript
+- [spectacles-ts](https://github.com/anthonyjoeseph/spectacles-ts/) - A simple facade built on top of monocle-ts (autocompletes possible combinators)
 - [newtype-ts](https://github.com/gcanti/newtype-ts) - Implementation of newtypes in TypeScript
 - [logging-ts](https://github.com/gcanti/logging-ts) - Composable loggers for TypeScript
 - [fp-ts-routing](https://github.com/gcanti/fp-ts-routing) - A type-safe bidirectional routing library for TypeScript


### PR DESCRIPTION
Adds [spectacles-ts](https://github.com/anthonyjoeseph/spectacles-ts/) to the fp-ts ecosystem page

It's a simple, syntactically-sugary facade built on top of monocle-ts that autocompletes possible combinators

I think this library could be valuable as a way to get beginners hooked on fp-ts - it's simple to use, has a pretty universal use-case, and heavily features 'pipeable' syntax and the `Option` type

(Ofc please feel free to close this PR - I wasn't sure the best place to have this discussion and I'd be happy to relocate)