### PR TITLE
Applicative4 added to Record traverse

### DIFF
--- a/docs/modules/ReadonlyRecord.ts.md
+++ b/docs/modules/ReadonlyRecord.ts.md
@@ -1888,6 +1888,11 @@ Added in v2.5.0
 **Signature**
 
 ```ts
+export declare function traverse<F extends URIS4>(
+  F: Applicative4<F>
+): <K extends string, S, R, E, A, B>(
+  f: (a: A) => Kind4<F, S, R, E, B>
+) => (ta: Record<K, A>) => Kind4<F, S, R, E, Record<K, B>>
 export declare function traverse<F extends URIS3>(
   F: Applicative3<F>
 ): <R, E, A, B>(
@@ -1923,6 +1928,11 @@ Added in v2.5.0
 **Signature**
 
 ```ts
+export declare function traverseWithIndex<F extends URIS4>(
+  F: Applicative4<F>
+): <K extends string, S, R, E, A, B>(
+  f: (k: K, a: A) => Kind4<F, S, R, E, B>
+) => (ta: Record<K, A>) => Kind4<F, S, R, E, Record<K, B>>
 export declare function traverseWithIndex<F extends URIS3>(
   F: Applicative3<F>
 ): <K extends string, R, E, A, B>(

--- a/docs/modules/ReadonlyRecord.ts.md
+++ b/docs/modules/ReadonlyRecord.ts.md
@@ -1890,9 +1890,9 @@ Added in v2.5.0
 ```ts
 export declare function traverse<F extends URIS4>(
   F: Applicative4<F>
-): <K extends string, S, R, E, A, B>(
+): <S, R, E, A, B>(
   f: (a: A) => Kind4<F, S, R, E, B>
-) => (ta: Record<K, A>) => Kind4<F, S, R, E, Record<K, B>>
+) => <K extends string>(ta: ReadonlyRecord<K, A>) => Kind4<F, S, R, E, ReadonlyRecord<K, B>>
 export declare function traverse<F extends URIS3>(
   F: Applicative3<F>
 ): <R, E, A, B>(
@@ -1932,7 +1932,7 @@ export declare function traverseWithIndex<F extends URIS4>(
   F: Applicative4<F>
 ): <K extends string, S, R, E, A, B>(
   f: (k: K, a: A) => Kind4<F, S, R, E, B>
-) => (ta: Record<K, A>) => Kind4<F, S, R, E, Record<K, B>>
+) => (ta: ReadonlyRecord<K, A>) => Kind4<F, S, R, E, ReadonlyRecord<K, B>>
 export declare function traverseWithIndex<F extends URIS3>(
   F: Applicative3<F>
 ): <K extends string, R, E, A, B>(

--- a/docs/modules/Record.ts.md
+++ b/docs/modules/Record.ts.md
@@ -1783,6 +1783,11 @@ Added in v2.0.0
 **Signature**
 
 ```ts
+export declare function traverse<F extends URIS4>(
+  F: Applicative4<F>
+): <K extends string, S, R, E, A, B>(
+  f: (a: A) => Kind4<F, S, R, E, B>
+) => (ta: Record<K, A>) => Kind4<F, S, R, E, Record<K, B>>
 export declare function traverse<F extends URIS3>(
   F: Applicative3<F>
 ): <R, E, A, B>(f: (a: A) => Kind3<F, R, E, B>) => <K extends string>(ta: Record<K, A>) => Kind3<F, R, E, Record<K, B>>
@@ -1810,6 +1815,11 @@ Added in v2.0.0
 **Signature**
 
 ```ts
+export declare function traverseWithIndex<F extends URIS4>(
+  F: Applicative4<F>
+): <K extends string, S, R, E, A, B>(
+  f: (k: K, a: A) => Kind4<F, S, R, E, B>
+) => (ta: Record<K, A>) => Kind4<F, S, R, E, Record<K, B>>
 export declare function traverseWithIndex<F extends URIS3>(
   F: Applicative3<F>
 ): <K extends string, R, E, A, B>(

--- a/docs/modules/Record.ts.md
+++ b/docs/modules/Record.ts.md
@@ -1785,9 +1785,9 @@ Added in v2.0.0
 ```ts
 export declare function traverse<F extends URIS4>(
   F: Applicative4<F>
-): <K extends string, S, R, E, A, B>(
+): <S, R, E, A, B>(
   f: (a: A) => Kind4<F, S, R, E, B>
-) => (ta: Record<K, A>) => Kind4<F, S, R, E, Record<K, B>>
+) => <K extends string>(ta: Record<K, A>) => Kind4<F, S, R, E, Record<K, B>>
 export declare function traverse<F extends URIS3>(
   F: Applicative3<F>
 ): <R, E, A, B>(f: (a: A) => Kind3<F, R, E, B>) => <K extends string>(ta: Record<K, A>) => Kind3<F, R, E, Record<K, B>>

