### PR TITLE
fix chainNullableK from option

### DIFF
--- a/docs/modules/Option.ts.md
+++ b/docs/modules/Option.ts.md
@@ -241,7 +241,7 @@ Use [`chainNullableK`](#chainnullablek) instead.
 **Signature**
 
 ```ts
-export declare const mapNullable: <A, B>(f: (a: A) => B | null | undefined) => (ma: Option<A>) => Option<B>
+export declare const mapNullable: <A, B>(f: (a: A) => B | null | undefined) => (ma: Option<A>) => Option<NonNullable<B>>
 ```
 
 Added in v2.0.0
@@ -1163,7 +1163,9 @@ This is `chain` + `fromNullable`, useful when working with optional values.
 **Signature**
 
 ```ts
-export declare const chainNullableK: <A, B>(f: (a: A) => B | null | undefined) => (ma: Option<A>) => Option<B>
+export declare const chainNullableK: <A, B>(
+  f: (a: A) => B | null | undefined
+) => (ma: Option<A>) => Option<NonNullable<B>>
 ```
 
 **Example**

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -1043,7 +1043,7 @@ export const fromNullableK: <A extends ReadonlyArray<unknown>, B>(
  * @category interop
  * @since 2.9.0
  */
-export const chainNullableK = <A, B>(f: (a: A) => B | null | undefined) => (ma: Option<A>): Option<B> =>
+export const chainNullableK = <A, B>(f: (a: A) => B | null | undefined) => (ma: Option<A>): Option<NonNullable<B>> =>
   isNone(ma) ? none : fromNullable(f(ma.value))
 
 /**


### PR DESCRIPTION
add missing NonNullable

Why:

```ts
type A = {
  k?: Array<'hello' | 'world'> | undefined
}

function program<K extends keyof A>(
  k: K,
  fa: O.Option<A>
): NonNullable<A[K]>[number] | undefined {
  // Type 'unknown' is not assignable to type 'NonNullable<A[K]>[number] | undefined'.
  //  Type 'unknown' is not assignable to type 'NonNullable<A[K]>[number]'.
  //    Type 'unknown' is not assignable to type 'string'.ts(2322)
  // |
  return pipe(
    fa,
    O.chainNullableK((a) => a[k]),
    O.chain(A.head),
    O.toUndefined
  )
}
```

This code does not compile. The expected result should be
```ts
function program<"k">(k: "k", fa: O.Option<A>): "hello" | "world" | undefined
```