### PR TITLE
Add intercalate to Monoid

### DIFF
--- a/docs/modules/Monoid.ts.md
+++ b/docs/modules/Monoid.ts.md
@@ -44,6 +44,7 @@ Added in v2.0.0
 <h2 class="text-delta">Table of contents</h2>
 
 - [combinators](#combinators)
+  - [intercalate](#intercalate)
   - [reverse](#reverse)
   - [struct](#struct)
   - [tuple](#tuple)
@@ -73,6 +74,30 @@ Added in v2.0.0
 ---
 
 # combinators
+
+## intercalate
+
+Between each pair of elements insert `middle`.
+
+**Signature**
+
+```ts
+export declare const intercalate: <A>(middle: A) => (M: Monoid<A>) => Monoid<A>
+```
+
+**Example**
+
+```ts
+import { intercalate } from 'fp-ts/Monoid'
+import * as S from 'fp-ts/string'
+import { pipe } from 'fp-ts/function'
+
+const S1 = pipe(S.Monoid, intercalate(' + '))
+
+assert.strictEqual(S1.concat('a', 'b'), 'a + b')
+```
+
+Added in v2.11.9
 
 ## reverse
 

--- a/src/Monoid.ts
+++ b/src/Monoid.ts
@@ -178,6 +178,26 @@ export const tuple = <A extends ReadonlyArray<unknown>>(
     empty: monoids.map((m) => m.empty)
   } as any)
 
+/**
+ * Between each pair of elements insert `middle`.
+ *
+ * @example
+ * import { intercalate } from 'fp-ts/Monoid'
+ * import * as S from 'fp-ts/string'
+ * import { pipe } from 'fp-ts/function'
+ *
+ * const S1 = pipe(S.Monoid, intercalate(' + '))
+ *
+ * assert.strictEqual(S1.concat('a', 'b'), 'a + b')
+ *
+ * @category combinators
+ * @since 2.11.9
+ */
+export const intercalate = <A>(middle: A) => (M: Monoid<A>): Monoid<A> => ({
+  empty: M.empty,
+  concat: Se.intercalate(middle)(M).concat
+})
+
 // -------------------------------------------------------------------------------------
 // utils
 // -------------------------------------------------------------------------------------

--- a/test/Monoid.ts
+++ b/test/Monoid.ts
@@ -51,4 +51,11 @@ describe('Monoid', () => {
     const s = _.struct(monoids)
     U.deepStrictEqual(s.empty, {})
   })
+
+  it('intercalate', () => {
+    const IM = _.intercalate(' ')(S.Monoid)
+    U.deepStrictEqual(IM.concat('a', 'b'), 'a b')
+    U.deepStrictEqual(IM.concat(IM.concat('a', 'b'), 'c'), IM.concat('a', IM.concat('b', 'c')))
+    U.deepStrictEqual(IM.empty, '')
+  })
 })


### PR DESCRIPTION
Adds `intercalate` to `Monoid`, to match `Semigroup`.