### PR TITLE
Add Divisible

### DIFF
--- a/docs/modules/Divisible.ts.md
+++ b/docs/modules/Divisible.ts.md
@@ -1,0 +1,129 @@
+---
+title: Divisible.ts
+nav_order: 25
+parent: Modules
+---
+
+## Divisible overview
+
+Added in v2.12.0
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [type classes](#type-classes)
+  - [Divisible (interface)](#divisible-interface)
+  - [Divisible1 (interface)](#divisible1-interface)
+  - [Divisible2 (interface)](#divisible2-interface)
+  - [Divisible2C (interface)](#divisible2c-interface)
+  - [Divisible3 (interface)](#divisible3-interface)
+  - [Divisible3C (interface)](#divisible3c-interface)
+  - [Divisible4 (interface)](#divisible4-interface)
+
+---
+
+# type classes
+
+## Divisible (interface)
+
+**Signature**
+
+```ts
+export interface Divisible<F> extends Contravariant<F> {
+  readonly divide: <C, B, A>(f: (a: A) => [B, C], first: HKT<F, B>, second: HKT<F, C>) => HKT<F, A>
+  readonly conquer: HKT<F, unknown>
+}
+```
+
+Added in v2.12.0
+
+## Divisible1 (interface)
+
+**Signature**
+
+```ts
+export interface Divisible1<F extends URIS> extends Contravariant1<F> {
+  readonly divide: <C, B, A>(f: (a: A) => [B, C], first: Kind<F, B>, second: Kind<F, C>) => Kind<F, A>
+  readonly conquer: Kind<F, unknown>
+}
+```
+
+Added in v2.12.0
+
+## Divisible2 (interface)
+
+**Signature**
+
+```ts
+export interface Divisible2<F extends URIS2> extends Contravariant2<F> {
+  readonly divide: <E, C, B, A>(f: (a: A) => [B, C], first: Kind2<F, E, B>, second: Kind2<F, E, C>) => Kind2<F, E, A>
+  readonly conquer: Kind2<F, unknown, unknown>
+}
+```
+
+Added in v2.12.0
+
+## Divisible2C (interface)
+
+**Signature**
+
+```ts
+export interface Divisible2C<F extends URIS2, E> extends Contravariant2C<F, E> {
+  readonly divide: <C, B, A>(f: (a: A) => [B, C], first: Kind2<F, E, B>, second: Kind2<F, E, C>) => Kind2<F, E, A>
+  readonly conquer: Kind2<F, E, unknown>
+}
+```
+
+Added in v2.12.0
+
+## Divisible3 (interface)
+
+**Signature**
+
+```ts
+export interface Divisible3<F extends URIS3> extends Contravariant3<F> {
+  readonly divide: <R, E, C, B, A>(
+    f: (a: A) => [B, C],
+    first: Kind3<F, R, E, B>,
+    second: Kind3<F, R, E, C>
+  ) => Kind3<F, R, E, A>
+  readonly conquer: Kind3<F, unknown, unknown, unknown>
+}
+```
+
+Added in v2.12.0
+
+## Divisible3C (interface)
+
+**Signature**
+
+```ts
+export interface Divisible3C<F extends URIS3, E> extends Contravariant3C<F, E> {
+  readonly divide: <R, C, B, A>(
+    f: (a: A) => [B, C],
+    first: Kind3<F, R, E, B>,
+    second: Kind3<F, R, E, C>
+  ) => Kind3<F, R, E, A>
+  readonly conquer: Kind3<F, unknown, unknown, unknown>
+}
+```
+
+Added in v2.12.0
+
+## Divisible4 (interface)
+
+**Signature**
+
+```ts
+export interface Divisible4<F extends URIS4> extends Contravariant4<F> {
+  readonly divide: <S, R, E, C, B, A>(
+    f: (a: A) => [B, C],
+    first: Kind4<F, S, R, E, B>,
+    second: Kind4<F, S, R, E, C>
+  ) => Kind4<F, S, R, E, A>
+  readonly conquer: Kind4<F, unknown, unknown, unknown, unknown>
+}
+```
+
+Added in v2.12.0

--- a/docs/modules/Either.ts.md
+++ b/docs/modules/Either.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Either.ts
-nav_order: 25
+nav_order: 26
 parent: Modules
 ---
 

--- a/docs/modules/EitherT.ts.md
+++ b/docs/modules/EitherT.ts.md
@@ -1,6 +1,6 @@
 ---
 title: EitherT.ts
-nav_order: 26
+nav_order: 27
 parent: Modules
 ---
 

--- a/docs/modules/Endomorphism.ts.md
+++ b/docs/modules/Endomorphism.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Endomorphism.ts
-nav_order: 27
+nav_order: 28
 parent: Modules
 ---
 

--- a/docs/modules/Eq.ts.md
+++ b/docs/modules/Eq.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Eq.ts
-nav_order: 28
+nav_order: 29
 parent: Modules
 ---
 

--- a/docs/modules/Eq.ts.md
+++ b/docs/modules/Eq.ts.md
@@ -31,6 +31,7 @@ Added in v2.0.0
   - [fromEquals](#fromequals)
 - [instances](#instances)
   - [Contravariant](#contravariant-1)
+  - [Divisible](#divisible)
   - [URI](#uri)
   - [URI (type alias)](#uri-type-alias)
   - [eqStrict](#eqstrict)
@@ -148,6 +149,16 @@ export declare const Contravariant: Contravariant1<'Eq'>
 ```
 
 Added in v2.7.0
+
+## Divisible
+
+**Signature**
+
+```ts
+export declare const Divisible: Divisible1<'Eq'>
+```
+
+Added in v2.12.0
 
 ## URI
 

--- a/docs/modules/Extend.ts.md
+++ b/docs/modules/Extend.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Extend.ts
-nav_order: 29
+nav_order: 30
 parent: Modules
 ---
 

--- a/docs/modules/Field.ts.md
+++ b/docs/modules/Field.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Field.ts
-nav_order: 30
+nav_order: 31
 parent: Modules
 ---
 

--- a/docs/modules/Filterable.ts.md
+++ b/docs/modules/Filterable.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Filterable.ts
-nav_order: 31
+nav_order: 32
 parent: Modules
 ---
 

--- a/docs/modules/FilterableWithIndex.ts.md
+++ b/docs/modules/FilterableWithIndex.ts.md
@@ -1,6 +1,6 @@
 ---
 title: FilterableWithIndex.ts
-nav_order: 32
+nav_order: 33
 parent: Modules
 ---
 

--- a/docs/modules/Foldable.ts.md
+++ b/docs/modules/Foldable.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Foldable.ts
-nav_order: 33
+nav_order: 34
 parent: Modules
 ---
 

--- a/docs/modules/FoldableWithIndex.ts.md
+++ b/docs/modules/FoldableWithIndex.ts.md
@@ -1,6 +1,6 @@
 ---
 title: FoldableWithIndex.ts
-nav_order: 34
+nav_order: 35
 parent: Modules
 ---
 

--- a/docs/modules/FromEither.ts.md
+++ b/docs/modules/FromEither.ts.md
@@ -1,6 +1,6 @@
 ---
 title: FromEither.ts
-nav_order: 35
+nav_order: 36
 parent: Modules
 ---
 

--- a/docs/modules/FromIO.ts.md
+++ b/docs/modules/FromIO.ts.md
@@ -1,6 +1,6 @@
 ---
 title: FromIO.ts
-nav_order: 36
+nav_order: 37
 parent: Modules
 ---
 

--- a/docs/modules/FromReader.ts.md
+++ b/docs/modules/FromReader.ts.md
@@ -1,6 +1,6 @@
 ---
 title: FromReader.ts
-nav_order: 37
+nav_order: 38
 parent: Modules
 ---
 

--- a/docs/modules/FromState.ts.md
+++ b/docs/modules/FromState.ts.md
@@ -1,6 +1,6 @@
 ---
 title: FromState.ts
-nav_order: 38
+nav_order: 39
 parent: Modules
 ---
 

--- a/docs/modules/FromTask.ts.md
+++ b/docs/modules/FromTask.ts.md
@@ -1,6 +1,6 @@
 ---
 title: FromTask.ts
-nav_order: 39
+nav_order: 40
 parent: Modules
 ---
 

--- a/docs/modules/FromThese.ts.md
+++ b/docs/modules/FromThese.ts.md
@@ -1,6 +1,6 @@
 ---
 title: FromThese.ts
-nav_order: 40
+nav_order: 41
 parent: Modules
 ---
 

--- a/docs/modules/Functor.ts.md
+++ b/docs/modules/Functor.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Functor.ts
-nav_order: 42
+nav_order: 43
 parent: Modules
 ---
 

--- a/docs/modules/FunctorWithIndex.ts.md
+++ b/docs/modules/FunctorWithIndex.ts.md
@@ -1,6 +1,6 @@
 ---
 title: FunctorWithIndex.ts
-nav_order: 43
+nav_order: 44
 parent: Modules
 ---
 

--- a/docs/modules/Group.ts.md
+++ b/docs/modules/Group.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Group.ts
-nav_order: 44
+nav_order: 45
 parent: Modules
 ---
 

--- a/docs/modules/HKT.ts.md
+++ b/docs/modules/HKT.ts.md
@@ -1,6 +1,6 @@
 ---
 title: HKT.ts
-nav_order: 46
+nav_order: 47
 parent: Modules
 ---
 

--- a/docs/modules/HeytingAlgebra.ts.md
+++ b/docs/modules/HeytingAlgebra.ts.md
@@ -1,6 +1,6 @@
 ---
 title: HeytingAlgebra.ts
-nav_order: 45
+nav_order: 46
 parent: Modules
 ---
 

--- a/docs/modules/IO.ts.md
+++ b/docs/modules/IO.ts.md
@@ -1,6 +1,6 @@
 ---
 title: IO.ts
-nav_order: 51
+nav_order: 52
 parent: Modules
 ---
 

--- a/docs/modules/IOEither.ts.md
+++ b/docs/modules/IOEither.ts.md
@@ -1,6 +1,6 @@
 ---
 title: IOEither.ts
-nav_order: 52
+nav_order: 53
 parent: Modules
 ---
 

--- a/docs/modules/IORef.ts.md
+++ b/docs/modules/IORef.ts.md
@@ -1,6 +1,6 @@
 ---
 title: IORef.ts
-nav_order: 53
+nav_order: 54
 parent: Modules
 ---
 

--- a/docs/modules/Identity.ts.md
+++ b/docs/modules/Identity.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Identity.ts
-nav_order: 47
+nav_order: 48
 parent: Modules
 ---
 

--- a/docs/modules/Invariant.ts.md
+++ b/docs/modules/Invariant.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Invariant.ts
-nav_order: 50
+nav_order: 51
 parent: Modules
 ---
 

--- a/docs/modules/JoinSemilattice.ts.md
+++ b/docs/modules/JoinSemilattice.ts.md
@@ -1,6 +1,6 @@
 ---
 title: JoinSemilattice.ts
-nav_order: 54
+nav_order: 55
 parent: Modules
 ---
 

--- a/docs/modules/Json.ts.md
+++ b/docs/modules/Json.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Json.ts
-nav_order: 55
+nav_order: 56
 parent: Modules
 ---
 

--- a/docs/modules/Lattice.ts.md
+++ b/docs/modules/Lattice.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Lattice.ts
-nav_order: 56
+nav_order: 57
 parent: Modules
 ---
 

--- a/docs/modules/Magma.ts.md
+++ b/docs/modules/Magma.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Magma.ts
-nav_order: 57
+nav_order: 58
 parent: Modules
 ---
 

--- a/docs/modules/Map.ts.md
+++ b/docs/modules/Map.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Map.ts
-nav_order: 58
+nav_order: 59
 parent: Modules
 ---
 

--- a/docs/modules/MeetSemilattice.ts.md
+++ b/docs/modules/MeetSemilattice.ts.md
@@ -1,6 +1,6 @@
 ---
 title: MeetSemilattice.ts
-nav_order: 59
+nav_order: 60
 parent: Modules
 ---
 

--- a/docs/modules/Monad.ts.md
+++ b/docs/modules/Monad.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Monad.ts
-nav_order: 60
+nav_order: 61
 parent: Modules
 ---
 

--- a/docs/modules/MonadIO.ts.md
+++ b/docs/modules/MonadIO.ts.md
@@ -1,6 +1,6 @@
 ---
 title: MonadIO.ts
-nav_order: 61
+nav_order: 62
 parent: Modules
 ---
 

--- a/docs/modules/MonadTask.ts.md
+++ b/docs/modules/MonadTask.ts.md
@@ -1,6 +1,6 @@
 ---
 title: MonadTask.ts
-nav_order: 62
+nav_order: 63
 parent: Modules
 ---
 

--- a/docs/modules/MonadThrow.ts.md
+++ b/docs/modules/MonadThrow.ts.md
@@ -1,6 +1,6 @@
 ---
 title: MonadThrow.ts
-nav_order: 63
+nav_order: 64
 parent: Modules
 ---
 

--- a/docs/modules/Monoid.ts.md
+++ b/docs/modules/Monoid.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Monoid.ts
-nav_order: 64
+nav_order: 65
 parent: Modules
 ---
 

--- a/docs/modules/NaturalTransformation.ts.md
+++ b/docs/modules/NaturalTransformation.ts.md
@@ -1,6 +1,6 @@
 ---
 title: NaturalTransformation.ts
-nav_order: 65
+nav_order: 66
 parent: Modules
 ---
 

--- a/docs/modules/NonEmptyArray.ts.md
+++ b/docs/modules/NonEmptyArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: NonEmptyArray.ts
-nav_order: 66
+nav_order: 67
 parent: Modules
 ---
 

--- a/docs/modules/Option.ts.md
+++ b/docs/modules/Option.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Option.ts
-nav_order: 68
+nav_order: 69
 parent: Modules
 ---
 

--- a/docs/modules/OptionT.ts.md
+++ b/docs/modules/OptionT.ts.md
@@ -1,6 +1,6 @@
 ---
 title: OptionT.ts
-nav_order: 69
+nav_order: 70
 parent: Modules
 ---
 

--- a/docs/modules/Ord.ts.md
+++ b/docs/modules/Ord.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Ord.ts
-nav_order: 70
+nav_order: 71
 parent: Modules
 ---
 

--- a/docs/modules/Ord.ts.md
+++ b/docs/modules/Ord.ts.md
@@ -33,6 +33,7 @@ Added in v2.0.0
   - [equalsDefault](#equalsdefault)
 - [instances](#instances)
   - [Contravariant](#contravariant-1)
+  - [Divisible](#divisible)
   - [URI](#uri)
   - [URI (type alias)](#uri-type-alias)
   - [getMonoid](#getmonoid)
@@ -169,6 +170,16 @@ export declare const Contravariant: Contravariant1<'Ord'>
 ```
 
 Added in v2.7.0
+
+## Divisible
+
+**Signature**
+
+```ts
+export declare const Divisible: Divisible1<'Ord'>
+```
+
+Added in v2.12.0
 
 ## URI
 

--- a/docs/modules/Ordering.ts.md
+++ b/docs/modules/Ordering.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Ordering.ts
-nav_order: 71
+nav_order: 72
 parent: Modules
 ---
 

--- a/docs/modules/Pointed.ts.md
+++ b/docs/modules/Pointed.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Pointed.ts
-nav_order: 73
+nav_order: 74
 parent: Modules
 ---
 

--- a/docs/modules/Predicate.ts.md
+++ b/docs/modules/Predicate.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Predicate.ts
-nav_order: 74
+nav_order: 75
 parent: Modules
 ---
 

--- a/docs/modules/Predicate.ts.md
+++ b/docs/modules/Predicate.ts.md
@@ -18,6 +18,8 @@ Added in v2.11.0
   - [Contravariant](#contravariant-1)
   - [URI](#uri)
   - [URI (type alias)](#uri-type-alias)
+  - [getDivisibleAll](#getdivisibleall)
+  - [getDivisibleAny](#getdivisibleany)
   - [getMonoidAll](#getmonoidall)
   - [getMonoidAny](#getmonoidany)
   - [getSemigroupAll](#getsemigroupall)
@@ -73,6 +75,26 @@ export type URI = typeof URI
 ```
 
 Added in v2.11.0
+
+## getDivisibleAll
+
+**Signature**
+
+```ts
+export declare const getDivisibleAll: () => Divisible1<URI>
+```
+
+Added in v2.12.0
+
+## getDivisibleAny
+
+**Signature**
+
+```ts
+export declare const getDivisibleAny: () => Divisible1<URI>
+```
+
+Added in v2.12.0
 
 ## getMonoidAll
 

--- a/docs/modules/Profunctor.ts.md
+++ b/docs/modules/Profunctor.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Profunctor.ts
-nav_order: 75
+nav_order: 76
 parent: Modules
 ---
 

--- a/docs/modules/Random.ts.md
+++ b/docs/modules/Random.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Random.ts
-nav_order: 76
+nav_order: 77
 parent: Modules
 ---
 

--- a/docs/modules/Reader.ts.md
+++ b/docs/modules/Reader.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Reader.ts
-nav_order: 77
+nav_order: 78
 parent: Modules
 ---
 

--- a/docs/modules/ReaderEither.ts.md
+++ b/docs/modules/ReaderEither.ts.md
@@ -1,6 +1,6 @@
 ---
 title: ReaderEither.ts
-nav_order: 78
+nav_order: 79
 parent: Modules
 ---
 

--- a/docs/modules/ReaderT.ts.md
+++ b/docs/modules/ReaderT.ts.md
@@ -1,6 +1,6 @@
 ---
 title: ReaderT.ts
-nav_order: 79
+nav_order: 80
 parent: Modules
 ---
 

--- a/docs/modules/ReaderTask.ts.md
+++ b/docs/modules/ReaderTask.ts.md
@@ -1,6 +1,6 @@
 ---
 title: ReaderTask.ts
-nav_order: 80
+nav_order: 81
 parent: Modules
 ---
 

--- a/docs/modules/ReaderTaskEither.ts.md
+++ b/docs/modules/ReaderTaskEither.ts.md
@@ -1,6 +1,6 @@
 ---
 title: ReaderTaskEither.ts
-nav_order: 81
+nav_order: 82
 parent: Modules
 ---
 

--- a/docs/modules/ReadonlyArray.ts.md
+++ b/docs/modules/ReadonlyArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: ReadonlyArray.ts
-nav_order: 82
+nav_order: 83
 parent: Modules
 ---
 

--- a/docs/modules/ReadonlyMap.ts.md
+++ b/docs/modules/ReadonlyMap.ts.md
@@ -1,6 +1,6 @@
 ---
 title: ReadonlyMap.ts
-nav_order: 83
+nav_order: 84
 parent: Modules
 ---
 

--- a/docs/modules/ReadonlyNonEmptyArray.ts.md
+++ b/docs/modules/ReadonlyNonEmptyArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: ReadonlyNonEmptyArray.ts
-nav_order: 84
+nav_order: 85
 parent: Modules
 ---
 

--- a/docs/modules/ReadonlyRecord.ts.md
+++ b/docs/modules/ReadonlyRecord.ts.md
@@ -1,6 +1,6 @@
 ---
 title: ReadonlyRecord.ts
-nav_order: 85
+nav_order: 86
 parent: Modules
 ---
 

--- a/docs/modules/ReadonlySet.ts.md
+++ b/docs/modules/ReadonlySet.ts.md
@@ -1,6 +1,6 @@
 ---
 title: ReadonlySet.ts
-nav_order: 86
+nav_order: 87
 parent: Modules
 ---
 

--- a/docs/modules/ReadonlyTuple.ts.md
+++ b/docs/modules/ReadonlyTuple.ts.md
@@ -1,6 +1,6 @@
 ---
 title: ReadonlyTuple.ts
-nav_order: 87
+nav_order: 88
 parent: Modules
 ---
 

--- a/docs/modules/Record.ts.md
+++ b/docs/modules/Record.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Record.ts
-nav_order: 88
+nav_order: 89
 parent: Modules
 ---
 

--- a/docs/modules/Refinement.ts.md
+++ b/docs/modules/Refinement.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Refinement.ts
-nav_order: 89
+nav_order: 90
 parent: Modules
 ---
 

--- a/docs/modules/Ring.ts.md
+++ b/docs/modules/Ring.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Ring.ts
-nav_order: 90
+nav_order: 91
 parent: Modules
 ---
 

--- a/docs/modules/Semigroup.ts.md
+++ b/docs/modules/Semigroup.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Semigroup.ts
-nav_order: 91
+nav_order: 92
 parent: Modules
 ---
 

--- a/docs/modules/Semigroupoid.ts.md
+++ b/docs/modules/Semigroupoid.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Semigroupoid.ts
-nav_order: 92
+nav_order: 93
 parent: Modules
 ---
 

--- a/docs/modules/Semiring.ts.md
+++ b/docs/modules/Semiring.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Semiring.ts
-nav_order: 93
+nav_order: 94
 parent: Modules
 ---
 

--- a/docs/modules/Separated.ts.md
+++ b/docs/modules/Separated.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Separated.ts
-nav_order: 94
+nav_order: 95
 parent: Modules
 ---
 

--- a/docs/modules/Set.ts.md
+++ b/docs/modules/Set.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Set.ts
-nav_order: 95
+nav_order: 96
 parent: Modules
 ---
 

--- a/docs/modules/Show.ts.md
+++ b/docs/modules/Show.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Show.ts
-nav_order: 96
+nav_order: 97
 parent: Modules
 ---
 

--- a/docs/modules/State.ts.md
+++ b/docs/modules/State.ts.md
@@ -1,6 +1,6 @@
 ---
 title: State.ts
-nav_order: 97
+nav_order: 98
 parent: Modules
 ---
 

--- a/docs/modules/StateReaderTaskEither.ts.md
+++ b/docs/modules/StateReaderTaskEither.ts.md
@@ -1,6 +1,6 @@
 ---
 title: StateReaderTaskEither.ts
-nav_order: 98
+nav_order: 99
 parent: Modules
 ---
 

--- a/docs/modules/StateT.ts.md
+++ b/docs/modules/StateT.ts.md
@@ -1,6 +1,6 @@
 ---
 title: StateT.ts
-nav_order: 99
+nav_order: 100
 parent: Modules
 ---
 

--- a/docs/modules/Store.ts.md
+++ b/docs/modules/Store.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Store.ts
-nav_order: 100
+nav_order: 101
 parent: Modules
 ---
 

--- a/docs/modules/Strong.ts.md
+++ b/docs/modules/Strong.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Strong.ts
-nav_order: 102
+nav_order: 103
 parent: Modules
 ---
 

--- a/docs/modules/Task.ts.md
+++ b/docs/modules/Task.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Task.ts
-nav_order: 104
+nav_order: 105
 parent: Modules
 ---
 

--- a/docs/modules/TaskEither.ts.md
+++ b/docs/modules/TaskEither.ts.md
@@ -1,6 +1,6 @@
 ---
 title: TaskEither.ts
-nav_order: 105
+nav_order: 106
 parent: Modules
 ---
 

--- a/docs/modules/TaskOption.ts.md
+++ b/docs/modules/TaskOption.ts.md
@@ -1,6 +1,6 @@
 ---
 title: TaskOption.ts
-nav_order: 106
+nav_order: 107
 parent: Modules
 ---
 

--- a/docs/modules/TaskThese.ts.md
+++ b/docs/modules/TaskThese.ts.md
@@ -1,6 +1,6 @@
 ---
 title: TaskThese.ts
-nav_order: 107
+nav_order: 108
 parent: Modules
 ---
 

--- a/docs/modules/These.ts.md
+++ b/docs/modules/These.ts.md
@@ -1,6 +1,6 @@
 ---
 title: These.ts
-nav_order: 108
+nav_order: 109
 parent: Modules
 ---
 

--- a/docs/modules/TheseT.ts.md
+++ b/docs/modules/TheseT.ts.md
@@ -1,6 +1,6 @@
 ---
 title: TheseT.ts
-nav_order: 109
+nav_order: 110
 parent: Modules
 ---
 

--- a/docs/modules/Traced.ts.md
+++ b/docs/modules/Traced.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Traced.ts
-nav_order: 110
+nav_order: 111
 parent: Modules
 ---
 

--- a/docs/modules/Traversable.ts.md
+++ b/docs/modules/Traversable.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Traversable.ts
-nav_order: 111
+nav_order: 112
 parent: Modules
 ---
 

--- a/docs/modules/TraversableWithIndex.ts.md
+++ b/docs/modules/TraversableWithIndex.ts.md
@@ -1,6 +1,6 @@
 ---
 title: TraversableWithIndex.ts
-nav_order: 112
+nav_order: 113
 parent: Modules
 ---
 

--- a/docs/modules/Tree.ts.md
+++ b/docs/modules/Tree.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Tree.ts
-nav_order: 113
+nav_order: 114
 parent: Modules
 ---
 

--- a/docs/modules/Tuple.ts.md
+++ b/docs/modules/Tuple.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Tuple.ts
-nav_order: 114
+nav_order: 115
 parent: Modules
 ---
 

--- a/docs/modules/Unfoldable.ts.md
+++ b/docs/modules/Unfoldable.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Unfoldable.ts
-nav_order: 115
+nav_order: 116
 parent: Modules
 ---
 

--- a/docs/modules/ValidationT.ts.md
+++ b/docs/modules/ValidationT.ts.md
@@ -1,6 +1,6 @@
 ---
 title: ValidationT.ts
-nav_order: 116
+nav_order: 117
 parent: Modules
 ---
 

--- a/docs/modules/Witherable.ts.md
+++ b/docs/modules/Witherable.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Witherable.ts
-nav_order: 118
+nav_order: 119
 parent: Modules
 ---
 

--- a/docs/modules/Writer.ts.md
+++ b/docs/modules/Writer.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Writer.ts
-nav_order: 119
+nav_order: 120
 parent: Modules
 ---
 

--- a/docs/modules/WriterT.ts.md
+++ b/docs/modules/WriterT.ts.md
@@ -1,6 +1,6 @@
 ---
 title: WriterT.ts
-nav_order: 120
+nav_order: 121
 parent: Modules
 ---
 

--- a/docs/modules/Zero.ts.md
+++ b/docs/modules/Zero.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Zero.ts
-nav_order: 121
+nav_order: 122
 parent: Modules
 ---
 

--- a/docs/modules/function.ts.md
+++ b/docs/modules/function.ts.md
@@ -1,6 +1,6 @@
 ---
 title: function.ts
-nav_order: 41
+nav_order: 42
 parent: Modules
 ---
 

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -1,6 +1,6 @@
 ---
 title: index.ts
-nav_order: 48
+nav_order: 49
 parent: Modules
 ---
 
@@ -37,6 +37,7 @@ Added in v2.0.0
   - [contravariant](#contravariant)
   - [date](#date)
   - [distributiveLattice](#distributivelattice)
+  - [divisible](#divisible)
   - [either](#either)
   - [eitherT](#eithert)
   - [endomorphism](#endomorphism)
@@ -376,6 +377,16 @@ export declare const distributiveLattice: typeof distributiveLattice
 ```
 
 Added in v2.0.0
+
+## divisible
+
+**Signature**
+
+```ts
+export declare const divisible: typeof divisible
+```
+
+Added in v2.12.0
 
 ## either
 

--- a/docs/modules/internal.ts.md
+++ b/docs/modules/internal.ts.md
@@ -1,6 +1,6 @@
 ---
 title: internal.ts
-nav_order: 49
+nav_order: 50
 parent: Modules
 ---
 

--- a/docs/modules/number.ts.md
+++ b/docs/modules/number.ts.md
@@ -1,6 +1,6 @@
 ---
 title: number.ts
-nav_order: 67
+nav_order: 68
 parent: Modules
 ---
 

--- a/docs/modules/pipeable.ts.md
+++ b/docs/modules/pipeable.ts.md
@@ -1,6 +1,6 @@
 ---
 title: pipeable.ts
-nav_order: 72
+nav_order: 73
 parent: Modules
 ---
 

--- a/docs/modules/string.ts.md
+++ b/docs/modules/string.ts.md
@@ -1,6 +1,6 @@
 ---
 title: string.ts
-nav_order: 101
+nav_order: 102
 parent: Modules
 ---
 

--- a/docs/modules/struct.ts.md
+++ b/docs/modules/struct.ts.md
@@ -1,6 +1,6 @@
 ---
 title: struct.ts
-nav_order: 103
+nav_order: 104
 parent: Modules
 ---
 

--- a/docs/modules/void.ts.md
+++ b/docs/modules/void.ts.md
@@ -1,6 +1,6 @@
 ---
 title: void.ts
-nav_order: 117
+nav_order: 118
 parent: Modules
 ---
 

--- a/src/Divisible.ts
+++ b/src/Divisible.ts
@@ -1,0 +1,92 @@
+/**
+ * @since 2.12.0
+ */
+import {
+  Contravariant,
+  Contravariant1,
+  Contravariant2,
+  Contravariant2C,
+  Contravariant3,
+  Contravariant3C,
+  Contravariant4
+} from './Contravariant'
+import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3, URIS4, Kind4 } from './HKT'
+
+// -------------------------------------------------------------------------------------
+// model
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category type classes
+ * @since 2.12.0
+ */
+export interface Divisible<F> extends Contravariant<F> {
+  readonly divide: <C, B, A>(f: (a: A) => [B, C], first: HKT<F, B>, second: HKT<F, C>) => HKT<F, A>
+  readonly conquer: HKT<F, unknown>
+}
+
+/**
+ * @category type classes
+ * @since 2.12.0
+ */
+export interface Divisible1<F extends URIS> extends Contravariant1<F> {
+  readonly divide: <C, B, A>(f: (a: A) => [B, C], first: Kind<F, B>, second: Kind<F, C>) => Kind<F, A>
+  readonly conquer: Kind<F, unknown>
+}
+
+/**
+ * @category type classes
+ * @since 2.12.0
+ */
+export interface Divisible2<F extends URIS2> extends Contravariant2<F> {
+  readonly divide: <E, C, B, A>(f: (a: A) => [B, C], first: Kind2<F, E, B>, second: Kind2<F, E, C>) => Kind2<F, E, A>
+  readonly conquer: Kind2<F, unknown, unknown>
+}
+
+/**
+ * @category type classes
+ * @since 2.12.0
+ */
+export interface Divisible2C<F extends URIS2, E> extends Contravariant2C<F, E> {
+  readonly divide: <C, B, A>(f: (a: A) => [B, C], first: Kind2<F, E, B>, second: Kind2<F, E, C>) => Kind2<F, E, A>
+  readonly conquer: Kind2<F, E, unknown>
+}
+
+/**
+ * @category type classes
+ * @since 2.12.0
+ */
+export interface Divisible3<F extends URIS3> extends Contravariant3<F> {
+  readonly divide: <R, E, C, B, A>(
+    f: (a: A) => [B, C],
+    first: Kind3<F, R, E, B>,
+    second: Kind3<F, R, E, C>
+  ) => Kind3<F, R, E, A>
+  readonly conquer: Kind3<F, unknown, unknown, unknown>
+}
+
+/**
+ * @category type classes
+ * @since 2.12.0
+ */
+export interface Divisible3C<F extends URIS3, E> extends Contravariant3C<F, E> {
+  readonly divide: <R, C, B, A>(
+    f: (a: A) => [B, C],
+    first: Kind3<F, R, E, B>,
+    second: Kind3<F, R, E, C>
+  ) => Kind3<F, R, E, A>
+  readonly conquer: Kind3<F, unknown, unknown, unknown>
+}
+
+/**
+ * @category type classes
+ * @since 2.12.0
+ */
+export interface Divisible4<F extends URIS4> extends Contravariant4<F> {
+  readonly divide: <S, R, E, C, B, A>(
+    f: (a: A) => [B, C],
+    first: Kind4<F, S, R, E, B>,
+    second: Kind4<F, S, R, E, C>
+  ) => Kind4<F, S, R, E, A>
+  readonly conquer: Kind4<F, unknown, unknown, unknown, unknown>
+}

--- a/src/Eq.ts
+++ b/src/Eq.ts
@@ -10,10 +10,12 @@
  * @since 2.0.0
  */
 import { Contravariant1 } from './Contravariant'
-import { pipe } from './function'
+import { Divisible1 } from './Divisible'
+import { flow, pipe } from './function'
 import { Monoid } from './Monoid'
 import { ReadonlyRecord } from './ReadonlyRecord'
 import { Semigroup } from './Semigroup'
+import { fst, snd } from './Tuple'
 
 // -------------------------------------------------------------------------------------
 // model
@@ -154,6 +156,18 @@ export const getMonoid = <A>(): Monoid<Eq<A>> => ({
 export const Contravariant: Contravariant1<URI> = {
   URI,
   contramap: contramap_
+}
+
+/**
+ * @category instances
+ * @since 2.12.0
+ */
+export const Divisible: Divisible1<URI> = {
+  URI: Contravariant.URI,
+  contramap: Contravariant.contramap,
+  divide: <C, B, A>(f: (a: A) => [B, C], first: Eq<B>, second: Eq<C>) =>
+    getSemigroup<A>().concat(contramap<B, A>(flow(f, fst))(first), contramap<C, A>(flow(f, snd))(second)),
+  conquer: empty
 }
 
 // -------------------------------------------------------------------------------------

--- a/src/Ord.ts
+++ b/src/Ord.ts
@@ -10,11 +10,13 @@
  * @since 2.0.0
  */
 import { Contravariant1 } from './Contravariant'
+import { Divisible1 } from './Divisible'
 import { Eq, eqStrict } from './Eq'
-import { constant, constTrue, pipe } from './function'
+import { constant, constTrue, flow, pipe } from './function'
 import { Monoid } from './Monoid'
 import { Ordering } from './Ordering'
 import { Semigroup } from './Semigroup'
+import { fst, snd } from './Tuple'
 
 // -------------------------------------------------------------------------------------
 // model
@@ -222,6 +224,21 @@ export const getMonoid = <A = never>(): Monoid<Ord<A>> => ({
 export const Contravariant: Contravariant1<URI> = {
   URI,
   contramap: contramap_
+}
+
+/**
+ * @category instances
+ * @since 2.12.0
+ */
+export const Divisible: Divisible1<URI> = {
+  URI,
+  contramap: contramap_,
+  divide: <C, B, A>(f: (a: A) => [B, C], first: Ord<B>, second: Ord<C>) =>
+    getSemigroup<A>().concat(contramap<B, A>(flow(f, fst))(first), contramap<C, A>(flow(f, snd))(second)),
+  conquer: {
+    equals: constTrue,
+    compare: constant(0)
+  }
 }
 
 // -------------------------------------------------------------------------------------

--- a/src/Predicate.ts
+++ b/src/Predicate.ts
@@ -2,6 +2,7 @@
  * @since 2.11.0
  */
 import { Contravariant1 } from './Contravariant'
+import { Divisible1 } from './Divisible'
 import { constFalse, constTrue, flow, pipe } from './function'
 import { Monoid } from './Monoid'
 import { Semigroup } from './Semigroup'
@@ -93,6 +94,28 @@ export const Contravariant: Contravariant1<URI> = {
   URI,
   contramap: contramap_
 }
+
+/**
+ * @category instances
+ * @since 2.12.0
+ */
+export const getDivisibleAny = (): Divisible1<URI> => ({
+  URI: Contravariant.URI,
+  contramap: Contravariant.contramap,
+  divide: (f, first, second) => flow(f, ([b, c]) => first(b) || second(c)),
+  conquer: constFalse
+})
+
+/**
+ * @category instances
+ * @since 2.12.0
+ */
+export const getDivisibleAll = (): Divisible1<URI> => ({
+  URI: Contravariant.URI,
+  contramap: Contravariant.contramap,
+  divide: (f, first, second) => flow(f, ([b, c]) => first(b) && second(c)),
+  conquer: constTrue
+})
 
 // -------------------------------------------------------------------------------------
 // utils

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import * as const_ from './Const'
 import * as contravariant from './Contravariant'
 import * as date from './Date'
 import * as distributiveLattice from './DistributiveLattice'
+import * as divisible from './Divisible'
 import * as either from './Either'
 import * as eitherT from './EitherT'
 import * as endomorphism from './Endomorphism'
@@ -218,6 +219,10 @@ export {
    * @since 2.0.0
    */
   distributiveLattice,
+  /**
+   * @since 2.12.0
+   */
+  divisible,
   /**
    * @since 2.0.0
    */

--- a/test/Eq.ts
+++ b/test/Eq.ts
@@ -85,4 +85,13 @@ describe('Eq', () => {
     U.deepStrictEqual(E.equals(new Date(0), new Date(1)), false)
     U.deepStrictEqual(E.equals(new Date(1), new Date(0)), false)
   })
+
+  it('Divisible', () => {
+    const eqPerson: _.Eq<Person> = _.Divisible.divide((p) => [p.name, p.age], S.Eq, N.Eq)
+    U.deepStrictEqual(eqPerson.equals({ name: 'a', age: 1 }, { name: 'a', age: 2 }), false)
+    U.deepStrictEqual(eqPerson.equals({ name: 'a', age: 1 }, { name: 'a', age: 1 }), true)
+    U.deepStrictEqual(eqPerson.equals({ name: 'a', age: 1 }, { name: 'b', age: 1 }), false)
+    U.deepStrictEqual(eqPerson.equals({ name: 'a', age: 1 }, { name: 'b', age: 2 }), false)
+    U.deepStrictEqual(eqPerson.equals({ name: 'a', age: 1 }, { name: 'a', age: 1 }), true)
+  })
 })

--- a/test/Ord.ts
+++ b/test/Ord.ts
@@ -167,4 +167,15 @@ describe('Ord', () => {
     U.deepStrictEqual(O.compare(new Date(0), new Date(1)), -1)
     U.deepStrictEqual(O.compare(new Date(1), new Date(0)), 1)
   })
+
+  it('Divisible', () => {
+    type Person = {
+      readonly name: string
+      readonly age: number
+    }
+    const P: _.Ord<Person> = _.Divisible.divide((p) => [p.name, p.age], S.Ord, N.Ord)
+    U.deepStrictEqual(P.compare({ name: 'a', age: 1 }, { name: 'a', age: 2 }), -1)
+    U.deepStrictEqual(P.compare({ name: 'a', age: 1 }, { name: 'b', age: 1 }), -1)
+    U.deepStrictEqual(P.compare({ name: 'a', age: 1 }, { name: 'a', age: 1 }), 0)
+  })
 })

--- a/test/Predicate.ts
+++ b/test/Predicate.ts
@@ -1,4 +1,5 @@
 import { pipe } from '../src/function'
+import { isEmpty } from '../src/string'
 import * as _ from '../src/Predicate'
 import * as U from './util'
 
@@ -28,6 +29,30 @@ describe('Predicate', () => {
     U.deepStrictEqual(predicate({ a: -1 }), false)
     U.deepStrictEqual(predicate({ a: 0 }), false)
     U.deepStrictEqual(predicate({ a: 1 }), true)
+  })
+
+  it('getDivisibleAny', () => {
+    type A = {
+      readonly b: string
+      readonly c: number
+    }
+    const predicate = _.getDivisibleAny().divide((a: A) => [a.c, a.b], isPositive, isEmpty)
+    U.deepStrictEqual(predicate({ b: '', c: 1 }), true)
+    U.deepStrictEqual(predicate({ b: 'b', c: 1 }), true)
+    U.deepStrictEqual(predicate({ b: '', c: -1 }), true)
+    U.deepStrictEqual(predicate({ b: 'b', c: -1 }), false)
+  })
+
+  it('getDivisibleAll', () => {
+    type A = {
+      readonly b: string
+      readonly c: number
+    }
+    const predicate = _.getDivisibleAll().divide((a: A) => [a.c, a.b], isPositive, isEmpty)
+    U.deepStrictEqual(predicate({ b: '', c: 1 }), true)
+    U.deepStrictEqual(predicate({ b: 'b', c: 1 }), false)
+    U.deepStrictEqual(predicate({ b: '', c: -1 }), false)
+    U.deepStrictEqual(predicate({ b: 'b', c: -1 }), false)
   })
 
   it('not', () => {


### PR DESCRIPTION
Add `Divisible` type class, useful to create `Eq`/`Ord`/`Predicate` as composition.

Inspirated by Haskell's [`Data.Functor.Contravariant.Divisable`](https://hackage.haskell.org/package/contravariant-1.5.5/docs/Data-Functor-Contravariant-Divisible.html)