### PR TITLE
Add nullable interop helpers for `EitherT` & `TaskEither`

### DIFF
--- a/docs/modules/EitherT.ts.md
+++ b/docs/modules/EitherT.ts.md
@@ -22,6 +22,9 @@ Added in v2.0.0
   - [ap](#ap)
   - [bimap](#bimap)
   - [chain](#chain)
+  - [chainNullableK](#chainnullablek)
+  - [fromNullable](#fromnullable)
+  - [fromNullableK](#fromnullablek)
   - [getOrElse](#getorelse)
   - [left](#left)
   - [leftF](#leftf)
@@ -249,6 +252,146 @@ export declare function chain<M>(
 ```
 
 Added in v2.10.0
+
+## chainNullableK
+
+**Signature**
+
+```ts
+export declare function chainNullableK<M extends URIS4>(
+  M: Monad4<M>
+): <E>(
+  e: E
+) => <A, B>(
+  f: (a: A) => B | null | undefined
+) => <S, R, T>(ma: Kind4<M, S, R, T, Either<E, A>>) => Kind4<M, S, R, T, Either<E, NonNullable<B>>>
+export declare function chainNullableK<M extends URIS3>(
+  M: Monad3<M>
+): <E>(
+  e: E
+) => <A, B>(
+  f: (a: A) => B | null | undefined
+) => <R, T>(ma: Kind3<M, R, T, Either<E, A>>) => Kind3<M, R, T, Either<E, NonNullable<B>>>
+export declare function chainNullableK<M extends URIS3, T>(
+  M: Monad3C<M, T>
+): <E>(
+  e: E
+) => <A, B>(
+  f: (a: A) => B | null | undefined
+) => <R>(ma: Kind3<M, R, T, Either<E, A>>) => Kind3<M, R, T, Either<E, NonNullable<B>>>
+export declare function chainNullableK<M extends URIS2>(
+  M: Monad2<M>
+): <E>(
+  e: E
+) => <A, B>(
+  f: (a: A) => B | null | undefined
+) => <T>(ma: Kind2<M, T, Either<E, A>>) => Kind2<M, T, Either<E, NonNullable<B>>>
+export declare function chainNullableK<M extends URIS2, T>(
+  M: Monad2C<M, T>
+): <E>(
+  e: E
+) => <A, B>(
+  f: (a: A) => B | null | undefined
+) => (ma: Kind2<M, T, Either<E, A>>) => Kind2<M, T, Either<E, NonNullable<B>>>
+export declare function chainNullableK<M extends URIS>(
+  M: Monad1<M>
+): <E>(
+  e: E
+) => <A, B>(f: (a: A) => B | null | undefined) => (ma: Kind<M, Either<E, A>>) => Kind<M, Either<E, NonNullable<B>>>
+export declare function chainNullableK<M>(
+  M: Monad<M>
+): <E>(
+  e: E
+) => <A, B>(f: (a: A) => B | null | undefined) => (ma: HKT<M, Either<E, A>>) => HKT<M, Either<E, NonNullable<B>>>
+```
+
+Added in v2.12.0
+
+## fromNullable
+
+**Signature**
+
+```ts
+export declare function fromNullable<F extends URIS4>(
+  F: Pointed4<F>
+): <E>(e: E) => <A, S, R, T>(a: A) => Kind4<F, S, R, T, Either<E, NonNullable<A>>>
+export declare function fromNullable<F extends URIS3>(
+  F: Pointed3<F>
+): <E>(e: E) => <A, R, T>(a: A) => Kind3<F, R, T, Either<E, NonNullable<A>>>
+export declare function fromNullable<F extends URIS3, T>(
+  F: Pointed3C<F, T>
+): <E>(e: E) => <A, R>(a: A) => Kind3<F, R, T, Either<E, NonNullable<A>>>
+export declare function fromNullable<F extends URIS2>(
+  F: Pointed2<F>
+): <E>(e: E) => <A, T>(a: A) => Kind2<F, T, Either<E, NonNullable<A>>>
+export declare function fromNullable<F extends URIS2, T>(
+  F: Pointed2C<F, T>
+): <E>(e: E) => <A>(a: A) => Kind2<F, T, Either<E, NonNullable<A>>>
+export declare function fromNullable<F extends URIS>(
+  F: Pointed1<F>
+): <E>(e: E) => <A>(a: A) => Kind<F, Either<E, NonNullable<A>>>
+export declare function fromNullable<F>(F: Pointed<F>): <E>(e: E) => <A>(a: A) => HKT<F, Either<E, NonNullable<A>>>
+```
+
+Added in v2.12.0
+
+## fromNullableK
+
+**Signature**
+
+```ts
+export declare function fromNullableK<F extends URIS4>(
+  F: Pointed4<F>
+): <E>(
+  e: E
+) => <A extends ReadonlyArray<unknown>, B>(
+  f: (...a: A) => B | null | undefined
+) => <S, R, T>(...a: A) => Kind4<F, S, R, T, Either<E, NonNullable<B>>>
+export declare function fromNullableK<F extends URIS3>(
+  F: Pointed3<F>
+): <E>(
+  e: E
+) => <A extends ReadonlyArray<unknown>, B>(
+  f: (...a: A) => B | null | undefined
+) => <R, T>(...a: A) => Kind3<F, R, T, Either<E, NonNullable<B>>>
+export declare function fromNullableK<F extends URIS3, T>(
+  F: Pointed3C<F, T>
+): <E>(
+  e: E
+) => <A extends ReadonlyArray<unknown>, B>(
+  f: (...a: A) => B | null | undefined
+) => <R>(...a: A) => Kind3<F, R, T, Either<E, NonNullable<B>>>
+export declare function fromNullableK<F extends URIS2>(
+  F: Pointed2<F>
+): <E>(
+  e: E
+) => <A extends ReadonlyArray<unknown>, B>(
+  f: (...a: A) => B | null | undefined
+) => <T>(...a: A) => Kind2<F, T, Either<E, NonNullable<B>>>
+export declare function fromNullableK<F extends URIS2, T>(
+  F: Pointed2C<F, T>
+): <E>(
+  e: E
+) => <A extends ReadonlyArray<unknown>, B>(
+  f: (...a: A) => B | null | undefined
+) => (...a: A) => Kind2<F, T, Either<E, NonNullable<B>>>
+export declare function fromNullableK<F extends URIS>(
+  F: Pointed1<F>
+): <E>(
+  e: E
+) => <A extends ReadonlyArray<unknown>, B>(
+  f: (...a: A) => B | null | undefined
+) => (...a: A) => Kind<F, Either<E, NonNullable<B>>>
+export declare function fromNullableK<F>(
+  F: Pointed<F>
+): <E>(
+  e: E
+) => <A extends ReadonlyArray<unknown>, B>(
+  f: (...a: A) => B | null | undefined
+) => (...a: A) => HKT<F, Either<E, NonNullable<B>>>
+```
+
+Added in v2.12.0
 
 ## getOrElse
 

--- a/docs/modules/TaskEither.ts.md
+++ b/docs/modules/TaskEither.ts.md
@@ -116,6 +116,9 @@ Added in v2.0.0
   - [~~taskEitherSeq~~](#taskeitherseq)
   - [~~taskEither~~](#taskeither)
 - [interop](#interop)
+  - [chainNullableK](#chainnullablek)
+  - [fromNullable](#fromnullable)
+  - [fromNullableK](#fromnullablek)
   - [toUnion](#tounion)
   - [tryCatch](#trycatch)
   - [tryCatchK](#trycatchk)
@@ -1230,6 +1233,42 @@ export declare const taskEither: Monad2<'TaskEither'> &
 Added in v2.0.0
 
 # interop
+
+## chainNullableK
+
+**Signature**
+
+```ts
+export declare const chainNullableK: <E>(
+  e: E
+) => <A, B>(f: (a: A) => B | null | undefined) => (ma: TaskEither<E, A>) => TaskEither<E, NonNullable<B>>
+```
+
+Added in v2.12.0
+
+## fromNullable
+
+**Signature**
+
+```ts
+export declare const fromNullable: <E>(e: E) => <A>(a: A) => TaskEither<E, NonNullable<A>>
+```
+
+Added in v2.12.0
+
+## fromNullableK
+
+**Signature**
+
+```ts
+export declare const fromNullableK: <E>(
+  e: E
+) => <A extends readonly unknown[], B>(
+  f: (...a: A) => B | null | undefined
+) => (...a: A) => TaskEither<E, NonNullable<B>>
+```
+
+Added in v2.12.0
 
 ## toUnion
 

--- a/src/EitherT.ts
+++ b/src/EitherT.ts
@@ -7,9 +7,9 @@ import { Chain, Chain1, Chain2, Chain2C, Chain3, Chain3C } from './Chain'
 import * as E from './Either'
 import { flow, Lazy, pipe } from './function'
 import { Functor, Functor1, Functor2, Functor2C, Functor3, Functor3C, map as map_ } from './Functor'
-import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3 } from './HKT'
-import { Monad, Monad1, Monad2, Monad2C, Monad3, Monad3C } from './Monad'
-import { Pointed, Pointed1, Pointed2, Pointed2C, Pointed3, Pointed3C } from './Pointed'
+import { HKT, Kind, Kind2, Kind3, Kind4, URIS, URIS2, URIS3, URIS4 } from './HKT'
+import { Monad, Monad1, Monad2, Monad2C, Monad3, Monad3C, Monad4 } from './Monad'
+import { Pointed, Pointed1, Pointed2, Pointed2C, Pointed3, Pointed3C, Pointed4 } from './Pointed'
 import { Semigroup } from './Semigroup'
 
 import Either = E.Either
@@ -86,6 +86,159 @@ export function leftF<F extends URIS>(F: Functor1<F>): <E, A = never>(fe: Kind<F
 export function leftF<F>(F: Functor<F>): <E, A = never>(fe: HKT<F, E>) => HKT<F, Either<E, A>>
 export function leftF<F>(F: Functor<F>): <E, A = never>(fe: HKT<F, E>) => HKT<F, Either<E, A>> {
   return (fe) => F.map(fe, E.left)
+}
+
+/**
+ * @since 2.12.0
+ */
+export function fromNullable<F extends URIS4>(
+  F: Pointed4<F>
+): <E>(e: E) => <A, S, R, T>(a: A) => Kind4<F, S, R, T, Either<E, NonNullable<A>>>
+export function fromNullable<F extends URIS3>(
+  F: Pointed3<F>
+): <E>(e: E) => <A, R, T>(a: A) => Kind3<F, R, T, Either<E, NonNullable<A>>>
+export function fromNullable<F extends URIS3, T>(
+  F: Pointed3C<F, T>
+): <E>(e: E) => <A, R>(a: A) => Kind3<F, R, T, Either<E, NonNullable<A>>>
+export function fromNullable<F extends URIS2>(
+  F: Pointed2<F>
+): <E>(e: E) => <A, T>(a: A) => Kind2<F, T, Either<E, NonNullable<A>>>
+export function fromNullable<F extends URIS2, T>(
+  F: Pointed2C<F, T>
+): <E>(e: E) => <A>(a: A) => Kind2<F, T, Either<E, NonNullable<A>>>
+export function fromNullable<F extends URIS>(
+  F: Pointed1<F>
+): <E>(e: E) => <A>(a: A) => Kind<F, Either<E, NonNullable<A>>>
+export function fromNullable<F>(F: Pointed<F>): <E>(e: E) => <A>(a: A) => HKT<F, Either<E, NonNullable<A>>>
+export function fromNullable<F>(F: Pointed<F>): <E>(e: E) => <A>(a: A) => HKT<F, Either<E, NonNullable<A>>> {
+  return (e) => flow(E.fromNullable(e), F.of)
+}
+
+/**
+ * @since 2.12.0
+ */
+export function fromNullableK<F extends URIS4>(
+  F: Pointed4<F>
+): <E>(
+  e: E
+) => <A extends ReadonlyArray<unknown>, B>(
+  f: (...a: A) => B | null | undefined
+) => <S, R, T>(...a: A) => Kind4<F, S, R, T, Either<E, NonNullable<B>>>
+export function fromNullableK<F extends URIS3>(
+  F: Pointed3<F>
+): <E>(
+  e: E
+) => <A extends ReadonlyArray<unknown>, B>(
+  f: (...a: A) => B | null | undefined
+) => <R, T>(...a: A) => Kind3<F, R, T, Either<E, NonNullable<B>>>
+export function fromNullableK<F extends URIS3, T>(
+  F: Pointed3C<F, T>
+): <E>(
+  e: E
+) => <A extends ReadonlyArray<unknown>, B>(
+  f: (...a: A) => B | null | undefined
+) => <R>(...a: A) => Kind3<F, R, T, Either<E, NonNullable<B>>>
+export function fromNullableK<F extends URIS2>(
+  F: Pointed2<F>
+): <E>(
+  e: E
+) => <A extends ReadonlyArray<unknown>, B>(
+  f: (...a: A) => B | null | undefined
+) => <T>(...a: A) => Kind2<F, T, Either<E, NonNullable<B>>>
+export function fromNullableK<F extends URIS2, T>(
+  F: Pointed2C<F, T>
+): <E>(
+  e: E
+) => <A extends ReadonlyArray<unknown>, B>(
+  f: (...a: A) => B | null | undefined
+) => (...a: A) => Kind2<F, T, Either<E, NonNullable<B>>>
+export function fromNullableK<F extends URIS>(
+  F: Pointed1<F>
+): <E>(
+  e: E
+) => <A extends ReadonlyArray<unknown>, B>(
+  f: (...a: A) => B | null | undefined
+) => (...a: A) => Kind<F, Either<E, NonNullable<B>>>
+export function fromNullableK<F>(
+  F: Pointed<F>
+): <E>(
+  e: E
+) => <A extends ReadonlyArray<unknown>, B>(
+  f: (...a: A) => B | null | undefined
+) => (...a: A) => HKT<F, Either<E, NonNullable<B>>>
+export function fromNullableK<F>(
+  F: Pointed<F>
+): <E>(
+  e: E
+) => <A extends ReadonlyArray<unknown>, B>(
+  f: (...a: A) => B | null | undefined
+) => (...a: A) => HKT<F, Either<E, NonNullable<B>>> {
+  const fromNullableF = fromNullable(F)
+  return (e) => {
+    const fromNullableFE = fromNullableF(e)
+    return (f) => flow(f, fromNullableFE)
+  }
+}
+
+/**
+ * @since 2.12.0
+ */
+export function chainNullableK<M extends URIS4>(
+  M: Monad4<M>
+): <E>(
+  e: E
+) => <A, B>(
+  f: (a: A) => B | null | undefined
+) => <S, R, T>(ma: Kind4<M, S, R, T, Either<E, A>>) => Kind4<M, S, R, T, Either<E, NonNullable<B>>>
+export function chainNullableK<M extends URIS3>(
+  M: Monad3<M>
+): <E>(
+  e: E
+) => <A, B>(
+  f: (a: A) => B | null | undefined
+) => <R, T>(ma: Kind3<M, R, T, Either<E, A>>) => Kind3<M, R, T, Either<E, NonNullable<B>>>
+export function chainNullableK<M extends URIS3, T>(
+  M: Monad3C<M, T>
+): <E>(
+  e: E
+) => <A, B>(
+  f: (a: A) => B | null | undefined
+) => <R>(ma: Kind3<M, R, T, Either<E, A>>) => Kind3<M, R, T, Either<E, NonNullable<B>>>
+export function chainNullableK<M extends URIS2>(
+  M: Monad2<M>
+): <E>(
+  e: E
+) => <A, B>(
+  f: (a: A) => B | null | undefined
+) => <T>(ma: Kind2<M, T, Either<E, A>>) => Kind2<M, T, Either<E, NonNullable<B>>>
+export function chainNullableK<M extends URIS2, T>(
+  M: Monad2C<M, T>
+): <E>(
+  e: E
+) => <A, B>(
+  f: (a: A) => B | null | undefined
+) => (ma: Kind2<M, T, Either<E, A>>) => Kind2<M, T, Either<E, NonNullable<B>>>
+export function chainNullableK<M extends URIS>(
+  M: Monad1<M>
+): <E>(
+  e: E
+) => <A, B>(f: (a: A) => B | null | undefined) => (ma: Kind<M, Either<E, A>>) => Kind<M, Either<E, NonNullable<B>>>
+export function chainNullableK<M>(
+  M: Monad<M>
+): <E>(
+  e: E
+) => <A, B>(f: (a: A) => B | null | undefined) => (ma: HKT<M, Either<E, A>>) => HKT<M, Either<E, NonNullable<B>>>
+export function chainNullableK<M>(
+  M: Monad<M>
+): <E>(
+  e: E
+) => <A, B>(f: (a: A) => B | null | undefined) => (ma: HKT<M, Either<E, A>>) => HKT<M, Either<E, NonNullable<B>>> {
+  const chainM = chain(M)
+  const fromNullableKM = fromNullableK(M)
+  return (e) => {
+    const fromNullableKMe = fromNullableKM(e)
+    return (f) => chainM(fromNullableKMe(f))
+  }
 }
 
 // -------------------------------------------------------------------------------------

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -294,6 +294,36 @@ export const toUnion: <E, A>(fa: TaskEither<E, A>) => Task<E | A> =
   /*#__PURE__*/
   ET.toUnion(T.Functor)
 
+/**
+ * @category interop
+ * @since 2.12.0
+ */
+export const fromNullable: <E>(e: E) => <A>(a: A) => TaskEither<E, NonNullable<A>> =
+  /*#__PURE__*/
+  ET.fromNullable(T.Pointed)
+
+/**
+ * @category interop
+ * @since 2.12.0
+ */
+export const fromNullableK: <E>(
+  e: E
+) => <A extends ReadonlyArray<unknown>, B>(
+  f: (...a: A) => B | null | undefined
+) => (...a: A) => TaskEither<E, NonNullable<B>> =
+  /*#__PURE__*/
+  ET.fromNullableK(T.Pointed)
+
+/**
+ * @category interop
+ * @since 2.12.0
+ */
+export const chainNullableK: <E>(
+  e: E
+) => <A, B>(f: (a: A) => B | null | undefined) => (ma: TaskEither<E, A>) => TaskEither<E, NonNullable<B>> =
+  /*#__PURE__*/
+  ET.chainNullableK(T.Monad)
+
 // -------------------------------------------------------------------------------------
 // combinators
 // -------------------------------------------------------------------------------------

--- a/test/TaskEither.ts
+++ b/test/TaskEither.ts
@@ -495,6 +495,27 @@ describe('TaskEither', () => {
     )
   })
 
+  it('fromNullable', async () => {
+    const testNullable = _.fromNullable('foo')
+    U.deepStrictEqual(await testNullable(1)(), E.right(1))
+    U.deepStrictEqual(await testNullable(null)(), E.left('foo'))
+    U.deepStrictEqual(await testNullable(undefined)(), E.left('foo'))
+  })
+
+  it('fromNullableK', async () => {
+    const f = _.fromNullableK('foo')((n: number) => (n > 0 ? n : n === 0 ? null : undefined))
+    U.deepStrictEqual(await f(1)(), E.right(1))
+    U.deepStrictEqual(await f(0)(), E.left('foo'))
+    U.deepStrictEqual(await f(-1)(), E.left('foo'))
+  })
+
+  it('chainNullableK', async () => {
+    const f = _.chainNullableK('foo')((n: number) => (n > 0 ? n : n === 0 ? null : undefined))
+    U.deepStrictEqual(await f(_.of(1))(), E.right(1))
+    U.deepStrictEqual(await f(_.of(0))(), E.left('foo'))
+    U.deepStrictEqual(await f(_.of(-1))(), E.left('foo'))
+  })
+
   it('fromIOEither', async () => {
     U.deepStrictEqual(await _.fromIOEither(() => E.right(1))(), E.right(1))
     U.deepStrictEqual(await _.fromIOEither(() => E.left('foo'))(), E.left('foo'))


### PR DESCRIPTION
I noticed that both `Either` and `TaskOption` had implementations of `chainNullableK`, `fromNullable`, and `fromNullableK`, but `TaskEither` did not. This PR adds implementations of those three functions for `EitherT` and `TaskEither`.

This was quite rote, so if there's some secret sauce to how many overloads are present in, say, `OptionT` vs `EitherT`, I'd appreciate someone pointing it out.
