### PR TITLE
chore: improve task execution order

### DIFF
--- a/src/Task.ts
+++ b/src/Task.ts
@@ -51,7 +51,7 @@ export interface Task<A> {
 
 let running = false
 // tslint:disable-next-line
-let queue = [] as Lazy<void>[]
+let queue: Lazy<void>[] = []
 const _schedule = <A>(task: Task<A>): Task<A> => () =>
   new Promise<A>((res, rej) => {
     queue.push(() => {


### PR DESCRIPTION
Some have noticed that the order of execution changed after the microtask PR got introduced, while there is no guarantee of order in case of parallel combinators it would still be good to preserve it if possible.

This PR introduce an internal task scheduler that uses mictotasks but avoids oversuspension, it basically suspends once and executes everything that can be scheduled in a loop until nothing else is to be done, this mechanisms preserves the order of scheduling because scheduling is sync within a single suspension