--- a/src/ReadonlyRecord.ts
+++ b/src/ReadonlyRecord.ts
@@ -6,7 +6,15 @@
  *
  * @since 2.5.0
  */
-import { Applicative, Applicative1, Applicative2, Applicative2C, Applicative3, Applicative3C } from './Applicative'
+import {
+  Applicative,
+  Applicative1,
+  Applicative2,
+  Applicative2C,
+  Applicative3,
+  Applicative3C,
+  Applicative4
+} from './Applicative'
 import { Compactable1 } from './Compactable'
 import { Either } from './Either'
 import { Eq, fromEquals } from './Eq'
@@ -17,7 +25,7 @@ import { FoldableWithIndex1 } from './FoldableWithIndex'
 import { flow, identity, pipe, SK } from './function'
 import { flap as flap_, Functor1 } from './Functor'
 import { FunctorWithIndex1 } from './FunctorWithIndex'
-import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3 } from './HKT'
+import { HKT, Kind, Kind2, Kind3, Kind4, URIS, URIS2, URIS3, URIS4 } from './HKT'
 import * as _ from './internal'
 import { Magma } from './Magma'
 import { Monoid } from './Monoid'
@@ -663,6 +671,11 @@ export const singleton = <A>(k: string, a: A): ReadonlyRecord<string, A> => ({ [
 /**
  * @since 2.5.0
  */
+export function traverseWithIndex<F extends URIS4>(
+  F: Applicative4<F>
+): <K extends string, S, R, E, A, B>(
+  f: (k: K, a: A) => Kind4<F, S, R, E, B>
+) => (ta: Record<K, A>) => Kind4<F, S, R, E, Record<K, B>>
 export function traverseWithIndex<F extends URIS3>(
   F: Applicative3<F>
 ): <K extends string, R, E, A, B>(
@@ -701,6 +714,11 @@ export function traverseWithIndex<F>(
 /**
  * @since 2.5.0
  */
+export function traverse<F extends URIS4>(
+  F: Applicative4<F>
+): <K extends string, S, R, E, A, B>(
+  f: (a: A) => Kind4<F, S, R, E, B>
+) => (ta: Record<K, A>) => Kind4<F, S, R, E, Record<K, B>>
 export function traverse<F extends URIS3>(
   F: Applicative3<F>
 ): <R, E, A, B>(

--- a/src/ReadonlyRecord.ts
+++ b/src/ReadonlyRecord.ts
@@ -675,7 +675,7 @@ export function traverseWithIndex<F extends URIS4>(
   F: Applicative4<F>
 ): <K extends string, S, R, E, A, B>(
   f: (k: K, a: A) => Kind4<F, S, R, E, B>
-) => (ta: Record<K, A>) => Kind4<F, S, R, E, Record<K, B>>
+) => (ta: ReadonlyRecord<K, A>) => Kind4<F, S, R, E, ReadonlyRecord<K, B>>
 export function traverseWithIndex<F extends URIS3>(
   F: Applicative3<F>
 ): <K extends string, R, E, A, B>(
@@ -716,9 +716,9 @@ export function traverseWithIndex<F>(
  */
 export function traverse<F extends URIS4>(
   F: Applicative4<F>
-): <K extends string, S, R, E, A, B>(
+): <S, R, E, A, B>(
   f: (a: A) => Kind4<F, S, R, E, B>
-) => (ta: Record<K, A>) => Kind4<F, S, R, E, Record<K, B>>
+) => <K extends string>(ta: ReadonlyRecord<K, A>) => Kind4<F, S, R, E, ReadonlyRecord<K, B>>
 export function traverse<F extends URIS3>(
   F: Applicative3<F>
 ): <R, E, A, B>(

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -4,7 +4,15 @@
  *
  * @since 2.0.0
  */
-import { Applicative, Applicative1, Applicative2, Applicative2C, Applicative3, Applicative3C } from './Applicative'
+import {
+  Applicative,
+  Applicative1,
+  Applicative2,
+  Applicative2C,
+  Applicative3,
+  Applicative3C,
+  Applicative4
+} from './Applicative'
 import * as A from './Array'
 import { Compactable1 } from './Compactable'
 import { Either } from './Either'
@@ -16,7 +24,7 @@ import { FoldableWithIndex1 } from './FoldableWithIndex'
 import { pipe } from './function'
 import { flap as flap_, Functor1 } from './Functor'
 import { FunctorWithIndex1 } from './FunctorWithIndex'
-import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3 } from './HKT'
+import { HKT, Kind, Kind2, Kind3, Kind4, URIS, URIS2, URIS3, URIS4 } from './HKT'
 import * as _ from './internal'
 import { Magma } from './Magma'
 import { Monoid } from './Monoid'
@@ -500,6 +508,11 @@ export const singleton: <A>(k: string, a: A) => Record<string, A> = RR.singleton
 /**
  * @since 2.0.0
  */
+export function traverseWithIndex<F extends URIS4>(
+  F: Applicative4<F>
+): <K extends string, S, R, E, A, B>(
+  f: (k: K, a: A) => Kind4<F, S, R, E, B>
+) => (ta: Record<K, A>) => Kind4<F, S, R, E, Record<K, B>>
 export function traverseWithIndex<F extends URIS3>(
   F: Applicative3<F>
 ): <K extends string, R, E, A, B>(
@@ -531,6 +544,11 @@ export function traverseWithIndex<F>(
 /**
  * @since 2.0.0
  */
+export function traverse<F extends URIS4>(
+  F: Applicative4<F>
+): <K extends string, S, R, E, A, B>(
+  f: (a: A) => Kind4<F, S, R, E, B>
+) => (ta: Record<K, A>) => Kind4<F, S, R, E, Record<K, B>>
 export function traverse<F extends URIS3>(
   F: Applicative3<F>
 ): <R, E, A, B>(f: (a: A) => Kind3<F, R, E, B>) => <K extends string>(ta: Record<K, A>) => Kind3<F, R, E, Record<K, B>>

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -546,9 +546,9 @@ export function traverseWithIndex<F>(
  */
 export function traverse<F extends URIS4>(
   F: Applicative4<F>
-): <K extends string, S, R, E, A, B>(
+): <S, R, E, A, B>(
   f: (a: A) => Kind4<F, S, R, E, B>
-) => (ta: Record<K, A>) => Kind4<F, S, R, E, Record<K, B>>
+) => <K extends string>(ta: Record<K, A>) => Kind4<F, S, R, E, Record<K, B>>
 export function traverse<F extends URIS3>(
   F: Applicative3<F>
 ): <R, E, A, B>(f: (a: A) => Kind3<F, R, E, B>) => <K extends string>(ta: Record<K, A>) => Kind3<F, R, E, Record<K, B>>


### PR DESCRIPTION
This allows the usage for `Record#traverse` with `StateReaderTaskEither` or `hyper-ts/ReaderMiddleware`.