### PR TITLE
Make JsonRecord type safe

### DIFF
--- a/docs/modules/Json.ts.md
+++ b/docs/modules/Json.ts.md
@@ -49,7 +49,7 @@ Added in v2.10.0
 
 ```ts
 export interface JsonRecord {
-  readonly [key: string]: Json
+  readonly [key: string]: Json | undefined
 }
 ```
 

--- a/dtslint/ts3.5/Json.ts
+++ b/dtslint/ts3.5/Json.ts
@@ -2,6 +2,15 @@ import * as E from '../../src/Either'
 import { pipe } from '../../src/function'
 import * as _ from '../../src/Json'
 
+declare const jr: _.JsonRecord
+
+//
+// JsonRecord
+//
+
+// $ExpectType string | number | boolean | JsonRecord | JsonArray | null | undefined
+jr.foo
+
 //
 // stringify
 //
@@ -12,10 +21,6 @@ _.stringify<_.Json>(undefined)
 _.stringify<_.Json>(() => {})
 // $ExpectError
 _.stringify<_.Json>(Symbol())
-// $ExpectError
-_.stringify<_.Json>({ a: undefined })
-// $ExpectError
-_.stringify<_.Json>({ ...{ a: undefined } })
 
 // tslint:disable-next-line: interface-over-type-literal
 interface AB {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2350,7 +2350,7 @@
       }
     },
     "dtslint": {
-      "version": "github:gcanti/dtslint#2c3c3487e7650d6ca90c2877dbbd7c4c08360d0d",
+      "version": "github:gcanti/dtslint#ef28f0ad1d3bd64b8367f6f543cf6fd3b9b09c1b",
       "from": "github:gcanti/dtslint",
       "dev": true,
       "requires": {

--- a/src/Json.ts
+++ b/src/Json.ts
@@ -13,7 +13,7 @@ export type Json = boolean | number | string | null | JsonArray | JsonRecord
  * @since 2.10.0
  */
 export interface JsonRecord {
-  readonly [key: string]: Json
+  readonly [key: string]: Json | undefined
 }
 
 /**

--- a/test/Json.ts
+++ b/test/Json.ts
@@ -11,6 +11,7 @@ describe('Json', () => {
 
   it('stringify', () => {
     U.deepStrictEqual(pipe({ a: 1 }, _.stringify), E.right('{"a":1}'))
+    U.deepStrictEqual(pipe({ a: undefined }, _.stringify), E.right('{}'))
     const circular: any = { ref: null }
     circular.ref = circular
     U.deepStrictEqual(


### PR DESCRIPTION
The `JsonRecord`'s type currently allows you to access _any_ string key, but [this isn't type safe](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbzgKwM4QHZwIargKTgF84AzKCEOAclLAFoZVqAoFgY01XigFNOoAEwBcBAHT50GAEr9oguAF5ELODlHVs1ADQsibThm5wwFML1gBPAIKj8EqUrh8BgsdjgB6T3BgALYDxAsmAMXhweAFcMGFBeDi54UwhzKwAhOwdMJxd5MQAjLx9-YOCMCBgxKpYgA). Looking at the commit history the type came from https://github.com/Microsoft/TypeScript/issues/1897#issuecomment-338650717, and does seem to have been copied over to many other libraries.

This PR changes the values of a `JsonRecord` to also possibly be `undefined`, covering the fact that the key might not be set.

This does mean that it's possible to set keys as `undefined`, even though this type doesn't exist in JSON (`stringify` will throw these keys away). This actually fixes my problem in https://github.com/gcanti/io-ts/pull/628#issuecomment-1084597642 (which was complicated to try and get round in https://github.com/gcanti/io-ts/pull/639).