### PR TITLE
Add orElseFirstIOK and orElseFirstTaskK

### DIFF
--- a/docs/modules/IOEither.ts.md
+++ b/docs/modules/IOEither.ts.md
@@ -53,6 +53,7 @@ Added in v2.0.0
   - [fromOptionK](#fromoptionk)
   - [orElse](#orelse)
   - [orElseFirst](#orelsefirst)
+  - [orElseFirstIOK](#orelsefirstiok)
   - [orElseFirstW](#orelsefirstw)
   - [orElseW](#orelsew)
   - [orLeft](#orleft)
@@ -518,6 +519,16 @@ export declare const orElseFirst: <E, B>(onLeft: (e: E) => IOEither<E, B>) => <A
 ```
 
 Added in v2.11.0
+
+## orElseFirstIOK
+
+**Signature**
+
+```ts
+export declare const orElseFirstIOK: <E, B>(onLeft: (e: E) => I.IO<B>) => <A>(ma: IOEither<E, A>) => IOEither<E, A>
+```
+
+Added in v2.11.8
 
 ## orElseFirstW
 

--- a/docs/modules/TaskEither.ts.md
+++ b/docs/modules/TaskEither.ts.md
@@ -65,6 +65,8 @@ Added in v2.0.0
   - [fromTaskOptionK](#fromtaskoptionk)
   - [orElse](#orelse)
   - [orElseFirst](#orelsefirst)
+  - [orElseFirstIOK](#orelsefirstiok)
+  - [orElseFirstTaskK](#orelsefirsttaskk)
   - [orElseFirstW](#orelsefirstw)
   - [orElseW](#orelsew)
   - [orLeft](#orleft)
@@ -695,6 +697,28 @@ export declare const orElseFirst: <E, B>(
 ```
 
 Added in v2.11.0
+
+## orElseFirstIOK
+
+**Signature**
+
+```ts
+export declare const orElseFirstIOK: <E, B>(onLeft: (e: E) => IO<B>) => <A>(ma: TaskEither<E, A>) => TaskEither<E, A>
+```
+
+Added in v2.11.8
+
+## orElseFirstTaskK
+
+**Signature**
+
+```ts
+export declare const orElseFirstTaskK: <E, B>(
+  onLeft: (e: E) => T.Task<B>
+) => <A>(ma: TaskEither<E, A>) => TaskEither<E, A>
+```
+
+Added in v2.11.8
 
 ## orElseFirstW
 

--- a/dtslint/ts3.5/IOEither.ts
+++ b/dtslint/ts3.5/IOEither.ts
@@ -54,6 +54,16 @@ pipe(
 )
 
 //
+// orElseFirstIOK
+//
+
+// $ExpectType IOEither<string, never>
+pipe(
+  _.left('a'),
+  _.orElseFirstIOK((a) => IO.of(a.length))
+)
+
+//
 // orLeft
 //
 

--- a/dtslint/ts3.5/TaskEither.ts
+++ b/dtslint/ts3.5/TaskEither.ts
@@ -2,6 +2,7 @@ import * as _ from '../../src/TaskEither'
 import * as T from '../../src/Task'
 import * as E from '../../src/Either'
 import * as TO from '../../src/TaskOption'
+import * as IO from '../../src/IO'
 import * as IOE from '../../src/IOEither'
 import { pipe } from '../../src/function'
 
@@ -53,6 +54,26 @@ pipe(
 pipe(
   _.left('a'),
   _.orElseFirstW((a) => _.left(a.length))
+)
+
+//
+// orElseFirstIOK
+//
+
+// $ExpectType TaskEither<string, never>
+pipe(
+  _.left('a'),
+  _.orElseFirstIOK((a) => IO.of(a.length))
+)
+
+//
+// orElseFirstTaskK
+//
+
+// $ExpectType TaskEither<string, never>
+pipe(
+  _.left('a'),
+  _.orElseFirstTaskK((a) => T.of(a.length))
 )
 
 //

--- a/src/IOEither.ts
+++ b/src/IOEither.ts
@@ -265,6 +265,13 @@ export const orElseFirstW: <E1, E2, B>(
 
 /**
  * @category combinators
+ * @since 2.11.8
+ */
+export const orElseFirstIOK: <E, B>(onLeft: (e: E) => IO<B>) => <A>(ma: IOEither<E, A>) => IOEither<E, A> = (onLeft) =>
+  orElseFirst(flow(onLeft, rightIO))
+
+/**
+ * @category combinators
  * @since 2.11.0
  */
 export const orLeft: <E1, E2>(onLeft: (e: E1) => IO<E2>) => <A>(fa: IOEither<E1, A>) => IOEither<E2, A> =

--- a/src/IOEither.ts
+++ b/src/IOEither.ts
@@ -268,7 +268,7 @@ export const orElseFirstW: <E1, E2, B>(
  * @since 2.11.8
  */
 export const orElseFirstIOK: <E, B>(onLeft: (e: E) => IO<B>) => <A>(ma: IOEither<E, A>) => IOEither<E, A> = (onLeft) =>
-  orElseFirst(flow(onLeft, rightIO))
+  orElseFirst(fromIOK(onLeft))
 
 /**
  * @category combinators

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -351,6 +351,22 @@ export const orElseFirstW: <E1, E2, B>(
 
 /**
  * @category combinators
+ * @since 2.11.8
+ */
+export const orElseFirstIOK: <E, B>(onLeft: (e: E) => IO<B>) => <A>(ma: TaskEither<E, A>) => TaskEither<E, A> = (
+  onLeft
+) => orElseFirst(flow(onLeft, rightIO))
+
+/**
+ * @category combinators
+ * @since 2.11.8
+ */
+export const orElseFirstTaskK: <E, B>(onLeft: (e: E) => Task<B>) => <A>(ma: TaskEither<E, A>) => TaskEither<E, A> = (
+  onLeft
+) => orElseFirst(flow(onLeft, rightTask))
+
+/**
+ * @category combinators
  * @since 2.11.0
  */
 export const orLeft: <E1, E2>(onLeft: (e: E1) => Task<E2>) => <A>(fa: TaskEither<E1, A>) => TaskEither<E2, A> =

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -355,7 +355,7 @@ export const orElseFirstW: <E1, E2, B>(
  */
 export const orElseFirstIOK: <E, B>(onLeft: (e: E) => IO<B>) => <A>(ma: TaskEither<E, A>) => TaskEither<E, A> = (
   onLeft
-) => orElseFirst(flow(onLeft, rightIO))
+) => orElseFirst(fromIOK(onLeft))
 
 /**
  * @category combinators
@@ -363,7 +363,7 @@ export const orElseFirstIOK: <E, B>(onLeft: (e: E) => IO<B>) => <A>(ma: TaskEith
  */
 export const orElseFirstTaskK: <E, B>(onLeft: (e: E) => Task<B>) => <A>(ma: TaskEither<E, A>) => TaskEither<E, A> = (
   onLeft
-) => orElseFirst(flow(onLeft, rightTask))
+) => orElseFirst(fromTaskK(onLeft))
 
 /**
  * @category combinators

--- a/test/IOEither.ts
+++ b/test/IOEither.ts
@@ -274,6 +274,12 @@ describe('IOEither', () => {
     U.deepStrictEqual(pipe(_.left('aa'), f)(), E.left('aa!'))
   })
 
+  it('orElseFirstIOK', () => {
+    const f = _.orElseFirstIOK((e: string) => I.of(e.length))
+    U.deepStrictEqual(pipe(_.right(1), f)(), E.right(1))
+    U.deepStrictEqual(pipe(_.left('a'), f)(), E.left('a'))
+  })
+
   it('orLeft', () => {
     const f = _.orLeft((e: string) => I.of(e + '!'))
     U.deepStrictEqual(pipe(_.right(1), f)(), E.right(1))

--- a/test/TaskEither.ts
+++ b/test/TaskEither.ts
@@ -431,6 +431,18 @@ describe('TaskEither', () => {
     U.deepStrictEqual(await pipe(_.left('aa'), f)(), E.left('aa!'))
   })
 
+  it('orElseFirstIOK', async () => {
+    const f = _.orElseFirstIOK((e: string) => I.of(e.length))
+    U.deepStrictEqual(await pipe(_.right(1), f)(), E.right(1))
+    U.deepStrictEqual(await pipe(_.left('a'), f)(), E.left('a'))
+  })
+
+  it('orElseFirstTaskK', async () => {
+    const f = _.orElseFirstTaskK((e: string) => T.of(e.length))
+    U.deepStrictEqual(await pipe(_.right(1), f)(), E.right(1))
+    U.deepStrictEqual(await pipe(_.left('a'), f)(), E.left('a'))
+  })
+
   it('orLeft', async () => {
     const f = _.orLeft((e: string) => T.of(e + '!'))
     U.deepStrictEqual(await pipe(_.right(1), f)(), E.right(1))


### PR DESCRIPTION
This adds `orElseFirstIOK` to `IOEither` and `TaskEither`, and `orElseFirstTaskK` to `TaskEither`, which are useful to help when logging (the left).

Refs https://github.com/gcanti/fp-ts/issues/1360#issuecomment-811972265