### PR TITLE
Refinement overload added to 'every' functions

### DIFF
--- a/docs/modules/Array.ts.md
+++ b/docs/modules/Array.ts.md
@@ -3313,7 +3313,10 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export declare const every: <A>(predicate: Predicate<A>) => (as: A[]) => boolean
+export declare const every: {
+  <A, B extends A>(refinement: Refinement<A, B>): Refinement<A[], B[]>
+  <A>(predicate: Predicate<A>): Predicate<A[]>
+}
 ```
 
 **Example**

--- a/docs/modules/ReadonlyArray.ts.md
+++ b/docs/modules/ReadonlyArray.ts.md
@@ -2433,7 +2433,10 @@ Check if a predicate holds true for every array member.
 **Signature**
 
 ```ts
-export declare const every: <A>(predicate: Predicate<A>) => (as: readonly A[]) => boolean
+export declare function every<A, B extends A>(
+  refinement: Refinement<A, B>
+): Refinement<ReadonlyArray<A>, ReadonlyArray<B>>
+export declare function every<A>(predicate: Predicate<A>): Predicate<ReadonlyArray<A>>
 ```
 
 **Example**

--- a/docs/modules/ReadonlyRecord.ts.md
+++ b/docs/modules/ReadonlyRecord.ts.md
@@ -1235,7 +1235,10 @@ Test if every value in a `ReadonlyRecord` satisfies the predicate.
 **Signature**
 
 ```ts
-export declare function every<A>(predicate: Predicate<A>): (r: ReadonlyRecord<string, A>) => boolean
+export declare function every<A, B extends A>(
+  refinement: Refinement<A, B>
+): Refinement<ReadonlyRecord<string, A>, ReadonlyRecord<string, B>>
+export declare function every<A>(predicate: Predicate<A>): Predicate<ReadonlyRecord<string, A>>
 ```
 
 **Example**

--- a/docs/modules/ReadonlySet.ts.md
+++ b/docs/modules/ReadonlySet.ts.md
@@ -392,7 +392,8 @@ Added in v2.5.0
 **Signature**
 
 ```ts
-export declare const every: <A>(predicate: Predicate<A>) => (set: ReadonlySet<A>) => boolean
+export declare function every<A, B extends A>(refinement: Refinement<A, B>): Refinement<ReadonlySet<A>, ReadonlySet<B>>
+export declare function every<A>(predicate: Predicate<A>): Predicate<ReadonlySet<A>>
 ```
 
 Added in v2.5.0

--- a/docs/modules/Record.ts.md
+++ b/docs/modules/Record.ts.md
@@ -995,7 +995,10 @@ Test if every value in a `Record` satisfies the predicate.
 **Signature**
 
 ```ts
