### PR TITLE
fix(ReadonlyRecord): `traverse` clones objects in place instead of referencing and assigning to them.

### DIFF
--- a/src/ReadonlyRecord.ts
+++ b/src/ReadonlyRecord.ts
@@ -1430,10 +1430,7 @@ const _traverseWithIndex = (O: Ord<string>) => <F>(
     let fr: HKT<F, Record<string, B>> = F.of({})
     for (const key of ks) {
       fr = F.ap(
-        F.map(fr, (r) => (b: B) => {
-          r[key] = b
-          return r
-        }),
+        F.map(fr, (r) => (b: B) => Object.assign({}, r, { [key]: b })),
         f(key, ta[key])
       )
     }

--- a/test/ReadonlyRecord.ts
+++ b/test/ReadonlyRecord.ts
@@ -289,27 +289,30 @@ describe('ReadonlyRecord', () => {
       )
     })
 
-    it('traverseWithIndex', () => {
-      const f = (k: string, n: number): O.Option<number> => (k !== 'a' ? O.some(n) : O.none)
-      const traverseWithIndex = _.traverseWithIndex(O.Applicative)(f)
-      U.deepStrictEqual(pipe({ a: 1, b: 2 }, traverseWithIndex), O.none)
-      U.deepStrictEqual(pipe({ b: 2 }, traverseWithIndex), O.some({ b: 2 }))
+    describe('traverseWithIndex', () => {
+      it('simple Traversal', () => {
+        const f = (k: string, n: number): O.Option<number> => (k !== 'a' ? O.some(n) : O.none)
+        const traverseWithIndex = _.traverseWithIndex(O.Applicative)(f)
+        U.deepStrictEqual(pipe({ a: 1, b: 2 }, traverseWithIndex), O.none)
+        U.deepStrictEqual(pipe({ b: 2 }, traverseWithIndex), O.some({ b: 2 }))
+      })
 
-      U.deepStrictEqual(
-        pipe(
+      it('should not modify arrays in place', () => {
+        const result = pipe(
           { a: 2, b: 3 },
           _.fromRecord,
           _.traverseWithIndex(RA.Applicative)((_, n) => RA.makeBy(n, (i) => i * 4))
-        ),
-        [
+        )
+
+        U.deepStrictEqual(result, [
           { a: 0, b: 0 },
           { a: 0, b: 4 },
           { a: 0, b: 8 },
           { a: 4, b: 0 },
           { a: 4, b: 4 },
           { a: 4, b: 8 }
-        ]
-      )
+        ])
+      })
     })
 
     it('getTraversableWithIndex', () => {

--- a/test/ReadonlyRecord.ts
+++ b/test/ReadonlyRecord.ts
@@ -294,6 +294,22 @@ describe('ReadonlyRecord', () => {
       const traverseWithIndex = _.traverseWithIndex(O.Applicative)(f)
       U.deepStrictEqual(pipe({ a: 1, b: 2 }, traverseWithIndex), O.none)
       U.deepStrictEqual(pipe({ b: 2 }, traverseWithIndex), O.some({ b: 2 }))
+
+      U.deepStrictEqual(
+        pipe(
+          { a: 2, b: 3 },
+          _.fromRecord,
+          _.traverseWithIndex(RA.Applicative)((_, n) => RA.makeBy(n, (i) => i * 4))
+        ),
+        [
+          { a: 0, b: 0 },
+          { a: 0, b: 4 },
+          { a: 0, b: 8 },
+          { a: 4, b: 0 },
+          { a: 4, b: 4 },
+          { a: 4, b: 8 }
+        ]
+      )
     })
 
     it('getTraversableWithIndex', () => {


### PR DESCRIPTION
closes #1703 