### PR TITLE
try/catch in tryCatch

### DIFF
--- a/docs/modules/TaskEither.ts.md
+++ b/docs/modules/TaskEither.ts.md
@@ -1245,8 +1245,6 @@ Added in v2.10.0
 
 Transforms a `Promise` that may reject to a `Promise` that never rejects and returns an `Either` instead.
 
-Note: `f` should never `throw` errors, they are not caught.
-
 See also [`tryCatchK`](#trycatchk).
 
 **Signature**

--- a/docs/modules/TaskOption.ts.md
+++ b/docs/modules/TaskOption.ts.md
@@ -808,8 +808,6 @@ Added in v2.10.0
 
 Transforms a `Promise` that may reject to a `Promise` that never rejects and returns an `Option` instead.
 
-Note: `f` should never `throw` errors, they are not caught.
-
 See also [`tryCatchK`](#trycatchk).
 
 **Signature**

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -254,8 +254,6 @@ export const getOrElseW: <E, B>(
 /**
  * Transforms a `Promise` that may reject to a `Promise` that never rejects and returns an `Either` instead.
  *
- * Note: `f` should never `throw` errors, they are not caught.
- *
  * See also [`tryCatchK`](#trycatchk).
  *
  * @example
@@ -272,8 +270,16 @@ export const getOrElseW: <E, B>(
  * @category interop
  * @since 2.0.0
  */
-export const tryCatch = <E, A>(f: Lazy<Promise<A>>, onRejected: (reason: unknown) => E): TaskEither<E, A> => () =>
-  f().then(_.right, (reason) => _.left(onRejected(reason)))
+export const tryCatch = <E, A>(
+  f: Lazy<Promise<A>>,
+  onRejected: (reason: unknown) => E
+): TaskEither<E, A> => async () => {
+  try {
+    return await f().then(_.right)
+  } catch (reason) {
+    return _.left(onRejected(reason))
+  }
+}
 
 /**
  * Converts a function returning a `Promise` to one returning a `TaskEither`.

--- a/src/TaskOption.ts
+++ b/src/TaskOption.ts
@@ -208,18 +208,18 @@ export const fromNullable: <A>(a: A) => TaskOption<NonNullable<A>> =
 /**
  * Transforms a `Promise` that may reject to a `Promise` that never rejects and returns an `Option` instead.
  *
- * Note: `f` should never `throw` errors, they are not caught.
- *
  * See also [`tryCatchK`](#trycatchk).
  *
  * @category interop
  * @since 2.10.0
  */
-export const tryCatch = <A>(f: Lazy<Promise<A>>): TaskOption<A> => () =>
-  f().then(
-    (a) => O.some(a),
-    () => O.none
-  )
+export const tryCatch = <A>(f: Lazy<Promise<A>>): TaskOption<A> => async () => {
+  try {
+    return await f().then(_.some)
+  } catch (reason) {
+    return _.none
+  }
+}
 
 /**
  * Converts a function returning a `Promise` to one returning a `TaskOption`.

--- a/test/TaskEither.ts
+++ b/test/TaskEither.ts
@@ -452,16 +452,23 @@ describe('TaskEither', () => {
     U.deepStrictEqual(await pipe(_.right('a'), _.chainIOEitherK(f))(), E.right(1))
   })
 
-  it('tryCatchK', async () => {
-    const f = (n: number) => {
-      if (n > 0) {
-        return Promise.resolve(n * 2)
-      }
-      return Promise.reject('negative')
-    }
-    const g = _.tryCatchK(f, identity)
-    U.deepStrictEqual(await g(1)(), E.right(2))
-    U.deepStrictEqual(await g(-1)(), E.left('negative'))
+  describe('tryCatchK', () => {
+    test('with a resolved promise', async () => {
+      const g = _.tryCatchK((a: number) => Promise.resolve(a), identity)
+      U.deepStrictEqual(await g(1)(), E.right(1))
+    })
+
+    test('with a rejected promise', async () => {
+      const g = _.tryCatchK((a: number) => Promise.reject(a), identity)
+      U.deepStrictEqual(await g(-1)(), E.left(-1))
+    })
+
+    test('with a thrown error', async () => {
+      const g = _.tryCatchK((_: number) => {
+        throw new Error('Some error')
+      }, identity)
+      U.deepStrictEqual(await g(-1)(), E.left(new Error('Some error')))
+    })
   })
 
   // -------------------------------------------------------------------------------------
@@ -478,21 +485,23 @@ describe('TaskEither', () => {
     U.deepStrictEqual(await _.leftIO(I.of(1))(), E.left(1))
   })
 
-  it('tryCatch', async () => {
-    U.deepStrictEqual(
-      await _.tryCatch(
-        () => Promise.resolve(1),
-        () => 'error'
-      )(),
-      E.right(1)
-    )
-    U.deepStrictEqual(
-      await _.tryCatch(
-        () => Promise.reject(undefined),
-        () => 'error'
-      )(),
-      E.left('error')
-    )
+  describe('tryCatch', () => {
+    test('with a resolving promise', async () => {
+      U.deepStrictEqual(await _.tryCatch(() => Promise.resolve(1), identity)(), E.right(1))
+    })
+
+    test('with a rejected promise', async () => {
+      U.deepStrictEqual(await _.tryCatch(() => Promise.reject(1), identity)(), E.left(1))
+    })
+
+    test('with a thrown error', async () => {
+      U.deepStrictEqual(
+        await _.tryCatch(() => {
+          throw new Error('Some error')
+        }, identity)(),
+        E.left(new Error('Some error'))
+      )
+    })
   })
 
   it('fromIOEither', async () => {

--- a/test/TaskOption.ts
+++ b/test/TaskOption.ts
@@ -89,9 +89,23 @@ describe('TaskOption', () => {
   // constructors
   // -------------------------------------------------------------------------------------
 
-  it('tryCatch', async () => {
-    U.deepStrictEqual(await _.tryCatch(() => Promise.resolve(1))(), O.some(1))
-    U.deepStrictEqual(await _.tryCatch(() => Promise.reject())(), O.none)
+  describe('tryCatch', () => {
+    test('with a resolving promise', async () => {
+      U.deepStrictEqual(await _.tryCatch(() => Promise.resolve(1))(), O.some(1))
+    })
+
+    test('with a rejected promise', async () => {
+      U.deepStrictEqual(await _.tryCatch(() => Promise.reject(1))(), O.none)
+    })
+
+    test('with a thrown error', async () => {
+      U.deepStrictEqual(
+        await _.tryCatch(() => {
+          throw new Error('Some error')
+        })(),
+        O.none
+      )
+    })
   })
 
   it('fromNullable', async () => {
@@ -288,11 +302,23 @@ describe('TaskOption', () => {
     })
   })
 
-  it('tryCatchK', async () => {
-    const f = (n: number) => (n > 0 ? Promise.resolve(n) : Promise.reject(n))
-    const g = _.tryCatchK(f)
-    U.deepStrictEqual(await g(1)(), O.some(1))
-    U.deepStrictEqual(await g(-1)(), O.none)
+  describe('tryCatchK', () => {
+    test('with a resolved promise', async () => {
+      const g = _.tryCatchK((a: number) => Promise.resolve(a))
+      U.deepStrictEqual(await g(1)(), O.some(1))
+    })
+
+    test('with a rejected promise', async () => {
+      const g = _.tryCatchK((a: number) => Promise.reject(a))
+      U.deepStrictEqual(await g(-1)(), O.none)
+    })
+
+    test('with a thrown error', async () => {
+      const g = _.tryCatchK((_: number) => {
+        throw new Error('Some error')
+      })
+      U.deepStrictEqual(await g(-1)(), O.none)
+    })
   })
 
   it('match', async () => {


### PR DESCRIPTION
This reopens and updates #1001 to allow `f` in `TaskEither` and `TaskOption`'s `tryCatch`/`tryCatchK` to throw an error (as opposed to only returning a resolved/rejected promise).

Fixes #1672.