### PR TITLE
Alternative: add getAlternativeMonoid

### DIFF
--- a/docs/modules/Alternative.ts.md
+++ b/docs/modules/Alternative.ts.md
@@ -35,6 +35,7 @@ Added in v2.0.0
   - [Alternative4 (interface)](#alternative4-interface)
 - [utils](#utils)
   - [altAll](#altall)
+  - [getAlternativeMonoid](#getalternativemonoid)
 
 ---
 
@@ -137,3 +138,33 @@ export declare function altAll<F>(F: Alternative<F>): <A>(as: ReadonlyArray<HKT<
 ```
 
 Added in v2.11.0
+
+## getAlternativeMonoid
+
+Lift a semigroup into a monoid alternative 'F', the inner values are concatenated using the provided `Semigroup`.
+
+**Signature**
+
+```ts
+export declare function getAlternativeMonoid<F extends URIS4>(
+  F: Alternative4<F>
+): <A, S, R, E>(S: Semigroup<A>) => Monoid<Kind4<F, S, R, E, A>>
+export declare function getAlternativeMonoid<F extends URIS3>(
+  F: Alternative3<F>
+): <A, R, E>(S: Semigroup<A>) => Monoid<Kind3<F, R, E, A>>
+export declare function getAlternativeMonoid<F extends URIS3, E>(
+  F: Alternative3C<F, E>
+): <A, R>(S: Semigroup<A>) => Monoid<Kind3<F, R, E, A>>
+export declare function getAlternativeMonoid<F extends URIS2>(
+  F: Alternative2<F>
+): <A, E>(S: Semigroup<A>) => Monoid<Kind2<F, E, A>>
+export declare function getAlternativeMonoid<F extends URIS2, E>(
+  F: Alternative2C<F, E>
+): <A>(S: Semigroup<A>) => Monoid<Kind2<F, E, A>>
+export declare function getAlternativeMonoid<F extends URIS>(
+  F: Alternative1<F>
+): <A>(S: Semigroup<A>) => Monoid<Kind<F, A>>
+export declare function getAlternativeMonoid<F>(F: Alternative<F>): <A>(S: Semigroup<A>) => Monoid<HKT<F, A>>
+```
+
+Added in v2.13.0

--- a/test/Alternative.ts
+++ b/test/Alternative.ts
@@ -1,5 +1,8 @@
 import * as _ from '../src/Alternative'
+import * as M from '../src/Monoid'
+import * as NEA from '../src/NonEmptyArray'
 import * as O from '../src/Option'
+import * as S from '../src/Semigroup'
 import * as U from './util'
 
 describe('Alternative', () => {
@@ -8,5 +11,22 @@ describe('Alternative', () => {
     U.deepStrictEqual(altAll([]), O.none)
     U.deepStrictEqual(altAll([O.none]), O.none)
     U.deepStrictEqual(altAll([O.none, O.some(1)]), O.some(1))
+  })
+
+  it('getAlternativeMonoid', () => {
+    const altConcatAll = M.concatAll(_.getAlternativeMonoid(O.Alternative)(NEA.getSemigroup<number>()))
+    U.deepStrictEqual(altConcatAll([]), O.none)
+    U.deepStrictEqual(altConcatAll([O.none]), O.none)
+    U.deepStrictEqual(altConcatAll([O.none, O.some([1]), O.some([2])]), O.some([1, 2]))
+
+    const pickFirst = _.getAlternativeMonoid(O.Alternative)(S.first<string>())
+    U.deepStrictEqual(pickFirst.concat(O.some('a'), O.some('b')), O.some('a'))
+    U.deepStrictEqual(pickFirst.concat(O.none, O.some('b')), O.some('b'))
+    U.deepStrictEqual(pickFirst.concat(O.some('a'), O.none), O.some('a'))
+
+    const pickLast = _.getAlternativeMonoid(O.Alternative)(S.last<string>())
+    U.deepStrictEqual(pickLast.concat(O.some('a'), O.some('b')), O.some('b'))
+    U.deepStrictEqual(pickLast.concat(O.none, O.some('b')), O.some('b'))
+    U.deepStrictEqual(pickLast.concat(O.some('a'), O.none), O.some('a'))
   })
 })


### PR DESCRIPTION
This provides a way to lift a semigroup into a monoid via an alternative...
think of it like a generalised version of `Option`'s `getMonoid`, except it applies to any `Alternative`.

It also means any module without a specialised `getMonoid` function like `TaskOption` and `IOOption` also have a way to produce an amalgamation.

Hopefully this is useful and not a duplication of functionality.
Alternatively, should all Alternative-capable modules expose a `getMonoid` function?

I did debate adding a way to get an Alternative Semigroup from a Semigroup (and Alternative Monoid from a Monoid) but I realised this had the biggest bang for buck in utilising the capabilities of the underlying Alternative.
I am pretty sure the order of `() => F.alt(first, () => second))` is irrelevant given it's a Semigroup.

(If the tests are redundant I'd be happy to rewrite them as showing identical behaviour to `Option`'s `getMonoid` function.)

