### PR TITLE
Narrow Json error types

### DIFF
--- a/docs/modules/Json.ts.md
+++ b/docs/modules/Json.ts.md
@@ -62,7 +62,7 @@ Converts a JavaScript Object Notation (JSON) string into a `Json` type.
 **Signature**
 
 ```ts
-export declare const parse: (s: string) => Either<unknown, Json>
+export declare const parse: (s: string) => Either<SyntaxError, Json>
 ```
 
 **Example**
@@ -85,7 +85,7 @@ Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
 **Signature**
 
 ```ts
-export declare const stringify: <A>(a: A) => Either<unknown, string>
+export declare const stringify: <A>(a: A) => Either<TypeError, string>
 ```
 
 **Example**
@@ -101,7 +101,7 @@ circular.ref = circular
 assert.deepStrictEqual(
   pipe(
     J.stringify(circular),
-    E.mapLeft((e) => e instanceof Error && e.message.includes('Converting circular structure to JSON'))
+    E.mapLeft((e) => e.message.includes('Converting circular structure to JSON'))
   ),
   E.left(true)
 )

--- a/dtslint/ts3.5/Json.ts
+++ b/dtslint/ts3.5/Json.ts
@@ -2,6 +2,15 @@ import * as E from '../../src/Either'
 import { pipe } from '../../src/function'
 import * as _ from '../../src/Json'
 
+declare const s: string
+
+//
+// parse
+//
+
+// $ExpectType Either<SyntaxError, Json>
+_.parse(s)
+
 //
 // stringify
 //
@@ -34,5 +43,5 @@ _.stringify([{ a: 'a', b: 1 }])
 _.stringify(abs)
 _.stringify([...abs])
 
-// $ExpectType Either<unknown, string>
+// $ExpectType Either<TypeError, string>
 pipe(E.right('a'), E.chainFirst(_.stringify))

--- a/src/Json.ts
+++ b/src/Json.ts
@@ -34,7 +34,7 @@ export interface JsonArray extends ReadonlyArray<Json> {}
  *
  * @since 2.10.0
  */
-export const parse = (s: string): Either<unknown, Json> => tryCatch(() => JSON.parse(s), identity)
+export const parse = (s: string): Either<SyntaxError, Json> => tryCatch(() => JSON.parse(s), identity as any)
 
 /**
  * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
@@ -50,18 +50,18 @@ export const parse = (s: string): Either<unknown, Json> => tryCatch(() => JSON.p
  * assert.deepStrictEqual(
  *   pipe(
  *     J.stringify(circular),
- *     E.mapLeft(e => e instanceof Error && e.message.includes('Converting circular structure to JSON'))
+ *     E.mapLeft(e => e.message.includes('Converting circular structure to JSON'))
  *   ),
  *   E.left(true)
  * )
  *
  *  @since 2.10.0
  */
-export const stringify = <A>(a: A): Either<unknown, string> =>
+export const stringify = <A>(a: A): Either<TypeError, string> =>
   tryCatch(() => {
     const s = JSON.stringify(a)
     if (typeof s !== 'string') {
-      throw new Error('Converting unsupported structure to JSON')
+      throw new TypeError('Converting unsupported structure to JSON')
     }
     return s
-  }, identity)
+  }, identity as any)

--- a/test/Json.ts
+++ b/test/Json.ts
@@ -17,7 +17,7 @@ describe('Json', () => {
       pipe(
         circular,
         _.stringify,
-        E.mapLeft((e) => (e as Error).message.includes('Converting circular structure to JSON'))
+        E.mapLeft((e) => e.message.includes('Converting circular structure to JSON'))
       ),
       E.left(true)
     )
@@ -28,6 +28,6 @@ describe('Json', () => {
     const person: Person = { name: 'Giulio', age: 45 }
     U.deepStrictEqual(pipe(person, _.stringify), E.right('{"name":"Giulio","age":45}'))
 
-    U.deepStrictEqual(_.stringify(undefined as any), E.left(new Error('Converting unsupported structure to JSON')))
+    U.deepStrictEqual(_.stringify(undefined), E.left(new TypeError('Converting unsupported structure to JSON')))
   })
 })


### PR DESCRIPTION
`JSON.parse` and `JSON.stringify` only throw [`SyntaxError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#exceptions) and [`TypeError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#exceptions) respectively, so we can narrow the types in the Json module.

There is one custom error in `stringify`, but this is better represented as a `TypeError` anyway.