### PR TITLE
IOOption: add description

### DIFF
--- a/docs/modules/IO.ts.md
+++ b/docs/modules/IO.ts.md
@@ -13,8 +13,10 @@ interface IO<A> {
 ```
 
 `IO<A>` represents a non-deterministic synchronous computation that can cause side effects, yields a value of
-type `A` and **never fails**. If you want to represent a synchronous computation that may fail, please see
-`IOEither`.
+type `A` and **never fails**.
+
+If you want to represent a synchronous computation that may fail, please see `IOEither`.
+If you want to represent a synchronous computation that may yield nothing, please see `IOOption`.
 
 Added in v2.0.0
 

--- a/docs/modules/IOEither.ts.md
+++ b/docs/modules/IOEither.ts.md
@@ -7,7 +7,10 @@ parent: Modules
 ## IOEither overview
 
 `IOEither<E, A>` represents a synchronous computation that either yields a value of type `A` or fails yielding an
-error of type `E`. If you want to represent a synchronous computation that never fails, please see `IO`.
+error of type `E`.
+
+If you want to represent a synchronous computation that never fails, please see `IO`.
+If you want to represent a synchronous computation that may yield nothing, please see `IOOption`.
 
 Added in v2.0.0
 

--- a/docs/modules/IOOption.ts.md
+++ b/docs/modules/IOOption.ts.md
@@ -6,6 +6,11 @@ parent: Modules
 
 ## IOOption overview
 
+`IOOption<A>` represents a synchronous computation that either yields a value of type `A` or nothing.
+
+If you want to represent a synchronous computation that never fails, please see `IO`.
+If you want to represent a synchronous computation that may fail, please see `IOEither`.
+
 Added in v2.12.0
 
 ---

--- a/src/IO.ts
+++ b/src/IO.ts
@@ -6,8 +6,10 @@
  * ```
  *
  * `IO<A>` represents a non-deterministic synchronous computation that can cause side effects, yields a value of
- * type `A` and **never fails**. If you want to represent a synchronous computation that may fail, please see
- * `IOEither`.
+ * type `A` and **never fails**.
+ *
+ * If you want to represent a synchronous computation that may fail, please see `IOEither`.
+ * If you want to represent a synchronous computation that may yield nothing, please see `IOOption`.
  *
  * @since 2.0.0
  */

--- a/src/IOEither.ts
+++ b/src/IOEither.ts
@@ -1,6 +1,9 @@
 /**
  * `IOEither<E, A>` represents a synchronous computation that either yields a value of type `A` or fails yielding an
- * error of type `E`. If you want to represent a synchronous computation that never fails, please see `IO`.
+ * error of type `E`.
+ *
+ * If you want to represent a synchronous computation that never fails, please see `IO`.
+ * If you want to represent a synchronous computation that may yield nothing, please see `IOOption`.
  *
  * @since 2.0.0
  */

--- a/src/IOOption.ts
+++ b/src/IOOption.ts
@@ -1,4 +1,9 @@
 /**
+ * `IOOption<A>` represents a synchronous computation that either yields a value of type `A` or nothing.
+ *
+ * If you want to represent a synchronous computation that never fails, please see `IO`.
+ * If you want to represent a synchronous computation that may fail, please see `IOEither`.
+ *
  * @since 2.12.0
  */
 import { Alt1 } from './Alt'


### PR DESCRIPTION
Adds description to IOOption and references to IOOption to IO & IOEither.

The references are a repeated sentence for ease of understanding/searching, but I will happily re-write or re-format to lose repetition if preferred.