-export declare const every: <A>(predicate: Predicate<A>) => (r: Record<string, A>) => boolean
+export declare const every: {
+  <A, B extends A>(refinement: Refinement<A, B>): Refinement<Record<string, A>, Record<string, B>>
+  <A>(predicate: Predicate<A>): Predicate<Record<string, A>>
+}
 ```
 
 **Example**

--- a/docs/modules/Set.ts.md
+++ b/docs/modules/Set.ts.md
@@ -328,7 +328,10 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export declare const every: <A>(predicate: Predicate<A>) => (set: Set<A>) => boolean
+export declare const every: {
+  <A, B extends A>(refinement: Refinement<A, B>): Refinement<Set<A>, Set<B>>
+  <A>(predicate: Predicate<A>): Predicate<Set<A>>
+}
 ```
 
 Added in v2.0.0

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -2863,7 +2863,10 @@ export const unsafeDeleteAt = <A>(i: number, as: Array<A>): Array<A> => {
  *
  * @since 2.9.0
  */
-export const every: <A>(predicate: Predicate<A>) => (as: Array<A>) => boolean = RA.every
+export const every: {
+  <A, B extends A>(refinement: Refinement<A, B>): Refinement<Array<A>, Array<B>>
+  <A>(predicate: Predicate<A>): Predicate<Array<A>>
+} = (predicate: any): any => RA.every(predicate)
 
 /**
  * `some` tells if the provided predicate holds true at least for one element in the `Array`.

--- a/src/ReadonlyArray.ts
+++ b/src/ReadonlyArray.ts
@@ -2455,7 +2455,11 @@ export const empty: ReadonlyArray<never> = RNEA.empty
  *
  * @since 2.9.0
  */
-export const every = <A>(predicate: Predicate<A>) => (as: ReadonlyArray<A>): boolean => as.every(predicate)
+export function every<A, B extends A>(refinement: Refinement<A, B>): Refinement<ReadonlyArray<A>, ReadonlyArray<B>>
+export function every<A>(predicate: Predicate<A>): Predicate<ReadonlyArray<A>>
+export function every<A>(predicate: Predicate<A>): Predicate<ReadonlyArray<A>> {
+  return (as) => as.every(predicate)
+}
 
 /**
  * Check if a predicate holds true for any array member.

--- a/src/ReadonlyRecord.ts
+++ b/src/ReadonlyRecord.ts
@@ -1093,7 +1093,11 @@ export function fromFoldableMap<F, B>(
  *
  * @since 2.5.0
  */
-export function every<A>(predicate: Predicate<A>): (r: ReadonlyRecord<string, A>) => boolean {
+export function every<A, B extends A>(
+  refinement: Refinement<A, B>
+): Refinement<ReadonlyRecord<string, A>, ReadonlyRecord<string, B>>
+export function every<A>(predicate: Predicate<A>): Predicate<ReadonlyRecord<string, A>>
+export function every<A>(predicate: Predicate<A>): Predicate<ReadonlyRecord<string, A>> {
   return (r) => {
     for (const k in r) {
       if (!predicate(r[k])) {

--- a/src/ReadonlySet.ts
+++ b/src/ReadonlySet.ts
@@ -468,7 +468,11 @@ export const some = <A>(predicate: Predicate<A>) => (set: ReadonlySet<A>): boole
 /**
  * @since 2.5.0
  */
-export const every = <A>(predicate: Predicate<A>): ((set: ReadonlySet<A>) => boolean) => not(some(not(predicate)))
+export function every<A, B extends A>(refinement: Refinement<A, B>): Refinement<ReadonlySet<A>, ReadonlySet<B>>
+export function every<A>(predicate: Predicate<A>): Predicate<ReadonlySet<A>>
+export function every<A>(predicate: Predicate<A>): Predicate<ReadonlySet<A>> {
+  return not(some(not(predicate)))
+}
 
 // TODO: remove non-curried overloading in v3
 /**

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -829,7 +829,10 @@ export function fromFoldableMap<F, B>(
  *
  * @since 2.0.0
  */
-export const every: <A>(predicate: Predicate<A>) => (r: Record<string, A>) => boolean = RR.every
+export const every: {
+  <A, B extends A>(refinement: Refinement<A, B>): Refinement<Record<string, A>, Record<string, B>>
+  <A>(predicate: Predicate<A>): Predicate<Record<string, A>>
+} = (predicate: any) => RR.every(predicate)
 
 /**
  * Test if at least one value in a `Record` satisfies the predicate.

--- a/src/Set.ts
+++ b/src/Set.ts
@@ -455,7 +455,10 @@ export const some: <A>(predicate: Predicate<A>) => (set: Set<A>) => boolean = RS
 /**
  * @since 2.0.0
  */
-export const every: <A>(predicate: Predicate<A>) => (set: Set<A>) => boolean = RS.every
+export const every: {
+  <A, B extends A>(refinement: Refinement<A, B>): Refinement<Set<A>, Set<B>>
+  <A>(predicate: Predicate<A>): Predicate<Set<A>>
+} = (predicate: any): any => RS.every(predicate)
 
 /**
  * @since 2.10.0


### PR DESCRIPTION
I have added `Refinement` overloads to the `every` function of `ReadonlyArray`,  `ReadonlyRecord`, `ReadonlySet` and their mutable counterparts.

Example

```ts
import { every } from 'fp-ts/ReadonlyArray'
import { isNumber } from 'fp-ts/number'

declare const as: ReadonlyArray<string | number>
every(isNumber)(as) // ReadonlyArray<number>
```
