### PR TITLE
Functor: add `bindMap` function as a do-notation helper

### DIFF
--- a/docs/modules/Array.ts.md
+++ b/docs/modules/Array.ts.md
@@ -188,6 +188,7 @@ Added in v2.0.0
   - [Spanned (interface)](#spanned-interface)
   - [apS](#aps)
   - [bind](#bind)
+  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [deleteAt](#deleteat)
   - [elem](#elem)
@@ -3287,6 +3288,19 @@ export declare const bind: <N, A, B>(
 ```
 
 Added in v2.8.0
+
+## bindMap
+
+**Signature**
+
+```ts
+export declare const bindMap: <N, A, B>(
+  name: N,
+  f: (a: A) => B
+) => (fa: A[]) => { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }[]
+```
+
+Added in v2.13.0
 
 ## bindTo
 

--- a/docs/modules/Array.ts.md
+++ b/docs/modules/Array.ts.md
@@ -188,7 +188,6 @@ Added in v2.0.0
   - [Spanned (interface)](#spanned-interface)
   - [apS](#aps)
   - [bind](#bind)
-  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [deleteAt](#deleteat)
   - [elem](#elem)
@@ -200,6 +199,7 @@ Added in v2.0.0
   - [insertAt](#insertat)
   - [intercalate](#intercalate)
   - [isOutOfBound](#isoutofbound)
+  - [let](#let)
   - [lookup](#lookup)
   - [modifyAt](#modifyat)
   - [size](#size)
@@ -3289,19 +3289,6 @@ export declare const bind: <N, A, B>(
 
 Added in v2.8.0
 
-## bindMap
-
-**Signature**
-
-```ts
-export declare const bindMap: <N, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => (fa: A[]) => { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }[]
-```
-
-Added in v2.13.0
-
 ## bindTo
 
 **Signature**
@@ -3526,6 +3513,19 @@ assert.strictEqual(isOutOfBound(3, ['a', 'b', 'c']), true)
 ```
 
 Added in v2.0.0
+
+## let
+
+**Signature**
+
+```ts
+export declare const let: <N, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => (fa: A[]) => { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }[]
+```
+
+Added in v2.13.0
 
 ## lookup
 

--- a/docs/modules/Array.ts.md
+++ b/docs/modules/Array.ts.md
@@ -3295,7 +3295,7 @@ Added in v2.8.0
 
 ```ts
 export declare const bindMap: <N, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => (fa: A[]) => { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }[]
 ```

--- a/docs/modules/Either.ts.md
+++ b/docs/modules/Either.ts.md
@@ -1742,7 +1742,7 @@ Added in v2.8.0
 
 ```ts
 export declare const bindMap: <N, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => <E>(fa: Either<E, A>) => Either<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
 ```

--- a/docs/modules/Either.ts.md
+++ b/docs/modules/Either.ts.md
@@ -175,11 +175,11 @@ Added in v2.0.0
   - [apS](#aps)
   - [apSW](#apsw)
   - [bind](#bind)
-  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [bindW](#bindw)
   - [elem](#elem)
   - [exists](#exists)
+  - [let](#let)
   - [sequenceArray](#sequencearray)
   - [toError](#toerror)
   - [traverseArray](#traversearray)
@@ -1736,19 +1736,6 @@ export declare const bind: <N, A, E, B>(
 
 Added in v2.8.0
 
-## bindMap
-
-**Signature**
-
-```ts
-export declare const bindMap: <N, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => <E>(fa: Either<E, A>) => Either<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-```
-
-Added in v2.13.0
-
 ## bindTo
 
 **Signature**
@@ -1812,6 +1799,19 @@ assert.strictEqual(gt2(right(3)), true)
 ```
 
 Added in v2.0.0
+
+## let
+
+**Signature**
+
+```ts
+export declare const let: <N, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => <E>(fa: Either<E, A>) => Either<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## sequenceArray
 

--- a/docs/modules/Either.ts.md
+++ b/docs/modules/Either.ts.md
@@ -175,6 +175,7 @@ Added in v2.0.0
   - [apS](#aps)
   - [apSW](#apsw)
   - [bind](#bind)
+  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [bindW](#bindw)
   - [elem](#elem)
@@ -1734,6 +1735,19 @@ export declare const bind: <N, A, E, B>(
 ```
 
 Added in v2.8.0
+
+## bindMap
+
+**Signature**
+
+```ts
+export declare const bindMap: <N, A, B>(
+  name: N,
+  f: (a: A) => B
+) => <E>(fa: Either<E, A>) => Either<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## bindTo
 

--- a/docs/modules/Functor.ts.md
+++ b/docs/modules/Functor.ts.md
@@ -34,6 +34,7 @@ Added in v2.0.0
   - [Functor3C (interface)](#functor3c-interface)
   - [Functor4 (interface)](#functor4-interface)
 - [utils](#utils)
+  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [~~FunctorComposition11~~ (interface)](#functorcomposition11-interface)
   - [~~FunctorComposition12C~~ (interface)](#functorcomposition12c-interface)
@@ -217,6 +218,59 @@ export interface Functor4<F extends URIS4> {
 Added in v2.0.0
 
 # utils
+
+## bindMap
+
+**Signature**
+
+```ts
+export declare function bindMap<F extends URIS4>(
+  F: Functor4<F>
+): <N extends string, A, B>(
+  name: N,
+  f: (a: A) => B
+) => <S, R, E>(
+  fa: Kind4<F, S, R, E, A>
+) => Kind4<F, S, R, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+export declare function bindMap<F extends URIS3>(
+  F: Functor3<F>
+): <N extends string, A, B>(
+  name: N,
+  f: (a: A) => B
+) => <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+export declare function bindMap<F extends URIS3, E>(
+  F: Functor3C<F, E>
+): <N extends string, A, B>(
+  name: N,
+  f: (a: A) => B
+) => <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+export declare function bindMap<F extends URIS2>(
+  F: Functor2<F>
+): <N extends string, A, B>(
+  name: N,
+  f: (a: A) => B
+) => <E>(fa: Kind2<F, E, A>) => Kind2<F, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+export declare function bindMap<F extends URIS2, E>(
+  F: Functor2C<F, E>
+): <N extends string, A, B>(
+  name: N,
+  f: (a: A) => B
+) => (fa: Kind2<F, E, A>) => Kind2<F, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+export declare function bindMap<F extends URIS>(
+  F: Functor1<F>
+): <N extends string, A, B>(
+  name: N,
+  f: (a: A) => B
+) => (fa: Kind<F, A>) => Kind<F, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+export declare function bindMap<F>(
+  F: Functor<F>
+): <N extends string, A, B>(
+  name: N,
+  f: (a: A) => B
+) => (fa: HKT<F, A>) => HKT<F, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## bindTo
 

--- a/docs/modules/Functor.ts.md
+++ b/docs/modules/Functor.ts.md
@@ -34,8 +34,9 @@ Added in v2.0.0
   - [Functor3C (interface)](#functor3c-interface)
   - [Functor4 (interface)](#functor4-interface)
 - [utils](#utils)
-  - [bindMap](#bindmap)
   - [bindTo](#bindto)
+  - [let](#let)
+  - [let\_](#let_)
   - [~~FunctorComposition11~~ (interface)](#functorcomposition11-interface)
   - [~~FunctorComposition12C~~ (interface)](#functorcomposition12c-interface)
   - [~~FunctorComposition12~~ (interface)](#functorcomposition12-interface)
@@ -219,59 +220,6 @@ Added in v2.0.0
 
 # utils
 
-## bindMap
-
-**Signature**
-
-```ts
-export declare function bindMap<F extends URIS4>(
-  F: Functor4<F>
-): <N extends string, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => <S, R, E>(
-  fa: Kind4<F, S, R, E, A>
-) => Kind4<F, S, R, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
-export declare function bindMap<F extends URIS3>(
-  F: Functor3<F>
-): <N extends string, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
-export declare function bindMap<F extends URIS3, E>(
-  F: Functor3C<F, E>
-): <N extends string, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
-export declare function bindMap<F extends URIS2>(
-  F: Functor2<F>
-): <N extends string, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => <E>(fa: Kind2<F, E, A>) => Kind2<F, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
-export declare function bindMap<F extends URIS2, E>(
-  F: Functor2C<F, E>
-): <N extends string, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => (fa: Kind2<F, E, A>) => Kind2<F, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
-export declare function bindMap<F extends URIS>(
-  F: Functor1<F>
-): <N extends string, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => (fa: Kind<F, A>) => Kind<F, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
-export declare function bindMap<F>(
-  F: Functor<F>
-): <N extends string, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => (fa: HKT<F, A>) => HKT<F, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
-```
-
-Added in v2.13.0
-
 ## bindTo
 
 **Signature**
@@ -301,6 +249,69 @@ export declare function bindTo<F>(
 ```
 
 Added in v2.10.0
+
+## let
+
+**Signature**
+
+```ts
+export declare const let: typeof let_
+```
+
+Added in v2.13.0
+
+## let\_
+
+**Signature**
+
+```ts
+function let_<F extends URIS4>(
+  F: Functor4<F>
+): <N extends string, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => <S, R, E>(
+  fa: Kind4<F, S, R, E, A>
+) => Kind4<F, S, R, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+function let_<F extends URIS3>(
+  F: Functor3<F>
+): <N extends string, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+function let_<F extends URIS3, E>(
+  F: Functor3C<F, E>
+): <N extends string, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+function let_<F extends URIS2>(
+  F: Functor2<F>
+): <N extends string, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => <E>(fa: Kind2<F, E, A>) => Kind2<F, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+function let_<F extends URIS2, E>(
+  F: Functor2C<F, E>
+): <N extends string, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => (fa: Kind2<F, E, A>) => Kind2<F, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+function let_<F extends URIS>(
+  F: Functor1<F>
+): <N extends string, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => (fa: Kind<F, A>) => Kind<F, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+function let_<F>(
+  F: Functor<F>
+): <N extends string, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => (fa: HKT<F, A>) => HKT<F, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## ~~FunctorComposition11~~ (interface)
 

--- a/docs/modules/Functor.ts.md
+++ b/docs/modules/Functor.ts.md
@@ -227,7 +227,7 @@ Added in v2.0.0
 export declare function bindMap<F extends URIS4>(
   F: Functor4<F>
 ): <N extends string, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => <S, R, E>(
   fa: Kind4<F, S, R, E, A>
@@ -235,37 +235,37 @@ export declare function bindMap<F extends URIS4>(
 export declare function bindMap<F extends URIS3>(
   F: Functor3<F>
 ): <N extends string, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
 export declare function bindMap<F extends URIS3, E>(
   F: Functor3C<F, E>
 ): <N extends string, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
 export declare function bindMap<F extends URIS2>(
   F: Functor2<F>
 ): <N extends string, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => <E>(fa: Kind2<F, E, A>) => Kind2<F, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
 export declare function bindMap<F extends URIS2, E>(
   F: Functor2C<F, E>
 ): <N extends string, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => (fa: Kind2<F, E, A>) => Kind2<F, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
 export declare function bindMap<F extends URIS>(
   F: Functor1<F>
 ): <N extends string, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => (fa: Kind<F, A>) => Kind<F, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
 export declare function bindMap<F>(
   F: Functor<F>
 ): <N extends string, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => (fa: HKT<F, A>) => HKT<F, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
 ```

--- a/docs/modules/IO.ts.md
+++ b/docs/modules/IO.ts.md
@@ -426,7 +426,7 @@ Added in v2.8.0
 
 ```ts
 export declare const bindMap: <N, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => (fa: IO<A>) => IO<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
 ```

--- a/docs/modules/IO.ts.md
+++ b/docs/modules/IO.ts.md
@@ -62,8 +62,8 @@ Added in v2.0.0
   - [Do](#do)
   - [apS](#aps)
   - [bind](#bind)
-  - [bindMap](#bindmap)
   - [bindTo](#bindto)
+  - [let](#let)
   - [sequenceArray](#sequencearray)
   - [traverseArray](#traversearray)
   - [traverseArrayWithIndex](#traversearraywithindex)
@@ -420,19 +420,6 @@ export declare const bind: <N, A, B>(
 
 Added in v2.8.0
 
-## bindMap
-
-**Signature**
-
-```ts
-export declare const bindMap: <N, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => (fa: IO<A>) => IO<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-```
-
-Added in v2.13.0
-
 ## bindTo
 
 **Signature**
@@ -442,6 +429,19 @@ export declare const bindTo: <N>(name: N) => <A>(fa: IO<A>) => IO<{ readonly [K 
 ```
 
 Added in v2.8.0
+
+## let
+
+**Signature**
+
+```ts
+export declare const let: <N, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => (fa: IO<A>) => IO<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## sequenceArray
 

--- a/docs/modules/IO.ts.md
+++ b/docs/modules/IO.ts.md
@@ -62,6 +62,7 @@ Added in v2.0.0
   - [Do](#do)
   - [apS](#aps)
   - [bind](#bind)
+  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [sequenceArray](#sequencearray)
   - [traverseArray](#traversearray)
@@ -418,6 +419,19 @@ export declare const bind: <N, A, B>(
 ```
 
 Added in v2.8.0
+
+## bindMap
+
+**Signature**
+
+```ts
+export declare const bindMap: <N, A, B>(
+  name: N,
+  f: (a: A) => B
+) => (fa: IO<A>) => IO<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## bindTo
 

--- a/docs/modules/IOEither.ts.md
+++ b/docs/modules/IOEither.ts.md
@@ -122,11 +122,11 @@ Added in v2.0.0
   - [apS](#aps)
   - [apSW](#apsw)
   - [bind](#bind)
-  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [bindW](#bindw)
   - [bracket](#bracket)
   - [bracketW](#bracketw)
+  - [let](#let)
   - [sequenceArray](#sequencearray)
   - [sequenceSeqArray](#sequenceseqarray)
   - [traverseArray](#traversearray)
@@ -1268,19 +1268,6 @@ export declare const bind: <N, A, E, B>(
 
 Added in v2.8.0
 
-## bindMap
-
-**Signature**
-
-```ts
-export declare const bindMap: <N, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => <E>(fa: IOEither<E, A>) => IOEither<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-```
-
-Added in v2.8.0
-
 ## bindTo
 
 **Signature**
@@ -1342,6 +1329,19 @@ export declare const bracketW: <E1, A, E2, B, E3>(
 ```
 
 Added in v2.12.0
+
+## let
+
+**Signature**
+
+```ts
+export declare const let: <N, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => <E>(fa: IOEither<E, A>) => IOEither<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## sequenceArray
 

--- a/docs/modules/IOEither.ts.md
+++ b/docs/modules/IOEither.ts.md
@@ -122,6 +122,7 @@ Added in v2.0.0
   - [apS](#aps)
   - [apSW](#apsw)
   - [bind](#bind)
+  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [bindW](#bindw)
   - [bracket](#bracket)
@@ -1263,6 +1264,19 @@ export declare const bind: <N, A, E, B>(
   name: Exclude<N, keyof A>,
   f: <A2>(a: A | A2) => IOEither<E, B>
 ) => (ma: IOEither<E, A>) => IOEither<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.8.0
+
+## bindMap
+
+**Signature**
+
+```ts
+export declare const bindMap: <N, A, B>(
+  name: N,
+  f: (a: A) => B
+) => <E>(fa: IOEither<E, A>) => IOEither<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
 ```
 
 Added in v2.8.0

--- a/docs/modules/IOEither.ts.md
+++ b/docs/modules/IOEither.ts.md
@@ -1274,7 +1274,7 @@ Added in v2.8.0
 
 ```ts
 export declare const bindMap: <N, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => <E>(fa: IOEither<E, A>) => IOEither<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
 ```

--- a/docs/modules/IOOption.ts.md
+++ b/docs/modules/IOOption.ts.md
@@ -99,6 +99,7 @@ Added in v2.12.0
   - [Do](#do)
   - [apS](#aps)
   - [bind](#bind)
+  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [traverseReadonlyArrayWithIndex](#traversereadonlyarraywithindex)
   - [traverseReadonlyNonEmptyArrayWithIndex](#traversereadonlynonemptyarraywithindex)
@@ -865,6 +866,19 @@ export declare const bind: <N, A, B>(
 ```
 
 Added in v2.12.0
+
+## bindMap
+
+**Signature**
+
+```ts
+export declare const bindMap: <N, A, B>(
+  name: N,
+  f: (a: A) => B
+) => (fa: IOOption<A>) => IOOption<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## bindTo
 

--- a/docs/modules/IOOption.ts.md
+++ b/docs/modules/IOOption.ts.md
@@ -873,7 +873,7 @@ Added in v2.12.0
 
 ```ts
 export declare const bindMap: <N, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => (fa: IOOption<A>) => IOOption<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
 ```

--- a/docs/modules/IOOption.ts.md
+++ b/docs/modules/IOOption.ts.md
@@ -99,8 +99,8 @@ Added in v2.12.0
   - [Do](#do)
   - [apS](#aps)
   - [bind](#bind)
-  - [bindMap](#bindmap)
   - [bindTo](#bindto)
+  - [let](#let)
   - [traverseReadonlyArrayWithIndex](#traversereadonlyarraywithindex)
   - [traverseReadonlyNonEmptyArrayWithIndex](#traversereadonlynonemptyarraywithindex)
 
@@ -867,19 +867,6 @@ export declare const bind: <N, A, B>(
 
 Added in v2.12.0
 
-## bindMap
-
-**Signature**
-
-```ts
-export declare const bindMap: <N, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => (fa: IOOption<A>) => IOOption<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-```
-
-Added in v2.13.0
-
 ## bindTo
 
 **Signature**
@@ -889,6 +876,19 @@ export declare const bindTo: <N>(name: N) => <A>(fa: IOOption<A>) => IOOption<{ 
 ```
 
 Added in v2.12.0
+
+## let
+
+**Signature**
+
+```ts
+export declare const let: <N, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => (fa: IOOption<A>) => IOOption<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## traverseReadonlyArrayWithIndex
 

--- a/docs/modules/Identity.ts.md
+++ b/docs/modules/Identity.ts.md
@@ -516,7 +516,7 @@ Added in v2.8.0
 
 ```ts
 export declare const bindMap: <N, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => (fa: A) => { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }
 ```

--- a/docs/modules/Identity.ts.md
+++ b/docs/modules/Identity.ts.md
@@ -61,6 +61,7 @@ Added in v2.0.0
   - [Do](#do)
   - [apS](#aps)
   - [bind](#bind)
+  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [sequence](#sequence)
   - [traverse](#traverse)
@@ -508,6 +509,19 @@ export declare const bind: <N, A, B>(
 ```
 
 Added in v2.8.0
+
+## bindMap
+
+**Signature**
+
+```ts
+export declare const bindMap: <N, A, B>(
+  name: N,
+  f: (a: A) => B
+) => (fa: A) => { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }
+```
+
+Added in v2.13.0
 
 ## bindTo
 

--- a/docs/modules/Identity.ts.md
+++ b/docs/modules/Identity.ts.md
@@ -61,8 +61,8 @@ Added in v2.0.0
   - [Do](#do)
   - [apS](#aps)
   - [bind](#bind)
-  - [bindMap](#bindmap)
   - [bindTo](#bindto)
+  - [let](#let)
   - [sequence](#sequence)
   - [traverse](#traverse)
 
@@ -510,19 +510,6 @@ export declare const bind: <N, A, B>(
 
 Added in v2.8.0
 
-## bindMap
-
-**Signature**
-
-```ts
-export declare const bindMap: <N, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => (fa: A) => { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }
-```
-
-Added in v2.13.0
-
 ## bindTo
 
 **Signature**
@@ -532,6 +519,19 @@ export declare const bindTo: <N>(name: N) => <A>(fa: A) => { readonly [K in N]: 
 ```
 
 Added in v2.8.0
+
+## let
+
+**Signature**
+
+```ts
+export declare const let: <N, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => (fa: A) => { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }
+```
+
+Added in v2.13.0
 
 ## sequence
 

--- a/docs/modules/NonEmptyArray.ts.md
+++ b/docs/modules/NonEmptyArray.ts.md
@@ -124,6 +124,7 @@ Added in v2.0.0
   - [Do](#do)
   - [apS](#aps)
   - [bind](#bind)
+  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [concatAll](#concatall)
   - [extract](#extract)
@@ -1370,6 +1371,19 @@ export declare const bind: <N, A, B>(
 ```
 
 Added in v2.8.0
+
+## bindMap
+
+**Signature**
+
+```ts
+export declare const bindMap: <N, A, B>(
+  name: N,
+  f: (a: A) => B
+) => (fa: NonEmptyArray<A>) => NonEmptyArray<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## bindTo
 

--- a/docs/modules/NonEmptyArray.ts.md
+++ b/docs/modules/NonEmptyArray.ts.md
@@ -1378,7 +1378,7 @@ Added in v2.8.0
 
 ```ts
 export declare const bindMap: <N, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => (fa: NonEmptyArray<A>) => NonEmptyArray<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
 ```

--- a/docs/modules/NonEmptyArray.ts.md
+++ b/docs/modules/NonEmptyArray.ts.md
@@ -124,7 +124,6 @@ Added in v2.0.0
   - [Do](#do)
   - [apS](#aps)
   - [bind](#bind)
-  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [concatAll](#concatall)
   - [extract](#extract)
@@ -132,6 +131,7 @@ Added in v2.0.0
   - [init](#init)
   - [intercalate](#intercalate)
   - [last](#last)
+  - [let](#let)
   - [max](#max)
   - [min](#min)
   - [modifyHead](#modifyhead)
@@ -1372,19 +1372,6 @@ export declare const bind: <N, A, B>(
 
 Added in v2.8.0
 
-## bindMap
-
-**Signature**
-
-```ts
-export declare const bindMap: <N, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => (fa: NonEmptyArray<A>) => NonEmptyArray<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-```
-
-Added in v2.13.0
-
 ## bindTo
 
 **Signature**
@@ -1476,6 +1463,19 @@ export declare const last: <A>(nea: NonEmptyArray<A>) => A
 ```
 
 Added in v2.0.0
+
+## let
+
+**Signature**
+
+```ts
+export declare const let: <N, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => (fa: NonEmptyArray<A>) => NonEmptyArray<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## max
 

--- a/docs/modules/Option.ts.md
+++ b/docs/modules/Option.ts.md
@@ -1592,7 +1592,7 @@ Added in v2.8.0
 
 ```ts
 export declare const bindMap: <N, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => (fa: Option<A>) => Option<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
 ```

--- a/docs/modules/Option.ts.md
+++ b/docs/modules/Option.ts.md
@@ -170,10 +170,10 @@ Added in v2.0.0
   - [Do](#do)
   - [apS](#aps)
   - [bind](#bind)
-  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [elem](#elem)
   - [exists](#exists)
+  - [let](#let)
   - [sequenceArray](#sequencearray)
   - [traverseArray](#traversearray)
   - [traverseArrayWithIndex](#traversearraywithindex)
@@ -1586,19 +1586,6 @@ export declare const bind: <N, A, B>(
 
 Added in v2.8.0
 
-## bindMap
-
-**Signature**
-
-```ts
-export declare const bindMap: <N, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => (fa: Option<A>) => Option<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-```
-
-Added in v2.13.0
-
 ## bindTo
 
 **Signature**
@@ -1678,6 +1665,19 @@ assert.strictEqual(
 ```
 
 Added in v2.0.0
+
+## let
+
+**Signature**
+
+```ts
+export declare const let: <N, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => (fa: Option<A>) => Option<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## sequenceArray
 

--- a/docs/modules/Option.ts.md
+++ b/docs/modules/Option.ts.md
@@ -170,6 +170,7 @@ Added in v2.0.0
   - [Do](#do)
   - [apS](#aps)
   - [bind](#bind)
+  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [elem](#elem)
   - [exists](#exists)
@@ -1584,6 +1585,19 @@ export declare const bind: <N, A, B>(
 ```
 
 Added in v2.8.0
+
+## bindMap
+
+**Signature**
+
+```ts
+export declare const bindMap: <N, A, B>(
+  name: N,
+  f: (a: A) => B
+) => (fa: Option<A>) => Option<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## bindTo
 

--- a/docs/modules/Reader.ts.md
+++ b/docs/modules/Reader.ts.md
@@ -114,6 +114,7 @@ Added in v2.0.0
   - [apS](#aps)
   - [apSW](#apsw)
   - [bind](#bind)
+  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [bindW](#bindw)
   - [sequenceArray](#sequencearray)
@@ -750,6 +751,19 @@ export declare const bind: <N, A, E, B>(
 ```
 
 Added in v2.8.0
+
+## bindMap
+
+**Signature**
+
+```ts
+export declare const bindMap: <N, A, B>(
+  name: N,
+  f: (a: A) => B
+) => <E>(fa: Reader<E, A>) => Reader<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## bindTo
 

--- a/docs/modules/Reader.ts.md
+++ b/docs/modules/Reader.ts.md
@@ -114,9 +114,9 @@ Added in v2.0.0
   - [apS](#aps)
   - [apSW](#apsw)
   - [bind](#bind)
-  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [bindW](#bindw)
+  - [let](#let)
   - [sequenceArray](#sequencearray)
   - [traverseArray](#traversearray)
   - [traverseArrayWithIndex](#traversearraywithindex)
@@ -752,19 +752,6 @@ export declare const bind: <N, A, E, B>(
 
 Added in v2.8.0
 
-## bindMap
-
-**Signature**
-
-```ts
-export declare const bindMap: <N, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => <E>(fa: Reader<E, A>) => Reader<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-```
-
-Added in v2.13.0
-
 ## bindTo
 
 **Signature**
@@ -789,6 +776,19 @@ export declare const bindW: <N extends string, A, R2, B>(
 ```
 
 Added in v2.8.0
+
+## let
+
+**Signature**
+
+```ts
+export declare const let: <N, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => <E>(fa: Reader<E, A>) => Reader<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## sequenceArray
 

--- a/docs/modules/Reader.ts.md
+++ b/docs/modules/Reader.ts.md
@@ -758,7 +758,7 @@ Added in v2.8.0
 
 ```ts
 export declare const bindMap: <N, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => <E>(fa: Reader<E, A>) => Reader<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
 ```

--- a/docs/modules/ReaderEither.ts.md
+++ b/docs/modules/ReaderEither.ts.md
@@ -1333,7 +1333,7 @@ Added in v2.8.0
 
 ```ts
 export declare const bindMap: <N, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => <R, E>(
   fa: ReaderEither<R, E, A>

--- a/docs/modules/ReaderEither.ts.md
+++ b/docs/modules/ReaderEither.ts.md
@@ -117,9 +117,9 @@ Added in v2.0.0
   - [apS](#aps)
   - [apSW](#apsw)
   - [bind](#bind)
-  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [bindW](#bindw)
+  - [let](#let)
   - [sequenceArray](#sequencearray)
   - [traverseArray](#traversearray)
   - [traverseArrayWithIndex](#traversearraywithindex)
@@ -1327,21 +1327,6 @@ export declare const bind: <N, A, R, E, B>(
 
 Added in v2.8.0
 
-## bindMap
-
-**Signature**
-
-```ts
-export declare const bindMap: <N, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => <R, E>(
-  fa: ReaderEither<R, E, A>
-) => ReaderEither<R, E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-```
-
-Added in v2.13.0
-
 ## bindTo
 
 **Signature**
@@ -1370,6 +1355,21 @@ export declare const bindW: <N extends string, A, R2, E2, B>(
 ```
 
 Added in v2.8.0
+
+## let
+
+**Signature**
+
+```ts
+export declare const let: <N, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => <R, E>(
+  fa: ReaderEither<R, E, A>
+) => ReaderEither<R, E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## sequenceArray
 

--- a/docs/modules/ReaderEither.ts.md
+++ b/docs/modules/ReaderEither.ts.md
@@ -117,6 +117,7 @@ Added in v2.0.0
   - [apS](#aps)
   - [apSW](#apsw)
   - [bind](#bind)
+  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [bindW](#bindw)
   - [sequenceArray](#sequencearray)
@@ -1325,6 +1326,21 @@ export declare const bind: <N, A, R, E, B>(
 ```
 
 Added in v2.8.0
+
+## bindMap
+
+**Signature**
+
+```ts
+export declare const bindMap: <N, A, B>(
+  name: N,
+  f: (a: A) => B
+) => <R, E>(
+  fa: ReaderEither<R, E, A>
+) => ReaderEither<R, E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## bindTo
 

--- a/docs/modules/ReaderTask.ts.md
+++ b/docs/modules/ReaderTask.ts.md
@@ -79,6 +79,7 @@ Added in v2.3.0
   - [apS](#aps)
   - [apSW](#apsw)
   - [bind](#bind)
+  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [bindW](#bindw)
   - [sequenceArray](#sequencearray)
@@ -796,6 +797,19 @@ export declare const bind: <N, A, E, B>(
 ```
 
 Added in v2.8.0
+
+## bindMap
+
+**Signature**
+
+```ts
+export declare const bindMap: <N, A, B>(
+  name: N,
+  f: (a: A) => B
+) => <E>(fa: ReaderTask<E, A>) => ReaderTask<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## bindTo
 

--- a/docs/modules/ReaderTask.ts.md
+++ b/docs/modules/ReaderTask.ts.md
@@ -79,9 +79,9 @@ Added in v2.3.0
   - [apS](#aps)
   - [apSW](#apsw)
   - [bind](#bind)
-  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [bindW](#bindw)
+  - [let](#let)
   - [sequenceArray](#sequencearray)
   - [traverseArray](#traversearray)
   - [traverseArrayWithIndex](#traversearraywithindex)
@@ -798,19 +798,6 @@ export declare const bind: <N, A, E, B>(
 
 Added in v2.8.0
 
-## bindMap
-
-**Signature**
-
-```ts
-export declare const bindMap: <N, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => <E>(fa: ReaderTask<E, A>) => ReaderTask<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-```
-
-Added in v2.13.0
-
 ## bindTo
 
 **Signature**
@@ -835,6 +822,19 @@ export declare const bindW: <N extends string, A, R2, B>(
 ```
 
 Added in v2.8.0
+
+## let
+
+**Signature**
+
+```ts
+export declare const let: <N, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => <E>(fa: ReaderTask<E, A>) => ReaderTask<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## sequenceArray
 

--- a/docs/modules/ReaderTask.ts.md
+++ b/docs/modules/ReaderTask.ts.md
@@ -804,7 +804,7 @@ Added in v2.8.0
 
 ```ts
 export declare const bindMap: <N, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => <E>(fa: ReaderTask<E, A>) => ReaderTask<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
 ```

--- a/docs/modules/ReaderTaskEither.ts.md
+++ b/docs/modules/ReaderTaskEither.ts.md
@@ -162,6 +162,7 @@ Added in v2.0.0
   - [apS](#aps)
   - [apSW](#apsw)
   - [bind](#bind)
+  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [bindW](#bindw)
   - [bracket](#bracket)
@@ -1942,6 +1943,21 @@ export declare const bind: <N, A, R, E, B>(
 ```
 
 Added in v2.8.0
+
+## bindMap
+
+**Signature**
+
+```ts
+export declare const bindMap: <N, A, B>(
+  name: N,
+  f: (a: A) => B
+) => <R, E>(
+  fa: ReaderTaskEither<R, E, A>
+) => ReaderTaskEither<R, E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## bindTo
 

--- a/docs/modules/ReaderTaskEither.ts.md
+++ b/docs/modules/ReaderTaskEither.ts.md
@@ -1950,7 +1950,7 @@ Added in v2.8.0
 
 ```ts
 export declare const bindMap: <N, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => <R, E>(
   fa: ReaderTaskEither<R, E, A>

--- a/docs/modules/ReaderTaskEither.ts.md
+++ b/docs/modules/ReaderTaskEither.ts.md
@@ -162,11 +162,11 @@ Added in v2.0.0
   - [apS](#aps)
   - [apSW](#apsw)
   - [bind](#bind)
-  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [bindW](#bindw)
   - [bracket](#bracket)
   - [bracketW](#bracketw)
+  - [let](#let)
   - [sequenceArray](#sequencearray)
   - [sequenceSeqArray](#sequenceseqarray)
   - [traverseArray](#traversearray)
@@ -1944,21 +1944,6 @@ export declare const bind: <N, A, R, E, B>(
 
 Added in v2.8.0
 
-## bindMap
-
-**Signature**
-
-```ts
-export declare const bindMap: <N, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => <R, E>(
-  fa: ReaderTaskEither<R, E, A>
-) => ReaderTaskEither<R, E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-```
-
-Added in v2.13.0
-
 ## bindTo
 
 **Signature**
@@ -2022,6 +2007,21 @@ export declare function bracketW<R1, E1, A, R2, E2, B, R3, E3>(
 ```
 
 Added in v2.12.0
+
+## let
+
+**Signature**
+
+```ts
+export declare const let: <N, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => <R, E>(
+  fa: ReaderTaskEither<R, E, A>
+) => ReaderTaskEither<R, E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## sequenceArray
 

--- a/docs/modules/ReadonlyArray.ts.md
+++ b/docs/modules/ReadonlyArray.ts.md
@@ -2442,7 +2442,7 @@ Added in v2.8.0
 
 ```ts
 export declare const bindMap: <N, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => (fa: readonly A[]) => readonly { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }[]
 ```

--- a/docs/modules/ReadonlyArray.ts.md
+++ b/docs/modules/ReadonlyArray.ts.md
@@ -178,6 +178,7 @@ Added in v2.5.0
   - [Spanned (interface)](#spanned-interface)
   - [apS](#aps)
   - [bind](#bind)
+  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [deleteAt](#deleteat)
   - [elem](#elem)
@@ -2434,6 +2435,19 @@ export declare const bind: <N, A, B>(
 ```
 
 Added in v2.8.0
+
+## bindMap
+
+**Signature**
+
+```ts
+export declare const bindMap: <N, A, B>(
+  name: N,
+  f: (a: A) => B
+) => (fa: readonly A[]) => readonly { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }[]
+```
+
+Added in v2.13.0
 
 ## bindTo
 

--- a/docs/modules/ReadonlyArray.ts.md
+++ b/docs/modules/ReadonlyArray.ts.md
@@ -178,7 +178,6 @@ Added in v2.5.0
   - [Spanned (interface)](#spanned-interface)
   - [apS](#aps)
   - [bind](#bind)
-  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [deleteAt](#deleteat)
   - [elem](#elem)
@@ -198,6 +197,7 @@ Added in v2.5.0
   - [intercalate](#intercalate)
   - [isOutOfBound](#isoutofbound)
   - [last](#last)
+  - [let](#let)
   - [lookup](#lookup)
   - [modifyAt](#modifyat)
   - [size](#size)
@@ -2436,19 +2436,6 @@ export declare const bind: <N, A, B>(
 
 Added in v2.8.0
 
-## bindMap
-
-**Signature**
-
-```ts
-export declare const bindMap: <N, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => (fa: readonly A[]) => readonly { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }[]
-```
-
-Added in v2.13.0
-
 ## bindTo
 
 **Signature**
@@ -2891,6 +2878,19 @@ assert.deepStrictEqual(last([]), none)
 ```
 
 Added in v2.5.0
+
+## let
+
+**Signature**
+
+```ts
+export declare const let: <N, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => (fa: readonly A[]) => readonly { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }[]
+```
+
+Added in v2.13.0
 
 ## lookup
 

--- a/docs/modules/ReadonlyNonEmptyArray.ts.md
+++ b/docs/modules/ReadonlyNonEmptyArray.ts.md
@@ -131,13 +131,13 @@ Added in v2.5.0
   - [Do](#do)
   - [apS](#aps)
   - [bind](#bind)
-  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [concatAll](#concatall)
   - [head](#head)
   - [init](#init)
   - [intercalate](#intercalate)
   - [last](#last)
+  - [let](#let)
   - [max](#max)
   - [min](#min)
   - [modifyHead](#modifyhead)
@@ -1502,21 +1502,6 @@ export declare const bind: <N, A, B>(
 
 Added in v2.8.0
 
-## bindMap
-
-**Signature**
-
-```ts
-export declare const bindMap: <N, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => (
-  fa: ReadonlyNonEmptyArray<A>
-) => ReadonlyNonEmptyArray<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-```
-
-Added in v2.13.0
-
 ## bindTo
 
 **Signature**
@@ -1600,6 +1585,21 @@ export declare const last: <A>(as: ReadonlyNonEmptyArray<A>) => A
 ```
 
 Added in v2.5.0
+
+## let
+
+**Signature**
+
+```ts
+export declare const let: <N, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => (
+  fa: ReadonlyNonEmptyArray<A>
+) => ReadonlyNonEmptyArray<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## max
 

--- a/docs/modules/ReadonlyNonEmptyArray.ts.md
+++ b/docs/modules/ReadonlyNonEmptyArray.ts.md
@@ -1508,7 +1508,7 @@ Added in v2.8.0
 
 ```ts
 export declare const bindMap: <N, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => (
   fa: ReadonlyNonEmptyArray<A>

--- a/docs/modules/ReadonlyNonEmptyArray.ts.md
+++ b/docs/modules/ReadonlyNonEmptyArray.ts.md
@@ -131,6 +131,7 @@ Added in v2.5.0
   - [Do](#do)
   - [apS](#aps)
   - [bind](#bind)
+  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [concatAll](#concatall)
   - [head](#head)
@@ -1500,6 +1501,21 @@ export declare const bind: <N, A, B>(
 ```
 
 Added in v2.8.0
+
+## bindMap
+
+**Signature**
+
+```ts
+export declare const bindMap: <N, A, B>(
+  name: N,
+  f: (a: A) => B
+) => (
+  fa: ReadonlyNonEmptyArray<A>
+) => ReadonlyNonEmptyArray<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## bindTo
 

--- a/docs/modules/State.ts.md
+++ b/docs/modules/State.ts.md
@@ -47,6 +47,7 @@ Added in v2.0.0
 - [utils](#utils)
   - [apS](#aps)
   - [bind](#bind)
+  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [evaluate](#evaluate)
   - [execute](#execute)
@@ -381,6 +382,19 @@ export declare const bind: <N, A, E, B>(
 ```
 
 Added in v2.8.0
+
+## bindMap
+
+**Signature**
+
+```ts
+export declare const bindMap: <N, A, B>(
+  name: N,
+  f: (a: A) => B
+) => <E>(fa: State<E, A>) => State<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## bindTo
 

--- a/docs/modules/State.ts.md
+++ b/docs/modules/State.ts.md
@@ -389,7 +389,7 @@ Added in v2.8.0
 
 ```ts
 export declare const bindMap: <N, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => <E>(fa: State<E, A>) => State<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
 ```

--- a/docs/modules/State.ts.md
+++ b/docs/modules/State.ts.md
@@ -47,10 +47,10 @@ Added in v2.0.0
 - [utils](#utils)
   - [apS](#aps)
   - [bind](#bind)
-  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [evaluate](#evaluate)
   - [execute](#execute)
+  - [let](#let)
   - [sequenceArray](#sequencearray)
   - [traverseArray](#traversearray)
   - [traverseArrayWithIndex](#traversearraywithindex)
@@ -383,19 +383,6 @@ export declare const bind: <N, A, E, B>(
 
 Added in v2.8.0
 
-## bindMap
-
-**Signature**
-
-```ts
-export declare const bindMap: <N, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => <E>(fa: State<E, A>) => State<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-```
-
-Added in v2.13.0
-
 ## bindTo
 
 **Signature**
@@ -429,6 +416,19 @@ export declare const execute: <S>(s: S) => <A>(ma: State<S, A>) => S
 ```
 
 Added in v2.8.0
+
+## let
+
+**Signature**
+
+```ts
+export declare const let: <N, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => <E>(fa: State<E, A>) => State<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## sequenceArray
 

--- a/docs/modules/StateReaderTaskEither.ts.md
+++ b/docs/modules/StateReaderTaskEither.ts.md
@@ -130,6 +130,7 @@ Added in v2.0.0
   - [apS](#aps)
   - [apSW](#apsw)
   - [bind](#bind)
+  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [bindW](#bindw)
   - [evaluate](#evaluate)
@@ -1492,6 +1493,21 @@ export declare const bind: <N, A, S, R, E, B>(
 ```
 
 Added in v2.8.0
+
+## bindMap
+
+**Signature**
+
+```ts
+export declare const bindMap: <N, A, B>(
+  name: N,
+  f: (a: A) => B
+) => <S, R, E>(
+  fa: StateReaderTaskEither<S, R, E, A>
+) => StateReaderTaskEither<S, R, E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## bindTo
 

--- a/docs/modules/StateReaderTaskEither.ts.md
+++ b/docs/modules/StateReaderTaskEither.ts.md
@@ -130,11 +130,11 @@ Added in v2.0.0
   - [apS](#aps)
   - [apSW](#apsw)
   - [bind](#bind)
-  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [bindW](#bindw)
   - [evaluate](#evaluate)
   - [execute](#execute)
+  - [let](#let)
   - [sequenceArray](#sequencearray)
   - [traverseArray](#traversearray)
   - [traverseArrayWithIndex](#traversearraywithindex)
@@ -1494,21 +1494,6 @@ export declare const bind: <N, A, S, R, E, B>(
 
 Added in v2.8.0
 
-## bindMap
-
-**Signature**
-
-```ts
-export declare const bindMap: <N, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => <S, R, E>(
-  fa: StateReaderTaskEither<S, R, E, A>
-) => StateReaderTaskEither<S, R, E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-```
-
-Added in v2.13.0
-
 ## bindTo
 
 **Signature**
@@ -1565,6 +1550,21 @@ export declare const execute: <S>(
 ```
 
 Added in v2.8.0
+
+## let
+
+**Signature**
+
+```ts
+export declare const let: <N, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => <S, R, E>(
+  fa: StateReaderTaskEither<S, R, E, A>
+) => StateReaderTaskEither<S, R, E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## sequenceArray
 

--- a/docs/modules/StateReaderTaskEither.ts.md
+++ b/docs/modules/StateReaderTaskEither.ts.md
@@ -1500,7 +1500,7 @@ Added in v2.8.0
 
 ```ts
 export declare const bindMap: <N, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => <S, R, E>(
   fa: StateReaderTaskEither<S, R, E, A>

--- a/docs/modules/Task.ts.md
+++ b/docs/modules/Task.ts.md
@@ -70,8 +70,8 @@ Added in v2.0.0
   - [Do](#do)
   - [apS](#aps)
   - [bind](#bind)
-  - [bindMap](#bindmap)
   - [bindTo](#bindto)
+  - [let](#let)
   - [never](#never)
   - [sequenceArray](#sequencearray)
   - [sequenceSeqArray](#sequenceseqarray)
@@ -595,19 +595,6 @@ export declare const bind: <N, A, B>(
 
 Added in v2.8.0
 
-## bindMap
-
-**Signature**
-
-```ts
-export declare const bindMap: <N, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => (fa: Task<A>) => Task<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-```
-
-Added in v2.13.0
-
 ## bindTo
 
 **Signature**
@@ -617,6 +604,19 @@ export declare const bindTo: <N>(name: N) => <A>(fa: Task<A>) => Task<{ readonly
 ```
 
 Added in v2.8.0
+
+## let
+
+**Signature**
+
+```ts
+export declare const let: <N, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => (fa: Task<A>) => Task<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## never
 

--- a/docs/modules/Task.ts.md
+++ b/docs/modules/Task.ts.md
@@ -70,6 +70,7 @@ Added in v2.0.0
   - [Do](#do)
   - [apS](#aps)
   - [bind](#bind)
+  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [never](#never)
   - [sequenceArray](#sequencearray)
@@ -593,6 +594,19 @@ export declare const bind: <N, A, B>(
 ```
 
 Added in v2.8.0
+
+## bindMap
+
+**Signature**
+
+```ts
+export declare const bindMap: <N, A, B>(
+  name: N,
+  f: (a: A) => B
+) => (fa: Task<A>) => Task<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## bindTo
 

--- a/docs/modules/Task.ts.md
+++ b/docs/modules/Task.ts.md
@@ -601,7 +601,7 @@ Added in v2.8.0
 
 ```ts
 export declare const bindMap: <N, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => (fa: Task<A>) => Task<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
 ```

--- a/docs/modules/TaskEither.ts.md
+++ b/docs/modules/TaskEither.ts.md
@@ -144,6 +144,7 @@ Added in v2.0.0
   - [apS](#aps)
   - [apSW](#apsw)
   - [bind](#bind)
+  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [bindW](#bindw)
   - [bracket](#bracket)
@@ -1659,6 +1660,19 @@ export declare const bind: <N, A, E, B>(
 ```
 
 Added in v2.8.0
+
+## bindMap
+
+**Signature**
+
+```ts
+export declare const bindMap: <N, A, B>(
+  name: N,
+  f: (a: A) => B
+) => <E>(fa: TaskEither<E, A>) => TaskEither<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## bindTo
 

--- a/docs/modules/TaskEither.ts.md
+++ b/docs/modules/TaskEither.ts.md
@@ -1667,7 +1667,7 @@ Added in v2.8.0
 
 ```ts
 export declare const bindMap: <N, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => <E>(fa: TaskEither<E, A>) => TaskEither<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
 ```

--- a/docs/modules/TaskEither.ts.md
+++ b/docs/modules/TaskEither.ts.md
@@ -144,11 +144,11 @@ Added in v2.0.0
   - [apS](#aps)
   - [apSW](#apsw)
   - [bind](#bind)
-  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [bindW](#bindw)
   - [bracket](#bracket)
   - [bracketW](#bracketw)
+  - [let](#let)
   - [sequenceArray](#sequencearray)
   - [sequenceSeqArray](#sequenceseqarray)
   - [taskify](#taskify)
@@ -1661,19 +1661,6 @@ export declare const bind: <N, A, E, B>(
 
 Added in v2.8.0
 
-## bindMap
-
-**Signature**
-
-```ts
-export declare const bindMap: <N, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => <E>(fa: TaskEither<E, A>) => TaskEither<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-```
-
-Added in v2.13.0
-
 ## bindTo
 
 **Signature**
@@ -1735,6 +1722,19 @@ export declare const bracketW: <E1, A, E2, B, E3>(
 ```
 
 Added in v2.12.0
+
+## let
+
+**Signature**
+
+```ts
+export declare const let: <N, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => <E>(fa: TaskEither<E, A>) => TaskEither<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## sequenceArray
 

--- a/docs/modules/TaskOption.ts.md
+++ b/docs/modules/TaskOption.ts.md
@@ -103,8 +103,8 @@ Added in v2.10.0
   - [Do](#do)
   - [apS](#aps)
   - [bind](#bind)
-  - [bindMap](#bindmap)
   - [bindTo](#bindto)
+  - [let](#let)
   - [sequenceArray](#sequencearray)
   - [sequenceSeqArray](#sequenceseqarray)
   - [traverseArray](#traversearray)
@@ -996,19 +996,6 @@ export declare const bind: <N, A, B>(
 
 Added in v2.10.0
 
-## bindMap
-
-**Signature**
-
-```ts
-export declare const bindMap: <N, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => (fa: TaskOption<A>) => TaskOption<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-```
-
-Added in v2.13.0
-
 ## bindTo
 
 **Signature**
@@ -1018,6 +1005,19 @@ export declare const bindTo: <N>(name: N) => <A>(fa: TaskOption<A>) => TaskOptio
 ```
 
 Added in v2.10.0
+
+## let
+
+**Signature**
+
+```ts
+export declare const let: <N, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => (fa: TaskOption<A>) => TaskOption<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## sequenceArray
 

--- a/docs/modules/TaskOption.ts.md
+++ b/docs/modules/TaskOption.ts.md
@@ -103,6 +103,7 @@ Added in v2.10.0
   - [Do](#do)
   - [apS](#aps)
   - [bind](#bind)
+  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [sequenceArray](#sequencearray)
   - [sequenceSeqArray](#sequenceseqarray)
@@ -994,6 +995,19 @@ export declare const bind: <N, A, B>(
 ```
 
 Added in v2.10.0
+
+## bindMap
+
+**Signature**
+
+```ts
+export declare const bindMap: <N, A, B>(
+  name: N,
+  f: (a: A) => B
+) => (fa: TaskOption<A>) => TaskOption<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## bindTo
 

--- a/docs/modules/TaskOption.ts.md
+++ b/docs/modules/TaskOption.ts.md
@@ -1002,7 +1002,7 @@ Added in v2.10.0
 
 ```ts
 export declare const bindMap: <N, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => (fa: TaskOption<A>) => TaskOption<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
 ```

--- a/docs/modules/Tree.ts.md
+++ b/docs/modules/Tree.ts.md
@@ -71,6 +71,7 @@ Added in v2.0.0
   - [Do](#do)
   - [apS](#aps)
   - [bind](#bind)
+  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [drawForest](#drawforest)
   - [drawTree](#drawtree)
@@ -620,6 +621,19 @@ export declare const bind: <N, A, B>(
 ```
 
 Added in v2.8.0
+
+## bindMap
+
+**Signature**
+
+```ts
+export declare const bindMap: <N, A, B>(
+  name: N,
+  f: (a: A) => B
+) => (fa: Tree<A>) => Tree<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## bindTo
 

--- a/docs/modules/Tree.ts.md
+++ b/docs/modules/Tree.ts.md
@@ -71,12 +71,12 @@ Added in v2.0.0
   - [Do](#do)
   - [apS](#aps)
   - [bind](#bind)
-  - [bindMap](#bindmap)
   - [bindTo](#bindto)
   - [drawForest](#drawforest)
   - [drawTree](#drawtree)
   - [elem](#elem)
   - [exists](#exists)
+  - [let](#let)
   - [sequence](#sequence)
   - [traverse](#traverse)
 
@@ -622,19 +622,6 @@ export declare const bind: <N, A, B>(
 
 Added in v2.8.0
 
-## bindMap
-
-**Signature**
-
-```ts
-export declare const bindMap: <N, A, B>(
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-) => (fa: Tree<A>) => Tree<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-```
-
-Added in v2.13.0
-
 ## bindTo
 
 **Signature**
@@ -706,6 +693,19 @@ export declare const exists: <A>(predicate: Predicate<A>) => (ma: Tree<A>) => bo
 ```
 
 Added in v2.11.0
+
+## let
+
+**Signature**
+
+```ts
+export declare const let: <N, A, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => B
+) => (fa: Tree<A>) => Tree<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
 
 ## sequence
 

--- a/docs/modules/Tree.ts.md
+++ b/docs/modules/Tree.ts.md
@@ -628,7 +628,7 @@ Added in v2.8.0
 
 ```ts
 export declare const bindMap: <N, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => (fa: Tree<A>) => Tree<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
 ```

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -21,7 +21,7 @@ import { Foldable1 } from './Foldable'
 import { FoldableWithIndex1 } from './FoldableWithIndex'
 import { FromEither1, fromEitherK as fromEitherK_ } from './FromEither'
 import { identity, Lazy, pipe } from './function'
-import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
+import { let as let__, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import { FunctorWithIndex1 } from './FunctorWithIndex'
 import { HKT } from './HKT'
 import * as _ from './internal'
@@ -2925,10 +2925,14 @@ export const Do: Array<{}> = /*#__PURE__*/ of(_.emptyRecord)
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
 
-/**
- * @since 2.13.0
- */
-export const bindMap = /*#__PURE__*/ bindMap_(Functor)
+const let_ = /*#__PURE__*/ let__(Functor)
+
+export {
+  /**
+   * @since 2.13.0
+   */
+  let_ as let
+}
 
 /**
  * @since 2.8.0

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -21,7 +21,7 @@ import { Foldable1 } from './Foldable'
 import { FoldableWithIndex1 } from './FoldableWithIndex'
 import { FromEither1, fromEitherK as fromEitherK_ } from './FromEither'
 import { identity, Lazy, pipe } from './function'
-import { bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
+import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import { FunctorWithIndex1 } from './FunctorWithIndex'
 import { HKT } from './HKT'
 import * as _ from './internal'
@@ -2924,6 +2924,11 @@ export const Do: Array<{}> = /*#__PURE__*/ of(_.emptyRecord)
  * @since 2.8.0
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
+
+/**
+ * @since 2.13.0
+ */
+export const bindMap = /*#__PURE__*/ bindMap_(Functor)
 
 /**
  * @since 2.8.0

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -87,7 +87,7 @@ import {
   fromPredicate as fromPredicate_
 } from './FromEither'
 import { flow, identity, Lazy, pipe } from './function'
-import { bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
+import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
 import { HKT } from './HKT'
 import * as _ from './internal'
 import { Monad2, Monad2C } from './Monad'
@@ -1469,6 +1469,11 @@ export const Do: Either<never, {}> = /*#__PURE__*/ of(_.emptyRecord)
  * @since 2.8.0
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
+
+/**
+ * @since 2.13.0
+ */
+export const bindMap = /*#__PURE__*/ bindMap_(Functor)
 
 /**
  * @since 2.8.0

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -87,7 +87,7 @@ import {
   fromPredicate as fromPredicate_
 } from './FromEither'
 import { flow, identity, Lazy, pipe } from './function'
-import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
+import { let as let__, bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
 import { HKT } from './HKT'
 import * as _ from './internal'
 import { Monad2, Monad2C } from './Monad'
@@ -1470,10 +1470,14 @@ export const Do: Either<never, {}> = /*#__PURE__*/ of(_.emptyRecord)
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
 
-/**
- * @since 2.13.0
- */
-export const bindMap = /*#__PURE__*/ bindMap_(Functor)
+const let_ = /*#__PURE__*/ let__(Functor)
+
+export {
+  /**
+   * @since 2.13.0
+   */
+  let_ as let
+}
 
 /**
  * @since 2.8.0

--- a/src/Functor.ts
+++ b/src/Functor.ts
@@ -192,7 +192,7 @@ export function bindTo<F>(
 /**
  * @since 2.13.0
  */
-export function bindMap<F extends URIS4>(
+function let_<F extends URIS4>(
   F: Functor4<F>
 ): <N extends string, A, B>(
   name: Exclude<N, keyof A>,
@@ -200,49 +200,56 @@ export function bindMap<F extends URIS4>(
 ) => <S, R, E>(
   fa: Kind4<F, S, R, E, A>
 ) => Kind4<F, S, R, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
-export function bindMap<F extends URIS3>(
+function let_<F extends URIS3>(
   F: Functor3<F>
 ): <N extends string, A, B>(
   name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
-export function bindMap<F extends URIS3, E>(
+function let_<F extends URIS3, E>(
   F: Functor3C<F, E>
 ): <N extends string, A, B>(
   name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
-export function bindMap<F extends URIS2>(
+function let_<F extends URIS2>(
   F: Functor2<F>
 ): <N extends string, A, B>(
   name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => <E>(fa: Kind2<F, E, A>) => Kind2<F, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
-export function bindMap<F extends URIS2, E>(
+function let_<F extends URIS2, E>(
   F: Functor2C<F, E>
 ): <N extends string, A, B>(
   name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => (fa: Kind2<F, E, A>) => Kind2<F, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
-export function bindMap<F extends URIS>(
+function let_<F extends URIS>(
   F: Functor1<F>
 ): <N extends string, A, B>(
   name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => (fa: Kind<F, A>) => Kind<F, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
-export function bindMap<F>(
+function let_<F>(
   F: Functor<F>
 ): <N extends string, A, B>(
   name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => (fa: HKT<F, A>) => HKT<F, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
-export function bindMap<F>(
+function let_<F>(
   F: Functor<F>
 ): <N extends string, A, B>(
   name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => (fa: HKT<F, A>) => HKT<F, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }> {
   return (name, f) => (fa) => F.map(fa, (a) => Object.assign({}, a, { [name]: f(a) }) as any)
+}
+
+export {
+  /**
+   * @since 2.13.0
+   */
+  let_ as let
 }
 
 // -------------------------------------------------------------------------------------

--- a/src/Functor.ts
+++ b/src/Functor.ts
@@ -189,6 +189,62 @@ export function bindTo<F>(
   return (name) => (fa) => F.map(fa, (a) => ({ [name]: a } as any))
 }
 
+/**
+ * @since 2.13.0
+ */
+export function bindMap<F extends URIS4>(
+  F: Functor4<F>
+): <N extends string, A, B>(
+  name: N,
+  f: (a: A) => B
+) => <S, R, E>(
+  fa: Kind4<F, S, R, E, A>
+) => Kind4<F, S, R, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+export function bindMap<F extends URIS3>(
+  F: Functor3<F>
+): <N extends string, A, B>(
+  name: N,
+  f: (a: A) => B
+) => <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+export function bindMap<F extends URIS3, E>(
+  F: Functor3C<F, E>
+): <N extends string, A, B>(
+  name: N,
+  f: (a: A) => B
+) => <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+export function bindMap<F extends URIS2>(
+  F: Functor2<F>
+): <N extends string, A, B>(
+  name: N,
+  f: (a: A) => B
+) => <E>(fa: Kind2<F, E, A>) => Kind2<F, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+export function bindMap<F extends URIS2, E>(
+  F: Functor2C<F, E>
+): <N extends string, A, B>(
+  name: N,
+  f: (a: A) => B
+) => (fa: Kind2<F, E, A>) => Kind2<F, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+export function bindMap<F extends URIS>(
+  F: Functor1<F>
+): <N extends string, A, B>(
+  name: N,
+  f: (a: A) => B
+) => (fa: Kind<F, A>) => Kind<F, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+export function bindMap<F>(
+  F: Functor<F>
+): <N extends string, A, B>(
+  name: N,
+  f: (a: A) => B
+) => (fa: HKT<F, A>) => HKT<F, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+export function bindMap<F>(
+  F: Functor<F>
+): <N extends string, A, B>(
+  name: N,
+  f: (a: A) => B
+) => (fa: HKT<F, A>) => HKT<F, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }> {
+  return (name, f) => (fa) => F.map(fa, (a) => Object.assign({}, a, { [name]: f(a) }) as any)
+}
+
 // -------------------------------------------------------------------------------------
 // deprecated
 // -------------------------------------------------------------------------------------

--- a/src/Functor.ts
+++ b/src/Functor.ts
@@ -195,7 +195,7 @@ export function bindTo<F>(
 export function bindMap<F extends URIS4>(
   F: Functor4<F>
 ): <N extends string, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => <S, R, E>(
   fa: Kind4<F, S, R, E, A>
@@ -203,43 +203,43 @@ export function bindMap<F extends URIS4>(
 export function bindMap<F extends URIS3>(
   F: Functor3<F>
 ): <N extends string, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
 export function bindMap<F extends URIS3, E>(
   F: Functor3C<F, E>
 ): <N extends string, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
 export function bindMap<F extends URIS2>(
   F: Functor2<F>
 ): <N extends string, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => <E>(fa: Kind2<F, E, A>) => Kind2<F, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
 export function bindMap<F extends URIS2, E>(
   F: Functor2C<F, E>
 ): <N extends string, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => (fa: Kind2<F, E, A>) => Kind2<F, E, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
 export function bindMap<F extends URIS>(
   F: Functor1<F>
 ): <N extends string, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => (fa: Kind<F, A>) => Kind<F, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
 export function bindMap<F>(
   F: Functor<F>
 ): <N extends string, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => (fa: HKT<F, A>) => HKT<F, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }>
 export function bindMap<F>(
   F: Functor<F>
 ): <N extends string, A, B>(
-  name: N,
+  name: Exclude<N, keyof A>,
   f: (a: A) => B
 ) => (fa: HKT<F, A>) => HKT<F, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }> {
   return (name, f) => (fa) => F.map(fa, (a) => Object.assign({}, a, { [name]: f(a) }) as any)

--- a/src/IO.ts
+++ b/src/IO.ts
@@ -19,7 +19,7 @@ import { bind as bind_, Chain1, chainFirst as chainFirst_ } from './Chain'
 import { ChainRec1 } from './ChainRec'
 import { FromIO1 } from './FromIO'
 import { constant, identity } from './function'
-import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
+import { let as let__, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import * as _ from './internal'
 import { Monad1 } from './Monad'
 import { MonadIO1 } from './MonadIO'
@@ -277,10 +277,14 @@ export const Do: IO<{}> = /*#__PURE__*/ of(_.emptyRecord)
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
 
-/**
- * @since 2.13.0
- */
-export const bindMap = /*#__PURE__*/ bindMap_(Functor)
+const let_ = /*#__PURE__*/ let__(Functor)
+
+export {
+  /**
+   * @since 2.13.0
+   */
+  let_ as let
+}
 
 /**
  * @since 2.8.0

--- a/src/IO.ts
+++ b/src/IO.ts
@@ -19,7 +19,7 @@ import { bind as bind_, Chain1, chainFirst as chainFirst_ } from './Chain'
 import { ChainRec1 } from './ChainRec'
 import { FromIO1 } from './FromIO'
 import { constant, identity } from './function'
-import { bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
+import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import * as _ from './internal'
 import { Monad1 } from './Monad'
 import { MonadIO1 } from './MonadIO'
@@ -276,6 +276,11 @@ export const Do: IO<{}> = /*#__PURE__*/ of(_.emptyRecord)
  * @since 2.8.0
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
+
+/**
+ * @since 2.13.0
+ */
+export const bindMap = /*#__PURE__*/ bindMap_(Functor)
 
 /**
  * @since 2.8.0

--- a/src/IOEither.ts
+++ b/src/IOEither.ts
@@ -42,7 +42,7 @@ import {
 } from './FromEither'
 import { chainFirstIOK as chainFirstIOK_, chainIOK as chainIOK_, FromIO2, fromIOK as fromIOK_ } from './FromIO'
 import { flow, identity, Lazy, pipe, SK } from './function'
-import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
+import { let as let__, bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
 import * as _ from './internal'
 import * as I from './IO'
 import { Monad2, Monad2C } from './Monad'
@@ -946,10 +946,14 @@ export const Do: IOEither<never, {}> = /*#__PURE__*/ of(_.emptyRecord)
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
 
-/**
- * @since 2.8.0
- */
-export const bindMap = /*#__PURE__*/ bindMap_(Functor)
+const let_ = /*#__PURE__*/ let__(Functor)
+
+export {
+  /**
+   * @since 2.13.0
+   */
+  let_ as let
+}
 
 /**
  * @since 2.8.0

--- a/src/IOEither.ts
+++ b/src/IOEither.ts
@@ -42,7 +42,7 @@ import {
 } from './FromEither'
 import { chainFirstIOK as chainFirstIOK_, chainIOK as chainIOK_, FromIO2, fromIOK as fromIOK_ } from './FromIO'
 import { flow, identity, Lazy, pipe, SK } from './function'
-import { bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
+import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
 import * as _ from './internal'
 import * as I from './IO'
 import { Monad2, Monad2C } from './Monad'
@@ -945,6 +945,11 @@ export const Do: IOEither<never, {}> = /*#__PURE__*/ of(_.emptyRecord)
  * @since 2.8.0
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
+
+/**
+ * @since 2.8.0
+ */
+export const bindMap = /*#__PURE__*/ bindMap_(Functor)
 
 /**
  * @since 2.8.0

--- a/src/IOOption.ts
+++ b/src/IOOption.ts
@@ -28,7 +28,7 @@ import {
 } from './FromEither'
 import { chainFirstIOK as chainFirstIOK_, chainIOK as chainIOK_, FromIO1, fromIOK as fromIOK_ } from './FromIO'
 import { flow, identity, Lazy, pipe, SK } from './function'
-import { bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
+import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import * as _ from './internal'
 import { Monad1 } from './Monad'
 import { MonadIO1 } from './MonadIO'
@@ -636,6 +636,11 @@ export const Do: IOOption<{}> = /*#__PURE__*/ of(_.emptyRecord)
  * @since 2.12.0
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
+
+/**
+ * @since 2.13.0
+ */
+export const bindMap = /*#__PURE__*/ bindMap_(Functor)
 
 /**
  * @since 2.12.0

--- a/src/IOOption.ts
+++ b/src/IOOption.ts
@@ -28,7 +28,7 @@ import {
 } from './FromEither'
 import { chainFirstIOK as chainFirstIOK_, chainIOK as chainIOK_, FromIO1, fromIOK as fromIOK_ } from './FromIO'
 import { flow, identity, Lazy, pipe, SK } from './function'
-import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
+import { let as let__, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import * as _ from './internal'
 import { Monad1 } from './Monad'
 import { MonadIO1 } from './MonadIO'
@@ -637,10 +637,14 @@ export const Do: IOOption<{}> = /*#__PURE__*/ of(_.emptyRecord)
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
 
-/**
- * @since 2.13.0
- */
-export const bindMap = /*#__PURE__*/ bindMap_(Functor)
+const let_ = /*#__PURE__*/ let__(Functor)
+
+export {
+  /**
+   * @since 2.13.0
+   */
+  let_ as let
+}
 
 /**
  * @since 2.12.0

--- a/src/Identity.ts
+++ b/src/Identity.ts
@@ -11,7 +11,7 @@ import { Eq } from './Eq'
 import { Extend1 } from './Extend'
 import { Foldable1 } from './Foldable'
 import { identity as id, pipe } from './function'
-import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
+import { let as let__, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import { HKT } from './HKT'
 import * as _ from './internal'
 import { Monad1 } from './Monad'
@@ -379,10 +379,14 @@ export const Do: Identity<{}> = /*#__PURE__*/ of(_.emptyRecord)
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
 
-/**
- * @since 2.13.0
- */
-export const bindMap = /*#__PURE__*/ bindMap_(Functor)
+const let_ = /*#__PURE__*/ let__(Functor)
+
+export {
+  /**
+   * @since 2.13.0
+   */
+  let_ as let
+}
 
 /**
  * @since 2.8.0

--- a/src/Identity.ts
+++ b/src/Identity.ts
@@ -11,7 +11,7 @@ import { Eq } from './Eq'
 import { Extend1 } from './Extend'
 import { Foldable1 } from './Foldable'
 import { identity as id, pipe } from './function'
-import { bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
+import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import { HKT } from './HKT'
 import * as _ from './internal'
 import { Monad1 } from './Monad'
@@ -378,6 +378,11 @@ export const Do: Identity<{}> = /*#__PURE__*/ of(_.emptyRecord)
  * @since 2.8.0
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
+
+/**
+ * @since 2.13.0
+ */
+export const bindMap = /*#__PURE__*/ bindMap_(Functor)
 
 /**
  * @since 2.8.0

--- a/src/NonEmptyArray.ts
+++ b/src/NonEmptyArray.ts
@@ -23,7 +23,7 @@ import { Extend1 } from './Extend'
 import { Foldable1 } from './Foldable'
 import { FoldableWithIndex1 } from './FoldableWithIndex'
 import { identity, Lazy, pipe } from './function'
-import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
+import { let as let__, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import { FunctorWithIndex1 } from './FunctorWithIndex'
 import { HKT } from './HKT'
 import * as _ from './internal'
@@ -1123,10 +1123,14 @@ export const Do: NonEmptyArray<{}> = /*#__PURE__*/ of(_.emptyRecord)
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
 
-/**
- * @since 2.13.0
- */
-export const bindMap = /*#__PURE__*/ bindMap_(Functor)
+const let_ = /*#__PURE__*/ let__(Functor)
+
+export {
+  /**
+   * @since 2.13.0
+   */
+  let_ as let
+}
 
 /**
  * @since 2.8.0

--- a/src/NonEmptyArray.ts
+++ b/src/NonEmptyArray.ts
@@ -23,7 +23,7 @@ import { Extend1 } from './Extend'
 import { Foldable1 } from './Foldable'
 import { FoldableWithIndex1 } from './FoldableWithIndex'
 import { identity, Lazy, pipe } from './function'
-import { bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
+import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import { FunctorWithIndex1 } from './FunctorWithIndex'
 import { HKT } from './HKT'
 import * as _ from './internal'
@@ -1122,6 +1122,11 @@ export const Do: NonEmptyArray<{}> = /*#__PURE__*/ of(_.emptyRecord)
  * @since 2.8.0
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
+
+/**
+ * @since 2.13.0
+ */
+export const bindMap = /*#__PURE__*/ bindMap_(Functor)
 
 /**
  * @since 2.8.0

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -84,7 +84,7 @@ import {
   chainFirstEitherK as chainFirstEitherK_
 } from './FromEither'
 import { constNull, constUndefined, flow, identity, Lazy, pipe } from './function'
-import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
+import { let as let__, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import { HKT } from './HKT'
 import * as _ from './internal'
 import { Monad1 } from './Monad'
@@ -1244,10 +1244,14 @@ export const Do: Option<{}> = /*#__PURE__*/ of(_.emptyRecord)
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
 
-/**
- * @since 2.13.0
- */
-export const bindMap = /*#__PURE__*/ bindMap_(Functor)
+const let_ = /*#__PURE__*/ let__(Functor)
+
+export {
+  /**
+   * @since 2.13.0
+   */
+  let_ as let
+}
 
 /**
  * @since 2.8.0

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -84,7 +84,7 @@ import {
   chainFirstEitherK as chainFirstEitherK_
 } from './FromEither'
 import { constNull, constUndefined, flow, identity, Lazy, pipe } from './function'
-import { bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
+import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import { HKT } from './HKT'
 import * as _ from './internal'
 import { Monad1 } from './Monad'
@@ -1243,6 +1243,11 @@ export const Do: Option<{}> = /*#__PURE__*/ of(_.emptyRecord)
  * @since 2.8.0
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
+
+/**
+ * @since 2.13.0
+ */
+export const bindMap = /*#__PURE__*/ bindMap_(Functor)
 
 /**
  * @since 2.8.0

--- a/src/Reader.ts
+++ b/src/Reader.ts
@@ -45,7 +45,7 @@ import { bind as bind_, Chain2, chainFirst as chainFirst_ } from './Chain'
 import { Choice2 } from './Choice'
 import * as E from './Either'
 import { constant, flow, identity, pipe } from './function'
-import { bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
+import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
 import * as _ from './internal'
 import { Monad2 } from './Monad'
 import { Monoid } from './Monoid'
@@ -493,6 +493,11 @@ export const Choice: Choice2<URI> = {
  * @since 2.8.0
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
+
+/**
+ * @since 2.13.0
+ */
+export const bindMap = /*#__PURE__*/ bindMap_(Functor)
 
 /**
  * @since 2.8.0

--- a/src/Reader.ts
+++ b/src/Reader.ts
@@ -45,7 +45,7 @@ import { bind as bind_, Chain2, chainFirst as chainFirst_ } from './Chain'
 import { Choice2 } from './Choice'
 import * as E from './Either'
 import { constant, flow, identity, pipe } from './function'
-import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
+import { let as let__, bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
 import * as _ from './internal'
 import { Monad2 } from './Monad'
 import { Monoid } from './Monoid'
@@ -494,10 +494,14 @@ export const Choice: Choice2<URI> = {
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
 
-/**
- * @since 2.13.0
- */
-export const bindMap = /*#__PURE__*/ bindMap_(Functor)
+const let_ = /*#__PURE__*/ let__(Functor)
+
+export {
+  /**
+   * @since 2.13.0
+   */
+  let_ as let
+}
 
 /**
  * @since 2.8.0

--- a/src/ReaderEither.ts
+++ b/src/ReaderEither.ts
@@ -43,7 +43,7 @@ import {
   fromReaderK as fromReaderK_
 } from './FromReader'
 import { flow, identity, Lazy, pipe, SK } from './function'
-import { bindTo as bindTo_, flap as flap_, Functor3 } from './Functor'
+import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor3 } from './Functor'
 import * as _ from './internal'
 import { Monad3, Monad3C } from './Monad'
 import { MonadThrow3, MonadThrow3C } from './MonadThrow'
@@ -935,6 +935,11 @@ export const Do: ReaderEither<unknown, never, {}> = /*#__PURE__*/ of(_.emptyReco
  * @since 2.8.0
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
+
+/**
+ * @since 2.13.0
+ */
+export const bindMap = /*#__PURE__*/ bindMap_(Functor)
 
 /**
  * @since 2.8.0

--- a/src/ReaderEither.ts
+++ b/src/ReaderEither.ts
@@ -43,7 +43,7 @@ import {
   fromReaderK as fromReaderK_
 } from './FromReader'
 import { flow, identity, Lazy, pipe, SK } from './function'
-import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor3 } from './Functor'
+import { let as let__, bindTo as bindTo_, flap as flap_, Functor3 } from './Functor'
 import * as _ from './internal'
 import { Monad3, Monad3C } from './Monad'
 import { MonadThrow3, MonadThrow3C } from './MonadThrow'
@@ -936,10 +936,14 @@ export const Do: ReaderEither<unknown, never, {}> = /*#__PURE__*/ of(_.emptyReco
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
 
-/**
- * @since 2.13.0
- */
-export const bindMap = /*#__PURE__*/ bindMap_(Functor)
+const let_ = /*#__PURE__*/ let__(Functor)
+
+export {
+  /**
+   * @since 2.13.0
+   */
+  let_ as let
+}
 
 /**
  * @since 2.8.0

--- a/src/ReaderTask.ts
+++ b/src/ReaderTask.ts
@@ -26,7 +26,7 @@ import {
   fromTaskK as fromTaskK_
 } from './FromTask'
 import { flow, identity, pipe, SK } from './function'
-import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
+import { let as let__, bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
 import * as _ from './internal'
 import { Monad2 } from './Monad'
 import { MonadIO2 } from './MonadIO'
@@ -529,10 +529,14 @@ export const Do: ReaderTask<unknown, {}> = /*#__PURE__*/ of(_.emptyRecord)
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
 
-/**
- * @since 2.13.0
- */
-export const bindMap = /*#__PURE__*/ bindMap_(Functor)
+const let_ = /*#__PURE__*/ let__(Functor)
+
+export {
+  /**
+   * @since 2.13.0
+   */
+  let_ as let
+}
 
 /**
  * @since 2.8.0

--- a/src/ReaderTask.ts
+++ b/src/ReaderTask.ts
@@ -26,7 +26,7 @@ import {
   fromTaskK as fromTaskK_
 } from './FromTask'
 import { flow, identity, pipe, SK } from './function'
-import { bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
+import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
 import * as _ from './internal'
 import { Monad2 } from './Monad'
 import { MonadIO2 } from './MonadIO'
@@ -528,6 +528,11 @@ export const Do: ReaderTask<unknown, {}> = /*#__PURE__*/ of(_.emptyRecord)
  * @since 2.8.0
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
+
+/**
+ * @since 2.13.0
+ */
+export const bindMap = /*#__PURE__*/ bindMap_(Functor)
 
 /**
  * @since 2.8.0

--- a/src/ReaderTaskEither.ts
+++ b/src/ReaderTaskEither.ts
@@ -51,7 +51,7 @@ import {
   fromTaskK as fromTaskK_
 } from './FromTask'
 import { flow, identity, Lazy, pipe, SK } from './function'
-import { bindTo as bindTo_, flap as flap_, Functor3 } from './Functor'
+import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor3 } from './Functor'
 import * as _ from './internal'
 import { IO } from './IO'
 import { IOEither, URI as IEURI } from './IOEither'
@@ -1405,6 +1405,11 @@ export const Do: ReaderTaskEither<unknown, never, {}> = /*#__PURE__*/ of(_.empty
  * @since 2.8.0
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
+
+/**
+ * @since 2.13.0
+ */
+export const bindMap = /*#__PURE__*/ bindMap_(Functor)
 
 /**
  * @since 2.8.0

--- a/src/ReaderTaskEither.ts
+++ b/src/ReaderTaskEither.ts
@@ -51,7 +51,7 @@ import {
   fromTaskK as fromTaskK_
 } from './FromTask'
 import { flow, identity, Lazy, pipe, SK } from './function'
-import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor3 } from './Functor'
+import { let as let__, bindTo as bindTo_, flap as flap_, Functor3 } from './Functor'
 import * as _ from './internal'
 import { IO } from './IO'
 import { IOEither, URI as IEURI } from './IOEither'
@@ -1406,10 +1406,14 @@ export const Do: ReaderTaskEither<unknown, never, {}> = /*#__PURE__*/ of(_.empty
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
 
-/**
- * @since 2.13.0
- */
-export const bindMap = /*#__PURE__*/ bindMap_(Functor)
+const let_ = /*#__PURE__*/ let__(Functor)
+
+export {
+  /**
+   * @since 2.13.0
+   */
+  let_ as let
+}
 
 /**
  * @since 2.8.0

--- a/src/ReadonlyArray.ts
+++ b/src/ReadonlyArray.ts
@@ -17,7 +17,7 @@ import { Foldable1 } from './Foldable'
 import { FoldableWithIndex1 } from './FoldableWithIndex'
 import { FromEither1, fromEitherK as fromEitherK_ } from './FromEither'
 import { identity, Lazy, pipe } from './function'
-import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
+import { let as let__, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import { FunctorWithIndex1 } from './FunctorWithIndex'
 import { HKT } from './HKT'
 import * as _ from './internal'
@@ -2560,10 +2560,14 @@ export const Do: ReadonlyArray<{}> = /*#__PURE__*/ of(_.emptyRecord)
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
 
-/**
- * @since 2.13.0
- */
-export const bindMap = /*#__PURE__*/ bindMap_(Functor)
+const let_ = /*#__PURE__*/ let__(Functor)
+
+export {
+  /**
+   * @since 2.13.0
+   */
+  let_ as let
+}
 
 /**
  * @since 2.8.0

--- a/src/ReadonlyArray.ts
+++ b/src/ReadonlyArray.ts
@@ -17,7 +17,7 @@ import { Foldable1 } from './Foldable'
 import { FoldableWithIndex1 } from './FoldableWithIndex'
 import { FromEither1, fromEitherK as fromEitherK_ } from './FromEither'
 import { identity, Lazy, pipe } from './function'
-import { bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
+import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import { FunctorWithIndex1 } from './FunctorWithIndex'
 import { HKT } from './HKT'
 import * as _ from './internal'
@@ -2559,6 +2559,11 @@ export const Do: ReadonlyArray<{}> = /*#__PURE__*/ of(_.emptyRecord)
  * @since 2.8.0
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
+
+/**
+ * @since 2.13.0
+ */
+export const bindMap = /*#__PURE__*/ bindMap_(Functor)
 
 /**
  * @since 2.8.0

--- a/src/ReadonlyNonEmptyArray.ts
+++ b/src/ReadonlyNonEmptyArray.ts
@@ -23,7 +23,7 @@ import { Extend1 } from './Extend'
 import { Foldable1 } from './Foldable'
 import { FoldableWithIndex1 } from './FoldableWithIndex'
 import { flow, identity, Lazy, pipe, SK } from './function'
-import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
+import { let as let__, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import { FunctorWithIndex1 } from './FunctorWithIndex'
 import { HKT } from './HKT'
 import * as _ from './internal'
@@ -1195,10 +1195,14 @@ export const Do: ReadonlyNonEmptyArray<{}> = /*#__PURE__*/ of(_.emptyRecord)
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
 
-/**
- * @since 2.13.0
- */
-export const bindMap = /*#__PURE__*/ bindMap_(Functor)
+const let_ = /*#__PURE__*/ let__(Functor)
+
+export {
+  /**
+   * @since 2.13.0
+   */
+  let_ as let
+}
 
 /**
  * @since 2.8.0

--- a/src/ReadonlyNonEmptyArray.ts
+++ b/src/ReadonlyNonEmptyArray.ts
@@ -23,7 +23,7 @@ import { Extend1 } from './Extend'
 import { Foldable1 } from './Foldable'
 import { FoldableWithIndex1 } from './FoldableWithIndex'
 import { flow, identity, Lazy, pipe, SK } from './function'
-import { bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
+import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import { FunctorWithIndex1 } from './FunctorWithIndex'
 import { HKT } from './HKT'
 import * as _ from './internal'
@@ -1194,6 +1194,11 @@ export const Do: ReadonlyNonEmptyArray<{}> = /*#__PURE__*/ of(_.emptyRecord)
  * @since 2.8.0
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
+
+/**
+ * @since 2.13.0
+ */
+export const bindMap = /*#__PURE__*/ bindMap_(Functor)
 
 /**
  * @since 2.8.0

--- a/src/State.ts
+++ b/src/State.ts
@@ -6,7 +6,7 @@ import { apFirst as apFirst_, Apply2, apS as apS_, apSecond as apSecond_ } from 
 import { bind as bind_, Chain2, chainFirst as chainFirst_ } from './Chain'
 import { FromState2 } from './FromState'
 import { identity, pipe } from './function'
-import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
+import { let as let__, bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
 import { Monad2 } from './Monad'
 import { NonEmptyArray } from './NonEmptyArray'
 import { Pointed2 } from './Pointed'
@@ -285,10 +285,14 @@ export const execute = <S>(s: S) => <A>(ma: State<S, A>): S => ma(s)[1]
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
 
-/**
- * @since 2.13.0
- */
-export const bindMap = /*#__PURE__*/ bindMap_(Functor)
+const let_ = /*#__PURE__*/ let__(Functor)
+
+export {
+  /**
+   * @since 2.13.0
+   */
+  let_ as let
+}
 
 /**
  * @since 2.8.0

--- a/src/State.ts
+++ b/src/State.ts
@@ -6,7 +6,7 @@ import { apFirst as apFirst_, Apply2, apS as apS_, apSecond as apSecond_ } from 
 import { bind as bind_, Chain2, chainFirst as chainFirst_ } from './Chain'
 import { FromState2 } from './FromState'
 import { identity, pipe } from './function'
-import { bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
+import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
 import { Monad2 } from './Monad'
 import { NonEmptyArray } from './NonEmptyArray'
 import { Pointed2 } from './Pointed'
@@ -284,6 +284,11 @@ export const execute = <S>(s: S) => <A>(ma: State<S, A>): S => ma(s)[1]
  * @since 2.8.0
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
+
+/**
+ * @since 2.13.0
+ */
+export const bindMap = /*#__PURE__*/ bindMap_(Functor)
 
 /**
  * @since 2.8.0

--- a/src/StateReaderTaskEither.ts
+++ b/src/StateReaderTaskEither.ts
@@ -44,7 +44,7 @@ import {
   fromTaskK as fromTaskK_
 } from './FromTask'
 import { flow, identity, Lazy, pipe } from './function'
-import { bindTo as bindTo_, flap as flap_, Functor4 } from './Functor'
+import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor4 } from './Functor'
 import * as _ from './internal'
 import { IO } from './IO'
 import { IOEither, URI as IEURI } from './IOEither'
@@ -1112,6 +1112,11 @@ export const execute: <S>(
  * @since 2.8.0
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
+
+/**
+ * @since 2.13.0
+ */
+export const bindMap = /*#__PURE__*/ bindMap_(Functor)
 
 /**
  * @since 2.8.0

--- a/src/StateReaderTaskEither.ts
+++ b/src/StateReaderTaskEither.ts
@@ -44,7 +44,7 @@ import {
   fromTaskK as fromTaskK_
 } from './FromTask'
 import { flow, identity, Lazy, pipe } from './function'
-import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor4 } from './Functor'
+import { let as let__, bindTo as bindTo_, flap as flap_, Functor4 } from './Functor'
 import * as _ from './internal'
 import { IO } from './IO'
 import { IOEither, URI as IEURI } from './IOEither'
@@ -1113,10 +1113,14 @@ export const execute: <S>(
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
 
-/**
- * @since 2.13.0
- */
-export const bindMap = /*#__PURE__*/ bindMap_(Functor)
+const let_ = /*#__PURE__*/ let__(Functor)
+
+export {
+  /**
+   * @since 2.13.0
+   */
+  let_ as let
+}
 
 /**
  * @since 2.8.0

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -22,7 +22,7 @@ import { bind as bind_, Chain1, chainFirst as chainFirst_ } from './Chain'
 import { chainFirstIOK as chainFirstIOK_, chainIOK as chainIOK_, FromIO1, fromIOK as fromIOK_ } from './FromIO'
 import { FromTask1 } from './FromTask'
 import { identity, pipe } from './function'
-import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
+import { let as let__, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import * as _ from './internal'
 import { Monad1 } from './Monad'
 import { MonadIO1 } from './MonadIO'
@@ -431,10 +431,14 @@ export const Do: Task<{}> = /*#__PURE__*/ of(_.emptyRecord)
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
 
-/**
- * @since 2.13.0
- */
-export const bindMap = /*#__PURE__*/ bindMap_(Functor)
+const let_ = /*#__PURE__*/ let__(Functor)
+
+export {
+  /**
+   * @since 2.13.0
+   */
+  let_ as let
+}
 
 /**
  * @since 2.8.0

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -22,7 +22,7 @@ import { bind as bind_, Chain1, chainFirst as chainFirst_ } from './Chain'
 import { chainFirstIOK as chainFirstIOK_, chainIOK as chainIOK_, FromIO1, fromIOK as fromIOK_ } from './FromIO'
 import { FromTask1 } from './FromTask'
 import { identity, pipe } from './function'
-import { bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
+import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import * as _ from './internal'
 import { Monad1 } from './Monad'
 import { MonadIO1 } from './MonadIO'
@@ -430,6 +430,11 @@ export const Do: Task<{}> = /*#__PURE__*/ of(_.emptyRecord)
  * @since 2.8.0
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
+
+/**
+ * @since 2.13.0
+ */
+export const bindMap = /*#__PURE__*/ bindMap_(Functor)
 
 /**
  * @since 2.8.0

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -50,7 +50,7 @@ import {
   fromTaskK as fromTaskK_
 } from './FromTask'
 import { flow, identity, Lazy, pipe, SK } from './function'
-import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
+import { let as let__, bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
 import * as _ from './internal'
 import { IO } from './IO'
 import { IOEither, URI as IEURI } from './IOEither'
@@ -1311,10 +1311,14 @@ export const Do: TaskEither<never, {}> = /*#__PURE__*/ of(_.emptyRecord)
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
 
-/**
- * @since 2.13.0
- */
-export const bindMap = /*#__PURE__*/ bindMap_(Functor)
+const let_ = /*#__PURE__*/ let__(Functor)
+
+export {
+  /**
+   * @since 2.13.0
+   */
+  let_ as let
+}
 
 /**
  * @since 2.8.0

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -50,7 +50,7 @@ import {
   fromTaskK as fromTaskK_
 } from './FromTask'
 import { flow, identity, Lazy, pipe, SK } from './function'
-import { bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
+import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
 import * as _ from './internal'
 import { IO } from './IO'
 import { IOEither, URI as IEURI } from './IOEither'
@@ -1310,6 +1310,11 @@ export const Do: TaskEither<never, {}> = /*#__PURE__*/ of(_.emptyRecord)
  * @since 2.8.0
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
+
+/**
+ * @since 2.13.0
+ */
+export const bindMap = /*#__PURE__*/ bindMap_(Functor)
 
 /**
  * @since 2.8.0

--- a/src/TaskOption.ts
+++ b/src/TaskOption.ts
@@ -29,7 +29,7 @@ import {
   fromTaskK as fromTaskK_
 } from './FromTask'
 import { flow, identity, Lazy, pipe, SK } from './function'
-import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
+import { let as let__, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import * as _ from './internal'
 import { Monad1 } from './Monad'
 import { MonadIO1 } from './MonadIO'
@@ -757,10 +757,14 @@ export const Do: TaskOption<{}> = /*#__PURE__*/ of(_.emptyRecord)
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
 
-/**
- * @since 2.13.0
- */
-export const bindMap = /*#__PURE__*/ bindMap_(Functor)
+const let_ = /*#__PURE__*/ let__(Functor)
+
+export {
+  /**
+   * @since 2.13.0
+   */
+  let_ as let
+}
 
 /**
  * @since 2.10.0

--- a/src/TaskOption.ts
+++ b/src/TaskOption.ts
@@ -29,7 +29,7 @@ import {
   fromTaskK as fromTaskK_
 } from './FromTask'
 import { flow, identity, Lazy, pipe, SK } from './function'
-import { bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
+import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import * as _ from './internal'
 import { Monad1 } from './Monad'
 import { MonadIO1 } from './MonadIO'
@@ -756,6 +756,11 @@ export const Do: TaskOption<{}> = /*#__PURE__*/ of(_.emptyRecord)
  * @since 2.10.0
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
+
+/**
+ * @since 2.13.0
+ */
+export const bindMap = /*#__PURE__*/ bindMap_(Functor)
 
 /**
  * @since 2.10.0

--- a/src/Tree.ts
+++ b/src/Tree.ts
@@ -16,7 +16,7 @@ import { Eq, fromEquals } from './Eq'
 import { Extend1 } from './Extend'
 import { Foldable1 } from './Foldable'
 import { identity, pipe } from './function'
-import { bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
+import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import { HKT, Kind, Kind2, Kind3, Kind4, URIS, URIS2, URIS3, URIS4 } from './HKT'
 import * as _ from './internal'
 import { Monad as MonadHKT, Monad1, Monad2, Monad2C, Monad3, Monad3C, Monad4 } from './Monad'
@@ -589,6 +589,11 @@ export const Do: Tree<{}> = /*#__PURE__*/ of(_.emptyRecord)
  * @since 2.8.0
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
+
+/**
+ * @since 2.13.0
+ */
+export const bindMap = /*#__PURE__*/ bindMap_(Functor)
 
 /**
  * @since 2.8.0

--- a/src/Tree.ts
+++ b/src/Tree.ts
@@ -16,7 +16,7 @@ import { Eq, fromEquals } from './Eq'
 import { Extend1 } from './Extend'
 import { Foldable1 } from './Foldable'
 import { identity, pipe } from './function'
-import { bindMap as bindMap_, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
+import { let as let__, bindTo as bindTo_, flap as flap_, Functor1 } from './Functor'
 import { HKT, Kind, Kind2, Kind3, Kind4, URIS, URIS2, URIS3, URIS4 } from './HKT'
 import * as _ from './internal'
 import { Monad as MonadHKT, Monad1, Monad2, Monad2C, Monad3, Monad3C, Monad4 } from './Monad'
@@ -590,10 +590,14 @@ export const Do: Tree<{}> = /*#__PURE__*/ of(_.emptyRecord)
  */
 export const bindTo = /*#__PURE__*/ bindTo_(Functor)
 
-/**
- * @since 2.13.0
- */
-export const bindMap = /*#__PURE__*/ bindMap_(Functor)
+const let_ = /*#__PURE__*/ let__(Functor)
+
+export {
+  /**
+   * @since 2.13.0
+   */
+  let_ as let
+}
 
 /**
  * @since 2.8.0

--- a/test/Either.ts
+++ b/test/Either.ts
@@ -584,9 +584,10 @@ describe('Either', () => {
       pipe(
         _.right<string, number>(1),
         _.bindTo('a'),
-        _.bind('b', () => _.right('b'))
+        _.bind('b', () => _.right('b')),
+        _.bindMap('c', ({ a, b }) => [a, b])
       ),
-      _.right({ a: 1, b: 'b' })
+      _.right({ a: 1, b: 'b', c: [1, 'b'] })
     )
   })
 

--- a/test/Either.ts
+++ b/test/Either.ts
@@ -585,7 +585,7 @@ describe('Either', () => {
         _.right<string, number>(1),
         _.bindTo('a'),
         _.bind('b', () => _.right('b')),
-        _.bindMap('c', ({ a, b }) => [a, b])
+        _.let('c', ({ a, b }) => [a, b])
       ),
       _.right({ a: 1, b: 'b', c: [1, 'b'] })
     )

--- a/test/IO.ts
+++ b/test/IO.ts
@@ -66,9 +66,10 @@ describe('IO', () => {
       pipe(
         _.of(1),
         _.bindTo('a'),
-        _.bind('b', () => _.of('b'))
+        _.bind('b', () => _.of('b')),
+        _.bindMap('c', ({ a, b }) => [a, b])
       )(),
-      { a: 1, b: 'b' }
+      { a: 1, b: 'b', c: [1, 'b'] }
     )
   })
 

--- a/test/IO.ts
+++ b/test/IO.ts
@@ -67,7 +67,7 @@ describe('IO', () => {
         _.of(1),
         _.bindTo('a'),
         _.bind('b', () => _.of('b')),
-        _.bindMap('c', ({ a, b }) => [a, b])
+        _.let('c', ({ a, b }) => [a, b])
       )(),
       { a: 1, b: 'b', c: [1, 'b'] }
     )

--- a/test/IOEither.ts
+++ b/test/IOEither.ts
@@ -493,9 +493,10 @@ describe('IOEither', () => {
       pipe(
         _.right<string, number>(1),
         _.bindTo('a'),
-        _.bind('b', () => _.right('b'))
+        _.bind('b', () => _.right('b')),
+        _.bindMap('c', ({ a, b }) => [a, b])
       )(),
-      E.right({ a: 1, b: 'b' })
+      E.right({ a: 1, b: 'b', c: [1, 'b'] })
     )
   })
 

--- a/test/IOEither.ts
+++ b/test/IOEither.ts
@@ -494,7 +494,7 @@ describe('IOEither', () => {
         _.right<string, number>(1),
         _.bindTo('a'),
         _.bind('b', () => _.right('b')),
-        _.bindMap('c', ({ a, b }) => [a, b])
+        _.let('c', ({ a, b }) => [a, b])
       )(),
       E.right({ a: 1, b: 'b', c: [1, 'b'] })
     )

--- a/test/Identity.ts
+++ b/test/Identity.ts
@@ -123,9 +123,10 @@ describe('Identity', () => {
       pipe(
         _.of(1),
         _.bindTo('a'),
-        _.bind('b', () => _.of('b'))
+        _.bind('b', () => _.of('b')),
+        _.bindMap('c', ({ a, b }) => [a, b])
       ),
-      { a: 1, b: 'b' }
+      { a: 1, b: 'b', c: [1, 'b'] }
     )
   })
 

--- a/test/Identity.ts
+++ b/test/Identity.ts
@@ -124,7 +124,7 @@ describe('Identity', () => {
         _.of(1),
         _.bindTo('a'),
         _.bind('b', () => _.of('b')),
-        _.bindMap('c', ({ a, b }) => [a, b])
+        _.let('c', ({ a, b }) => [a, b])
       ),
       { a: 1, b: 'b', c: [1, 'b'] }
     )

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -459,9 +459,10 @@ describe('Option', () => {
       pipe(
         _.some(1),
         _.bindTo('a'),
-        _.bind('b', () => _.some('b'))
+        _.bind('b', () => _.some('b')),
+        _.bindMap('c', ({ a, b }) => [a, b])
       ),
-      _.some({ a: 1, b: 'b' })
+      _.some({ a: 1, b: 'b', c: [1, 'b'] })
     )
   })
 

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -460,7 +460,7 @@ describe('Option', () => {
         _.some(1),
         _.bindTo('a'),
         _.bind('b', () => _.some('b')),
-        _.bindMap('c', ({ a, b }) => [a, b])
+        _.let('c', ({ a, b }) => [a, b])
       ),
       _.some({ a: 1, b: 'b', c: [1, 'b'] })
     )

--- a/test/Reader.ts
+++ b/test/Reader.ts
@@ -137,9 +137,10 @@ describe('Reader', () => {
       pipe(
         _.of(1),
         _.bindTo('a'),
-        _.bind('b', () => _.of('b'))
+        _.bind('b', () => _.of('b')),
+        _.bindMap('c', ({ a, b }) => [a, b])
       )(undefined),
-      { a: 1, b: 'b' }
+      { a: 1, b: 'b', c: [1, 'b'] }
     )
   })
 

--- a/test/Reader.ts
+++ b/test/Reader.ts
@@ -138,7 +138,7 @@ describe('Reader', () => {
         _.of(1),
         _.bindTo('a'),
         _.bind('b', () => _.of('b')),
-        _.bindMap('c', ({ a, b }) => [a, b])
+        _.let('c', ({ a, b }) => [a, b])
       )(undefined),
       { a: 1, b: 'b', c: [1, 'b'] }
     )

--- a/test/ReaderEither.ts
+++ b/test/ReaderEither.ts
@@ -264,7 +264,7 @@ describe('ReaderEither', () => {
         _.right<void, string, number>(1),
         _.bindTo('a'),
         _.bind('b', () => _.right('b')),
-        _.bindMap('c', ({ a, b }) => [a, b])
+        _.let('c', ({ a, b }) => [a, b])
       )(undefined),
       E.right({ a: 1, b: 'b', c: [1, 'b'] })
     )

--- a/test/ReaderEither.ts
+++ b/test/ReaderEither.ts
@@ -263,9 +263,10 @@ describe('ReaderEither', () => {
       pipe(
         _.right<void, string, number>(1),
         _.bindTo('a'),
-        _.bind('b', () => _.right('b'))
+        _.bind('b', () => _.right('b')),
+        _.bindMap('c', ({ a, b }) => [a, b])
       )(undefined),
-      E.right({ a: 1, b: 'b' })
+      E.right({ a: 1, b: 'b', c: [1, 'b'] })
     )
   })
 

--- a/test/ReaderTask.ts
+++ b/test/ReaderTask.ts
@@ -158,9 +158,10 @@ describe('ReaderTask', () => {
       await pipe(
         _.of(1),
         _.bindTo('a'),
-        _.bind('b', () => _.of('b'))
+        _.bind('b', () => _.of('b')),
+        _.bindMap('c', ({ a, b }) => [a, b])
       )(undefined)(),
-      { a: 1, b: 'b' }
+      { a: 1, b: 'b', c: [1, 'b'] }
     )
   })
 

--- a/test/ReaderTask.ts
+++ b/test/ReaderTask.ts
@@ -159,7 +159,7 @@ describe('ReaderTask', () => {
         _.of(1),
         _.bindTo('a'),
         _.bind('b', () => _.of('b')),
-        _.bindMap('c', ({ a, b }) => [a, b])
+        _.let('c', ({ a, b }) => [a, b])
       )(undefined)(),
       { a: 1, b: 'b', c: [1, 'b'] }
     )

--- a/test/ReaderTaskEither.ts
+++ b/test/ReaderTaskEither.ts
@@ -498,9 +498,10 @@ describe('ReaderTaskEither', () => {
       await pipe(
         _.right<void, string, number>(1),
         _.bindTo('a'),
-        _.bind('b', () => _.right('b'))
+        _.bind('b', () => _.right('b')),
+        _.bindMap('c', ({ a, b }) => [a, b])
       )(undefined)(),
-      E.right({ a: 1, b: 'b' })
+      E.right({ a: 1, b: 'b', c: [1, 'b'] })
     )
   })
 

--- a/test/ReaderTaskEither.ts
+++ b/test/ReaderTaskEither.ts
@@ -499,7 +499,7 @@ describe('ReaderTaskEither', () => {
         _.right<void, string, number>(1),
         _.bindTo('a'),
         _.bind('b', () => _.right('b')),
-        _.bindMap('c', ({ a, b }) => [a, b])
+        _.let('c', ({ a, b }) => [a, b])
       )(undefined)(),
       E.right({ a: 1, b: 'b', c: [1, 'b'] })
     )

--- a/test/ReadonlyArray.ts
+++ b/test/ReadonlyArray.ts
@@ -1223,7 +1223,7 @@ describe('ReadonlyArray', () => {
         _.of(1),
         _.bindTo('a'),
         _.bind('b', () => _.of('b')),
-        _.bindMap('c', ({ a, b }) => [a, b])
+        _.let('c', ({ a, b }) => [a, b])
       ),
       [{ a: 1, b: 'b', c: [1, 'b'] }]
     )

--- a/test/ReadonlyArray.ts
+++ b/test/ReadonlyArray.ts
@@ -1222,9 +1222,10 @@ describe('ReadonlyArray', () => {
       pipe(
         _.of(1),
         _.bindTo('a'),
-        _.bind('b', () => _.of('b'))
+        _.bind('b', () => _.of('b')),
+        _.bindMap('c', ({ a, b }) => [a, b])
       ),
-      [{ a: 1, b: 'b' }]
+      [{ a: 1, b: 'b', c: [1, 'b'] }]
     )
   })
 

--- a/test/ReadonlyNonEmptyArray.ts
+++ b/test/ReadonlyNonEmptyArray.ts
@@ -408,7 +408,7 @@ describe('ReadonlyNonEmptyArray', () => {
         _.of(1),
         _.bindTo('a'),
         _.bind('b', () => _.of('b')),
-        _.bindMap('c', ({ a, b }) => [a, b])
+        _.let('c', ({ a, b }) => [a, b])
       ),
       [{ a: 1, b: 'b', c: [1, 'b'] }]
     )

--- a/test/ReadonlyNonEmptyArray.ts
+++ b/test/ReadonlyNonEmptyArray.ts
@@ -407,9 +407,10 @@ describe('ReadonlyNonEmptyArray', () => {
       pipe(
         _.of(1),
         _.bindTo('a'),
-        _.bind('b', () => _.of('b'))
+        _.bind('b', () => _.of('b')),
+        _.bindMap('c', ({ a, b }) => [a, b])
       ),
-      [{ a: 1, b: 'b' }]
+      [{ a: 1, b: 'b', c: [1, 'b'] }]
     )
   })
 

--- a/test/State.ts
+++ b/test/State.ts
@@ -77,9 +77,10 @@ describe('State', () => {
       pipe(
         _.of(1),
         _.bindTo('a'),
-        _.bind('b', () => _.of('b'))
+        _.bind('b', () => _.of('b')),
+        _.bindMap('c', ({ a, b }) => [a, b])
       )('state'),
-      [{ a: 1, b: 'b' }, 'state']
+      [{ a: 1, b: 'b', c: [1, 'b'] }, 'state']
     )
   })
 

--- a/test/State.ts
+++ b/test/State.ts
@@ -78,7 +78,7 @@ describe('State', () => {
         _.of(1),
         _.bindTo('a'),
         _.bind('b', () => _.of('b')),
-        _.bindMap('c', ({ a, b }) => [a, b])
+        _.let('c', ({ a, b }) => [a, b])
       )('state'),
       [{ a: 1, b: 'b', c: [1, 'b'] }, 'state']
     )

--- a/test/StateReaderTaskEither.ts
+++ b/test/StateReaderTaskEither.ts
@@ -344,7 +344,7 @@ describe('StateReaderTaskEither', () => {
         _.right<void, void, string, number>(1),
         _.bindTo('a'),
         _.bind('b', () => _.right('b')),
-        _.bindMap('c', ({ a, b }) => [a, b])
+        _.let('c', ({ a, b }) => [a, b])
       )(undefined)(undefined)(),
       E.right([{ a: 1, b: 'b', c: [1, 'b'] }, undefined])
     )

--- a/test/StateReaderTaskEither.ts
+++ b/test/StateReaderTaskEither.ts
@@ -343,9 +343,10 @@ describe('StateReaderTaskEither', () => {
       await pipe(
         _.right<void, void, string, number>(1),
         _.bindTo('a'),
-        _.bind('b', () => _.right('b'))
+        _.bind('b', () => _.right('b')),
+        _.bindMap('c', ({ a, b }) => [a, b])
       )(undefined)(undefined)(),
-      E.right([{ a: 1, b: 'b' }, undefined])
+      E.right([{ a: 1, b: 'b', c: [1, 'b'] }, undefined])
     )
   })
 

--- a/test/Task.ts
+++ b/test/Task.ts
@@ -165,7 +165,7 @@ describe('Task', () => {
         _.of(1),
         _.bindTo('a'),
         _.bind('b', () => _.of('b')),
-        _.bindMap('c', ({ a, b }) => [a, b])
+        _.let('c', ({ a, b }) => [a, b])
       )(),
       { a: 1, b: 'b', c: [1, 'b'] }
     )

--- a/test/Task.ts
+++ b/test/Task.ts
@@ -164,9 +164,10 @@ describe('Task', () => {
       await pipe(
         _.of(1),
         _.bindTo('a'),
-        _.bind('b', () => _.of('b'))
+        _.bind('b', () => _.of('b')),
+        _.bindMap('c', ({ a, b }) => [a, b])
       )(),
-      { a: 1, b: 'b' }
+      { a: 1, b: 'b', c: [1, 'b'] }
     )
   })
 

--- a/test/TaskEither.ts
+++ b/test/TaskEither.ts
@@ -616,9 +616,10 @@ describe('TaskEither', () => {
       await pipe(
         _.right<string, number>(1),
         _.bindTo('a'),
-        _.bind('b', () => _.right('b'))
+        _.bind('b', () => _.right('b')),
+        _.bindMap('c', ({ a, b }) => [a, b])
       )(),
-      E.right({ a: 1, b: 'b' })
+      E.right({ a: 1, b: 'b', c: [1, 'b'] })
     )
   })
 

--- a/test/TaskEither.ts
+++ b/test/TaskEither.ts
@@ -617,7 +617,7 @@ describe('TaskEither', () => {
         _.right<string, number>(1),
         _.bindTo('a'),
         _.bind('b', () => _.right('b')),
-        _.bindMap('c', ({ a, b }) => [a, b])
+        _.let('c', ({ a, b }) => [a, b])
       )(),
       E.right({ a: 1, b: 'b', c: [1, 'b'] })
     )

--- a/test/Tree.ts
+++ b/test/Tree.ts
@@ -198,9 +198,10 @@ describe('Tree', () => {
       pipe(
         _.of(1),
         _.bindTo('a'),
-        _.bind('b', () => _.of('b'))
+        _.bind('b', () => _.of('b')),
+        _.bindMap('c', ({ a, b }) => [a, b])
       ),
-      _.make({ a: 1, b: 'b' })
+      _.make({ a: 1, b: 'b', c: [1, 'b'] })
     )
   })
 

--- a/test/Tree.ts
+++ b/test/Tree.ts
@@ -199,7 +199,7 @@ describe('Tree', () => {
         _.of(1),
         _.bindTo('a'),
         _.bind('b', () => _.of('b')),
-        _.bindMap('c', ({ a, b }) => [a, b])
+        _.let('c', ({ a, b }) => [a, b])
       ),
       _.make({ a: 1, b: 'b', c: [1, 'b'] })
     )


### PR DESCRIPTION
Hello 👋 

I took the liberty to create a new function on the `Functor` typeclass to help with introducing new values in do-notation context while leveraging pure computations that depend on said context.

ie. I needed to do something akin to this (example greatly simplified from my original genuine use-case):
```ts
pipe(
  option.Do,
  option.apS('x', some(42)),
  option.apS('y', some(1337)),
  option.bind('z', ({ x, y }) => option.of(x * y)),
); // => Option<{ x: number; y: number; z: number }>
```

Another way to achieve the same result would be to just use `option.map` at the last step:
```ts
pipe(
  option.Do,
  option.apS('x', some(42)),
  option.apS('y', some(1337)),
  option.map(factors => ({
    z: factors.x * factors*y,
    ...factors,
  })),
); // => Option<{ x: number; y: number; z: number }>
```

I find both these solutions unsatisfying so I introduced the `bindMap` function on `Functor` specifically for those use-cases. It is to `map` what `bind` is to `chain` and `apS` is to `ap`.

With this, we can rewrite the example above as such (getting rid of the `option.of` or the recreation of the context object):
 ```ts
pipe(
  option.Do,
  option.apS('x', some(42)),
  option.apS('y', some(1337)),
  option.bindMap('z', ({ x, y }) => x * y),
); // => Option<{ x: number; y: number; z: number }>
```

I hope this can be of use to others as well. I'm not too fond of the name `bindMap` but it's the best I could think of. I kinda liked `let` but as a reserved keyword in TS it was a no-go.