### PR TITLE
Add Show to Json

### DIFF
--- a/docs/modules/Json.ts.md
+++ b/docs/modules/Json.ts.md
@@ -12,16 +12,100 @@ Added in v2.10.0
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [utils](#utils)
+- [constructors](#constructors)
+  - [parse](#parse)
+- [destructors](#destructors)
+  - [stringify](#stringify)
+- [instances](#instances)
+  - [Show](#show)
+- [model](#model)
   - [Json (type alias)](#json-type-alias)
   - [JsonArray (interface)](#jsonarray-interface)
   - [JsonRecord (interface)](#jsonrecord-interface)
-  - [parse](#parse)
-  - [stringify](#stringify)
 
 ---
 
-# utils
+# constructors
+
+## parse
+
+Converts a JavaScript Object Notation (JSON) string into a `Json` type.
+
+**Signature**
+
+```ts
+export declare const parse: (s: string) => Either<unknown, Json>
+```
+
+**Example**
+
+```ts
+import * as J from 'fp-ts/Json'
+import * as E from 'fp-ts/Either'
+import { pipe } from 'fp-ts/function'
+
+assert.deepStrictEqual(pipe('{"a":1}', J.parse), E.right({ a: 1 }))
+assert.deepStrictEqual(pipe('{"a":}', J.parse), E.left(new SyntaxError('Unexpected token } in JSON at position 5')))
+```
+
+Added in v2.10.0
+
+# destructors
+
+## stringify
+
+Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
+
+**Signature**
+
+```ts
+export declare const stringify: <A>(a: A) => Either<unknown, string>
+```
+
+**Example**
+
+```ts
+import * as E from 'fp-ts/Either'
+import * as J from 'fp-ts/Json'
+import { pipe } from 'fp-ts/function'
+
+assert.deepStrictEqual(J.stringify({ a: 1 }), E.right('{"a":1}'))
+const circular: any = { ref: null }
+circular.ref = circular
+assert.deepStrictEqual(
+  pipe(
+    J.stringify(circular),
+    E.mapLeft((e) => e instanceof Error && e.message.includes('Converting circular structure to JSON'))
+  ),
+  E.left(true)
+)
+```
+
+Added in v2.10.0
+
+# instances
+
+## Show
+
+**Signature**
+
+```ts
+export declare const Show: Sh.Show<Json>
+```
+
+**Example**
+
+```ts
+import * as J from 'fp-ts/Json'
+
+const circular: any = { b: 1, a: 0 }
+circular.circular = circular
+assert.deepStrictEqual(J.Show.show(circular), '{"a":0,"b":1,"circular":"[Circular]"}')
+```
+
+Added in v2.11.9
+
+# model
 
 ## Json (type alias)
 
@@ -51,60 +135,6 @@ Added in v2.10.0
 export interface JsonRecord {
   readonly [key: string]: Json
 }
-```
-
-Added in v2.10.0
-
-## parse
-
-Converts a JavaScript Object Notation (JSON) string into a `Json` type.
-
-**Signature**
-
-```ts
-export declare const parse: (s: string) => Either<unknown, Json>
-```
-
-**Example**
-
-```ts
-import * as J from 'fp-ts/Json'
-import * as E from 'fp-ts/Either'
-import { pipe } from 'fp-ts/function'
-
-assert.deepStrictEqual(pipe('{"a":1}', J.parse), E.right({ a: 1 }))
-assert.deepStrictEqual(pipe('{"a":}', J.parse), E.left(new SyntaxError('Unexpected token } in JSON at position 5')))
-```
-
-Added in v2.10.0
-
-## stringify
-
-Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
-
-**Signature**
-
-```ts
-export declare const stringify: <A>(a: A) => Either<unknown, string>
-```
-
-**Example**
-
-```ts
-import * as E from 'fp-ts/Either'
-import * as J from 'fp-ts/Json'
-import { pipe } from 'fp-ts/function'
-
-assert.deepStrictEqual(J.stringify({ a: 1 }), E.right('{"a":1}'))
-const circular: any = { ref: null }
-circular.ref = circular
-assert.deepStrictEqual(
-  pipe(
-    J.stringify(circular),
-    E.mapLeft((e) => e instanceof Error && e.message.includes('Converting circular structure to JSON'))
-  ),
-  E.left(true)
-)
 ```
 
 Added in v2.10.0

--- a/dtslint/ts3.5/Json.ts
+++ b/dtslint/ts3.5/Json.ts
@@ -3,6 +3,21 @@ import { pipe } from '../../src/function'
 import * as _ from '../../src/Json'
 
 //
+// Show
+//
+
+// $ExpectError
+_.Show.show(undefined)
+// $ExpectError
+_.Show.show(() => {})
+// $ExpectError
+_.Show.show(Symbol())
+// $ExpectError
+_.Show.show({ a: undefined })
+// $ExpectError
+_.Show.show({ ...{ a: undefined } })
+
+//
 // stringify
 //
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6147,6 +6147,11 @@
         "ret": "~0.1.10"
       }
     },
+    "safe-stable-stringify": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
+      "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg=="
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -67,5 +67,7 @@
     "algebraic-data-types",
     "functional-programming"
   ],
-  "dependencies": {}
+  "dependencies": {
+    "safe-stable-stringify": "^2.3.1"
+  }
 }

--- a/src/Json.ts
+++ b/src/Json.ts
@@ -1,15 +1,23 @@
 /**
  * @since 2.10.0
  */
+import safeStringify from 'safe-stable-stringify'
 import { Either, tryCatch } from './Either'
 import { identity } from './function'
+import * as Sh from './Show'
+
+// -------------------------------------------------------------------------------------
+// model
+// -------------------------------------------------------------------------------------
 
 /**
+ * @category model
  * @since 2.10.0
  */
 export type Json = boolean | number | string | null | JsonArray | JsonRecord
 
 /**
+ * @category model
  * @since 2.10.0
  */
 export interface JsonRecord {
@@ -17,9 +25,33 @@ export interface JsonRecord {
 }
 
 /**
+ * @category model
  * @since 2.10.0
  */
 export interface JsonArray extends ReadonlyArray<Json> {}
+
+// -------------------------------------------------------------------------------------
+// instances
+// -------------------------------------------------------------------------------------
+
+/**
+ * @example
+ * import * as J from 'fp-ts/Json'
+ *
+ * const circular: any = { b: 1, a: 0 }
+ * circular.circular = circular
+ * assert.deepStrictEqual(J.Show.show(circular), '{"a":0,"b":1,"circular":"[Circular]"}')
+ *
+ * @category instances
+ * @since 2.11.9
+ */
+export const Show: Sh.Show<Json> = {
+  show: safeStringify
+}
+
+// -------------------------------------------------------------------------------------
+// constructors
+// -------------------------------------------------------------------------------------
 
 /**
  * Converts a JavaScript Object Notation (JSON) string into a `Json` type.
@@ -32,9 +64,14 @@ export interface JsonArray extends ReadonlyArray<Json> {}
  * assert.deepStrictEqual(pipe('{"a":1}', J.parse), E.right({ a: 1 }))
  * assert.deepStrictEqual(pipe('{"a":}', J.parse), E.left(new SyntaxError('Unexpected token } in JSON at position 5')))
  *
+ * @category constructors
  * @since 2.10.0
  */
 export const parse = (s: string): Either<unknown, Json> => tryCatch(() => JSON.parse(s), identity)
+
+// -------------------------------------------------------------------------------------
+// destructors
+// -------------------------------------------------------------------------------------
 
 /**
  * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
@@ -55,7 +92,8 @@ export const parse = (s: string): Either<unknown, Json> => tryCatch(() => JSON.p
  *   E.left(true)
  * )
  *
- *  @since 2.10.0
+ * @category destructors
+ * @since 2.10.0
  */
 export const stringify = <A>(a: A): Either<unknown, string> =>
   tryCatch(() => {

--- a/src/boolean.ts
+++ b/src/boolean.ts
@@ -4,6 +4,7 @@
 import * as BA from './BooleanAlgebra'
 import * as E from './Eq'
 import { Lazy } from './function'
+import * as J from './Json'
 import { Monoid } from './Monoid'
 import * as O from './Ord'
 import { Refinement } from './Refinement'
@@ -182,6 +183,4 @@ export const Ord: O.Ord<boolean> = {
  * @category instances
  * @since 2.10.0
  */
-export const Show: S.Show<boolean> = {
-  show: (b) => JSON.stringify(b)
-}
+export const Show: S.Show<boolean> = J.Show

--- a/src/number.ts
+++ b/src/number.ts
@@ -4,6 +4,7 @@
 import * as B from './Bounded'
 import * as E from './Eq'
 import * as F from './Field'
+import * as J from './Json'
 import { Magma } from './Magma'
 import { Monoid } from './Monoid'
 import * as O from './Ord'
@@ -57,9 +58,7 @@ export const Bounded: B.Bounded<number> = {
  * @category instances
  * @since 2.10.0
  */
-export const Show: S.Show<number> = {
-  show: (n) => JSON.stringify(n)
-}
+export const Show: S.Show<number> = J.Show
 
 /**
  * @category instances

--- a/src/string.ts
+++ b/src/string.ts
@@ -2,6 +2,7 @@
  * @since 2.10.0
  */
 import * as E from './Eq'
+import * as J from './Json'
 import * as M from './Monoid'
 import * as S from './Semigroup'
 import * as O from './Ord'
@@ -86,9 +87,7 @@ export const Ord: O.Ord<string> = {
  * @category instances
  * @since 2.10.0
  */
-export const Show: Sh.Show<string> = {
-  show: (s) => JSON.stringify(s)
-}
+export const Show: Sh.Show<string> = J.Show
 
 // -------------------------------------------------------------------------------------
 // refinements

--- a/test/Json.ts
+++ b/test/Json.ts
@@ -4,10 +4,35 @@ import * as _ from '../src/Json'
 import * as U from './util'
 
 describe('Json', () => {
+  // -------------------------------------------------------------------------------------
+  // instances
+  // -------------------------------------------------------------------------------------
+
+  it('Show', () => {
+    U.deepStrictEqual(_.Show.show({ a: 1 }), '{"a":1}')
+    const circular: any = { ref: null }
+    circular.ref = circular
+    U.deepStrictEqual(_.Show.show(circular), '{"ref":"[Circular]"}')
+    type Person = {
+      readonly name: string
+      readonly age: number
+    }
+    const person: Person = { name: 'Giulio', age: 45 }
+    U.deepStrictEqual(_.Show.show(person), '{"age":45,"name":"Giulio"}')
+  })
+
+  // -------------------------------------------------------------------------------------
+  // constructors
+  // -------------------------------------------------------------------------------------
+
   it('parse', () => {
     U.deepStrictEqual(pipe('{"a":1}', _.parse), E.right({ a: 1 }))
     U.deepStrictEqual(pipe('{"a":}', _.parse), E.left(new SyntaxError('Unexpected token } in JSON at position 5')))
   })
+
+  // -------------------------------------------------------------------------------------
+  // destructors
+  // -------------------------------------------------------------------------------------
 
   it('stringify', () => {
     U.deepStrictEqual(pipe({ a: 1 }, _.stringify), E.right('{"a":1}'))


### PR DESCRIPTION
This adds a `Show` to `Json`; since there can be circular references it replaces those with a `[Circular]` string so that it doesn't fail.