### PR TITLE
pipe: fix v8 performance cliff for >10 case stmts

### DIFF
--- a/src/function.ts
+++ b/src/function.ts
@@ -651,18 +651,7 @@ export function pipe(
   ef?: Function,
   fg?: Function,
   gh?: Function,
-  hi?: Function,
-  ij?: Function,
-  jk?: Function,
-  kl?: Function,
-  lm?: Function,
-  mn?: Function,
-  no?: Function,
-  op?: Function,
-  pq?: Function,
-  qr?: Function,
-  rs?: Function,
-  st?: Function
+  hi?: Function
 ): unknown {
   switch (arguments.length) {
     case 1:
@@ -683,30 +672,17 @@ export function pipe(
       return gh!(fg!(ef!(de!(cd!(bc!(ab!(a)))))))
     case 9:
       return hi!(gh!(fg!(ef!(de!(cd!(bc!(ab!(a))))))))
-    case 10:
-      return ij!(hi!(gh!(fg!(ef!(de!(cd!(bc!(ab!(a)))))))))
-    case 11:
-      return jk!(ij!(hi!(gh!(fg!(ef!(de!(cd!(bc!(ab!(a))))))))))
-    case 12:
-      return kl!(jk!(ij!(hi!(gh!(fg!(ef!(de!(cd!(bc!(ab!(a)))))))))))
-    case 13:
-      return lm!(kl!(jk!(ij!(hi!(gh!(fg!(ef!(de!(cd!(bc!(ab!(a))))))))))))
-    case 14:
-      return mn!(lm!(kl!(jk!(ij!(hi!(gh!(fg!(ef!(de!(cd!(bc!(ab!(a)))))))))))))
-    case 15:
-      return no!(mn!(lm!(kl!(jk!(ij!(hi!(gh!(fg!(ef!(de!(cd!(bc!(ab!(a))))))))))))))
-    case 16:
-      return op!(no!(mn!(lm!(kl!(jk!(ij!(hi!(gh!(fg!(ef!(de!(cd!(bc!(ab!(a)))))))))))))))
-    case 17:
-      return pq!(op!(no!(mn!(lm!(kl!(jk!(ij!(hi!(gh!(fg!(ef!(de!(cd!(bc!(ab!(a))))))))))))))))
-    case 18:
-      return qr!(pq!(op!(no!(mn!(lm!(kl!(jk!(ij!(hi!(gh!(fg!(ef!(de!(cd!(bc!(ab!(a)))))))))))))))))
-    case 19:
-      return rs!(qr!(pq!(op!(no!(mn!(lm!(kl!(jk!(ij!(hi!(gh!(fg!(ef!(de!(cd!(bc!(ab!(a))))))))))))))))))
-    case 20:
-      return st!(rs!(qr!(pq!(op!(no!(mn!(lm!(kl!(jk!(ij!(hi!(gh!(fg!(ef!(de!(cd!(bc!(ab!(a)))))))))))))))))))
+    default:
+      let ret
+      for (let i = 0; i < arguments.length; i++) {
+        if (i === 0) {
+          ret = arguments[0]
+        } else {
+          ret = arguments[i](ret)
+        }
+      }
+      return ret
   }
-  return
 }
 
 /**

--- a/src/function.ts
+++ b/src/function.ts
@@ -673,13 +673,9 @@ export function pipe(
     case 9:
       return hi!(gh!(fg!(ef!(de!(cd!(bc!(ab!(a))))))))
     default:
-      let ret
-      for (let i = 0; i < arguments.length; i++) {
-        if (i === 0) {
-          ret = arguments[0]
-        } else {
-          ret = arguments[i](ret)
-        }
+      let ret = arguments[0]
+      for (let i = 1; i < arguments.length; i++) {
+        ret = arguments[i](ret)
       }
       return ret
   }

--- a/test/function.ts
+++ b/test/function.ts
@@ -114,8 +114,7 @@ describe('function', () => {
     U.deepStrictEqual(_.pipe(2, f, g, f, g, f, g, f, g, f, g, f, g, f, g, f, g, f), 1023)
     U.deepStrictEqual(_.pipe(2, f, g, f, g, f, g, f, g, f, g, f, g, f, g, f, g, f, g), 2046)
     U.deepStrictEqual(_.pipe(2, f, g, f, g, f, g, f, g, f, g, f, g, f, g, f, g, f, g, f), 2047)
-    // this is just to satisfy noImplicitReturns and 100% coverage
-    U.deepStrictEqual((_.pipe as any)(...[2, f, g, f, g, f, g, f, g, f, g, f, g, f, g, f, g, f, g, f, g]), undefined)
+    U.deepStrictEqual((_.pipe as any)(...[2, f, g, f, g, f, g, f, g, f, g, f, g, f, g, f, g, f, g, f, g]), 4094)
   })
 
   it('getBooleanAlgebra', () => {


### PR DESCRIPTION
V8 has a performance cliff when there's more than 10 case blocks in a switch
statement. This fix reduces the number of fast specialised case statements
to 9 + extra one for general case.

More details here: https://groups.google.com/g/v8-users/c/_Add2xOVmfU/m/IQHh2IAVBAAJ

Fixes: https://github.com/gcanti/fp-ts/issues/1507