### PR TITLE
Add filterCollect to Record, Map and variants

### DIFF
--- a/docs/modules/Map.ts.md
+++ b/docs/modules/Map.ts.md
@@ -58,6 +58,7 @@ Added in v2.0.0
   - [collect](#collect)
   - [difference](#difference)
   - [elem](#elem)
+  - [filterCollect](#filtercollect)
   - [foldMap](#foldmap)
   - [foldMapWithIndex](#foldmapwithindex)
   - [intersection](#intersection)
@@ -536,6 +537,16 @@ export declare const elem: <A>(E: Eq<A>) => { (a: A): <K>(m: Map<K, A>) => boole
 ```
 
 Added in v2.0.0
+
+## filterCollect
+
+**Signature**
+
+```ts
+export declare const filterCollect: <K>(O: Ord<K>) => <A, B>(f: (k: K, a: A) => O.Option<B>) => (m: Map<K, A>) => B[]
+```
+
+Added in v2.12.0
 
 ## foldMap
 

--- a/docs/modules/ReadonlyMap.ts.md
+++ b/docs/modules/ReadonlyMap.ts.md
@@ -67,6 +67,7 @@ Added in v2.5.0
   - [difference](#difference)
   - [elem](#elem)
   - [empty](#empty)
+  - [filterCollect](#filtercollect)
   - [foldMap](#foldmap)
   - [foldMapWithIndex](#foldmapwithindex)
   - [intersection](#intersection)
@@ -654,6 +655,18 @@ export declare const empty: ReadonlyMap<never, never>
 ```
 
 Added in v2.5.0
+
+## filterCollect
+
+**Signature**
+
+```ts
+export declare function filterCollect<K>(
+  O: Ord<K>
+): <A, B>(f: (k: K, a: A) => Option<B>) => (m: ReadonlyMap<K, A>) => ReadonlyArray<B>
+```
+
+Added in v2.12.0
 
 ## foldMap
 

--- a/docs/modules/ReadonlyRecord.ts.md
+++ b/docs/modules/ReadonlyRecord.ts.md
@@ -78,6 +78,7 @@ Added in v2.5.0
   - [elem](#elem)
   - [empty](#empty)
   - [every](#every)
+  - [filterCollect](#filtercollect)
   - [filterWithIndex](#filterwithindex)
   - [foldMapWithIndex](#foldmapwithindex)
   - [fromFoldable](#fromfoldable)
@@ -791,6 +792,40 @@ export declare function every<A>(predicate: Predicate<A>): (r: ReadonlyRecord<st
 ```
 
 Added in v2.5.0
+
+## filterCollect
+
+Map a `ReadonlyRecord` into a `ReadonlyArray` passing a key/value pair to the
+iterating function and filtering out undesired results. The keys in the
+resulting record are sorted according to the passed instance of
+`Ord<string>`.
+
+**Signature**
+
+```ts
+export declare function filterCollect(
+  O: Ord<string>
+): <K extends string, A, B>(f: (k: K, a: A) => Option<B>) => (r: ReadonlyRecord<K, A>) => ReadonlyArray<B>
+```
+
+**Example**
+
+```ts
+import { none, some } from 'fp-ts/Option'
+import { filterCollect } from 'fp-ts/ReadonlyRecord'
+import { Ord } from 'fp-ts/string'
+
+const x: { readonly a: string; readonly b: boolean; readonly c: number } = { a: 'c', b: false, c: 123 }
+assert.deepStrictEqual(
+  filterCollect(Ord)((key, value) => (typeof value === 'boolean' ? none : some({ key, value })))(x),
+  [
+    { key: 'a', value: 'c' },
+    { key: 'c', value: 123 },
+  ]
+)
+```
+
+Added in v2.12.0
 
 ## filterWithIndex
 

--- a/docs/modules/Record.ts.md
+++ b/docs/modules/Record.ts.md
@@ -64,6 +64,7 @@ Added in v2.0.0
   - [deleteAt](#deleteat)
   - [elem](#elem)
   - [every](#every)
+  - [filterCollect](#filtercollect)
   - [filterMapWithIndex](#filtermapwithindex)
   - [filterWithIndex](#filterwithindex)
   - [foldMapWithIndex](#foldmapwithindex)
@@ -640,6 +641,39 @@ export declare const every: <A>(predicate: Predicate<A>) => (r: Record<string, A
 ```
 
 Added in v2.0.0
+
+## filterCollect
+
+Map a `Record` into an `Array` passing a key/value pair to the iterating
+function and filtering out undesired results. The keys in the resulting
+record are sorted according to the passed instance of `Ord<string>`.
+
+**Signature**
+
+```ts
+export declare const filterCollect: (
+  O: Ord<string>
+) => <K extends string, A, B>(f: (k: K, a: A) => Option<B>) => (r: Record<K, A>) => B[]
+```
+
+**Example**
+
+```ts
+import { none, some } from 'fp-ts/Option'
+import { filterCollect } from 'fp-ts/Record'
+import { Ord } from 'fp-ts/string'
+
+const x: { readonly a: string; readonly b: boolean; readonly c: number } = { a: 'c', b: false, c: 123 }
+assert.deepStrictEqual(
+  filterCollect(Ord)((key, value) => (typeof value === 'boolean' ? none : some({ key, value })))(x),
+  [
+    { key: 'a', value: 'c' },
+    { key: 'c', value: 123 },
+  ]
+)
+```
+
+Added in v2.12.0
 
 ## filterMapWithIndex
 

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -105,6 +105,13 @@ export function collect<K>(O: Ord<K>): <A, B>(f: (k: K, a: A) => B) => (m: Map<K
 }
 
 /**
+ * @since 2.12.0
+ */
+export const filterCollect: <K>(
+  O: Ord<K>
+) => <A, B>(f: (k: K, a: A) => Option<B>) => (m: Map<K, A>) => Array<B> = RM.filterCollect as any
+
+/**
  * Get a sorted `Array` of the key/value pairs contained in a `Map`.
  *
  * @since 2.0.0

--- a/src/ReadonlyMap.ts
+++ b/src/ReadonlyMap.ts
@@ -169,6 +169,25 @@ export function collect<K>(O: Ord<K>): <A, B>(f: (k: K, a: A) => B) => (m: Reado
 }
 
 /**
+ * @since 2.12.0
+ */
+export function filterCollect<K>(
+  O: Ord<K>
+): <A, B>(f: (k: K, a: A) => Option<B>) => (m: ReadonlyMap<K, A>) => ReadonlyArray<B> {
+  const keysO = keys(O)
+  return <A, B>(f: (k: K, a: A) => Option<B>) => (m: ReadonlyMap<K, A>): ReadonlyArray<B> => {
+    const out: Array<B> = []
+    for (const key of keysO(m)) {
+      const x = f(key, m.get(key)!)
+      if (_.isSome(x)) {
+        out.push(x.value)
+      }
+    }
+    return out
+  }
+}
+
+/**
  * Get a sorted `ReadonlyArray` of the key/value pairs contained in a `ReadonlyMap`.
  *
  * @since 2.5.0

--- a/src/ReadonlyRecord.ts
+++ b/src/ReadonlyRecord.ts
@@ -129,6 +129,41 @@ export function collect<A, B>(
 }
 
 /**
+ * Map a `ReadonlyRecord` into a `ReadonlyArray` passing a key/value pair to the
+ * iterating function and filtering out undesired results. The keys in the
+ * resulting record are sorted according to the passed instance of
+ * `Ord<string>`.
+ *
+ * @example
+ * import { none, some } from 'fp-ts/Option'
+ * import { filterCollect } from 'fp-ts/ReadonlyRecord'
+ * import { Ord } from 'fp-ts/string'
+ *
+ * const x: { readonly a: string, readonly b: boolean, readonly c: number } = { a: 'c', b: false, c: 123 }
+ * assert.deepStrictEqual(
+ *   filterCollect(Ord)((key, value) => typeof value === 'boolean' ? none : some({ key, value }))(x),
+ *   [{ key: 'a', value: 'c' }, { key: 'c', value: 123 }]
+ * )
+ *
+ * @since 2.12.0
+ */
+export function filterCollect(
+  O: Ord<string>
+): <K extends string, A, B>(f: (k: K, a: A) => Option<B>) => (r: ReadonlyRecord<K, A>) => ReadonlyArray<B> {
+  const keysO = keys_(O)
+  return <K extends string, A, B>(f: (k: K, a: A) => Option<B>) => (r: ReadonlyRecord<K, A>): ReadonlyArray<B> => {
+    const out: Array<B> = []
+    for (const key of keysO(r)) {
+      const x = f(key, r[key])
+      if (_.isSome(x)) {
+        out.push(x.value)
+      }
+    }
+    return out
+  }
+}
+
+/**
  * Get a sorted `ReadonlyArray` of the key/value pairs contained in a `ReadonlyRecord`.
  *
  * @since 2.5.0

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -99,6 +99,28 @@ export function collect<A, B>(
 }
 
 /**
+ * Map a `Record` into an `Array` passing a key/value pair to the iterating
+ * function and filtering out undesired results. The keys in the resulting
+ * record are sorted according to the passed instance of `Ord<string>`.
+ *
+ * @example
+ * import { none, some } from 'fp-ts/Option'
+ * import { filterCollect } from 'fp-ts/Record'
+ * import { Ord } from 'fp-ts/string'
+ *
+ * const x: { readonly a: string, readonly b: boolean, readonly c: number } = { a: 'c', b: false, c: 123 }
+ * assert.deepStrictEqual(
+ *   filterCollect(Ord)((key, value) => typeof value === 'boolean' ? none : some({ key, value }))(x),
+ *   [{ key: 'a', value: 'c' }, { key: 'c', value: 123 }]
+ * )
+ *
+ * @since 2.12.0
+ */
+export const filterCollect: (
+  O: Ord<string>
+) => <K extends string, A, B>(f: (k: K, a: A) => Option<B>) => (r: Record<K, A>) => Array<B> = RR.filterCollect as any
+
+/**
  * Get a sorted `Array` of the key/value pairs contained in a `Record`.
  *
  * @since 2.0.0

--- a/test/Map.ts
+++ b/test/Map.ts
@@ -225,6 +225,61 @@ describe('Map', () => {
     )
   })
 
+  it('filterCollect', () => {
+    const collectO = _.filterCollect(ordUser)
+    const f = (_k: User, a: number): O.Option<number> => (a % 2 === 0 ? O.none : O.some(a + 1))
+    U.deepStrictEqual(
+      collectO(f)(
+        new Map<User, number>([
+          [{ id: 'a' }, 1],
+          [{ id: 'b' }, 2],
+          [{ id: 'c' }, 3]
+        ])
+      ),
+      [2, 4]
+    )
+    U.deepStrictEqual(
+      collectO(f)(
+        new Map<User, number>([
+          [{ id: 'b' }, 2],
+          [{ id: 'a' }, 1],
+          [{ id: 'c' }, 3]
+        ])
+      ),
+      [2, 4]
+    )
+
+    const collect = _.filterCollect(ordKey)
+    const g = (k: Key, a: Value): O.Option<readonly [number, number]> =>
+      k.id % 2 === 0 ? O.some([k.id, a.value]) : O.none
+    U.deepStrictEqual(
+      collect(g)(
+        new Map([
+          [{ id: 1 }, { value: 1 }],
+          [{ id: 2 }, { value: 2 }],
+          [{ id: 4 }, { value: 4 }]
+        ])
+      ),
+      [
+        [4, 4],
+        [2, 2]
+      ]
+    )
+    U.deepStrictEqual(
+      collect(g)(
+        new Map([
+          [{ id: 2 }, { value: 2 }],
+          [{ id: 1 }, { value: 1 }],
+          [{ id: 4 }, { value: 4 }]
+        ])
+      ),
+      [
+        [4, 4],
+        [2, 2]
+      ]
+    )
+  })
+
   it('toArray', () => {
     const m1 = new Map<User, number>([
       [{ id: 'a' }, 1],

--- a/test/ReadonlyMap.ts
+++ b/test/ReadonlyMap.ts
@@ -321,6 +321,61 @@ describe('ReadonlyMap', () => {
     )
   })
 
+  it('filterCollect', () => {
+    const collectO = _.filterCollect(ordUser)
+    const f = (_k: User, a: number): O.Option<number> => (a % 2 === 0 ? O.none : O.some(a + 1))
+    U.deepStrictEqual(
+      collectO(f)(
+        new Map<User, number>([
+          [{ id: 'a' }, 1],
+          [{ id: 'b' }, 2],
+          [{ id: 'c' }, 3]
+        ])
+      ),
+      [2, 4]
+    )
+    U.deepStrictEqual(
+      collectO(f)(
+        new Map<User, number>([
+          [{ id: 'b' }, 2],
+          [{ id: 'a' }, 1],
+          [{ id: 'c' }, 3]
+        ])
+      ),
+      [2, 4]
+    )
+
+    const collect = _.filterCollect(ordKey)
+    const g = (k: Key, a: Value): O.Option<readonly [number, number]> =>
+      k.id % 2 === 0 ? O.some([k.id, a.value]) : O.none
+    U.deepStrictEqual(
+      collect(g)(
+        new Map([
+          [{ id: 1 }, { value: 1 }],
+          [{ id: 2 }, { value: 2 }],
+          [{ id: 4 }, { value: 4 }]
+        ])
+      ),
+      [
+        [4, 4],
+        [2, 2]
+      ]
+    )
+    U.deepStrictEqual(
+      collect(g)(
+        new Map([
+          [{ id: 2 }, { value: 2 }],
+          [{ id: 1 }, { value: 1 }],
+          [{ id: 4 }, { value: 4 }]
+        ])
+      ),
+      [
+        [4, 4],
+        [2, 2]
+      ]
+    )
+  })
+
   it('toReadonlyArray', () => {
     const m1 = new Map<User, number>([
       [{ id: 'a' }, 1],

--- a/test/ReadonlyRecord.ts
+++ b/test/ReadonlyRecord.ts
@@ -31,6 +31,16 @@ describe('ReadonlyRecord', () => {
         { key: 'b', value: false }
       ])
     })
+    it('filterCollect', () => {
+      const x: { readonly a: string; readonly b: boolean; readonly c: number } = { a: 'c', b: false, c: 123 }
+      U.deepStrictEqual(
+        _.filterCollect(S.Ord)((key, value) => (typeof value === 'boolean' ? O.none : O.some({ key, value })))(x),
+        [
+          { key: 'a', value: 'c' },
+          { key: 'c', value: 123 }
+        ]
+      )
+    })
 
     it('map', () => {
       U.deepStrictEqual(pipe({ k1: 1, k2: 2 }, _.map(U.double)), { k1: 2, k2: 4 })

--- a/test/Record.ts
+++ b/test/Record.ts
@@ -31,6 +31,16 @@ describe('Record', () => {
         { key: 'b', value: false }
       ])
     })
+    it('filterCollect', () => {
+      const x = { a: 'c', b: false, c: 123 }
+      U.deepStrictEqual(
+        _.filterCollect(S.Ord)((key, value) => (typeof value === 'boolean' ? O.none : O.some({ key, value })))(x),
+        [
+          { key: 'a', value: 'c' },
+          { key: 'c', value: 123 }
+        ]
+      )
+    })
 
     it('map', () => {
       U.deepStrictEqual(pipe({ k1: 1, k2: 2 }, _.map(U.double)), { k1: 2, k2: 4 })


### PR DESCRIPTION
There is `filterMap` as filtering extensions for `map`. This adds similar filtering variants for `collect`.