### PR TITLE
Add `ReaderIO`

### DIFF
--- a/docs/modules/ReaderIO.ts.md
+++ b/docs/modules/ReaderIO.ts.md
@@ -1,0 +1,703 @@
+---
+title: ReaderIO.ts
+nav_order: 80
+parent: Modules
+---
+
+## ReaderIO overview
+
+Added in v2.13.0
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [Apply](#apply)
+  - [ap](#ap)
+  - [apW](#apw)
+- [Functor](#functor)
+  - [map](#map)
+- [Monad](#monad)
+  - [chain](#chain)
+  - [chainW](#chainw)
+- [Pointed](#pointed)
+  - [of](#of)
+- [combinators](#combinators)
+  - [apFirst](#apfirst)
+  - [apSecond](#apsecond)
+  - [asksReaderIO](#asksreaderio)
+  - [asksReaderIOW](#asksreaderiow)
+  - [chainFirst](#chainfirst)
+  - [chainFirstIOK](#chainfirstiok)
+  - [chainFirstReaderK](#chainfirstreaderk)
+  - [chainFirstReaderKW](#chainfirstreaderkw)
+  - [chainFirstW](#chainfirstw)
+  - [chainIOK](#chainiok)
+  - [chainReaderK](#chainreaderk)
+  - [chainReaderKW](#chainreaderkw)
+  - [flap](#flap)
+  - [flatten](#flatten)
+  - [flattenW](#flattenw)
+  - [fromIOK](#fromiok)
+  - [fromReaderK](#fromreaderk)
+  - [local](#local)
+- [constructors](#constructors)
+  - [ask](#ask)
+  - [asks](#asks)
+- [instances](#instances)
+  - [Applicative](#applicative)
+  - [Apply](#apply-1)
+  - [Chain](#chain)
+  - [FromIO](#fromio)
+  - [FromReader](#fromreader)
+  - [Functor](#functor-1)
+  - [Monad](#monad-1)
+  - [MonadIO](#monadio)
+  - [Pointed](#pointed-1)
+  - [URI](#uri)
+  - [URI (type alias)](#uri-type-alias)
+- [model](#model)
+  - [ReaderIO (interface)](#readerio-interface)
+- [natural transformations](#natural-transformations)
+  - [fromIO](#fromio)
+  - [fromReader](#fromreader)
+- [utils](#utils)
+  - [ApT](#apt)
+  - [Do](#do)
+  - [apS](#aps)
+  - [apSW](#apsw)
+  - [bind](#bind)
+  - [bindTo](#bindto)
+  - [bindW](#bindw)
+  - [sequenceArray](#sequencearray)
+  - [traverseArray](#traversearray)
+  - [traverseArrayWithIndex](#traversearraywithindex)
+  - [traverseReadonlyArrayWithIndex](#traversereadonlyarraywithindex)
+  - [traverseReadonlyNonEmptyArrayWithIndex](#traversereadonlynonemptyarraywithindex)
+
+---
+
+# Apply
+
+## ap
+
+Apply a function to an argument under a type constructor.
+
+**Signature**
+
+```ts
+export declare const ap: <R, A>(fa: ReaderIO<R, A>) => <B>(fab: ReaderIO<R, (a: A) => B>) => ReaderIO<R, B>
+```
+
+Added in v2.13.0
+
+## apW
+
+Less strict version of [`ap`](#ap).
+
+**Signature**
+
+```ts
+export declare const apW: <R2, A>(
+  fa: ReaderIO<R2, A>
+) => <R1, B>(fab: ReaderIO<R1, (a: A) => B>) => ReaderIO<R1 & R2, B>
+```
+
+Added in v2.13.0
+
+# Functor
+
+## map
+
+`map` can be used to turn functions `(a: A) => B` into functions `(fa: F<A>) => F<B>` whose argument and return types
+use the type constructor `F` to represent some computational context.
+
+**Signature**
+
+```ts
+export declare const map: <A, B>(f: (a: A) => B) => <R>(fa: ReaderIO<R, A>) => ReaderIO<R, B>
+```
+
+Added in v2.13.0
+
+# Monad
+
+## chain
+
+Composes computations in sequence, using the return value of one computation to determine the next computation.
+
+**Signature**
+
+```ts
+export declare const chain: <A, R, B>(f: (a: A) => ReaderIO<R, B>) => (ma: ReaderIO<R, A>) => ReaderIO<R, B>
+```
+
+Added in v2.13.0
+
+## chainW
+
+Less strict version of [`chain`](#chain).
+
+**Signature**
+
+```ts
+export declare const chainW: <R2, A, B>(
+  f: (a: A) => ReaderIO<R2, B>
+) => <R1>(ma: ReaderIO<R1, A>) => ReaderIO<R1 & R2, B>
+```
+
+Added in v2.13.0
+
+# Pointed
+
+## of
+
+**Signature**
+
+```ts
+export declare const of: <E, A>(a: A) => ReaderIO<E, A>
+```
+
+Added in v2.13.0
+
+# combinators
+
+## apFirst
+
+Combine two effectful actions, keeping only the result of the first.
+
+Derivable from `Apply`.
+
+**Signature**
+
+```ts
+export declare const apFirst: <E, B>(second: ReaderIO<E, B>) => <A>(first: ReaderIO<E, A>) => ReaderIO<E, A>
+```
+
+Added in v2.13.0
+
+## apSecond
+
+Combine two effectful actions, keeping only the result of the second.
+
+Derivable from `Apply`.
+
+**Signature**
+
+```ts
+export declare const apSecond: <E, B>(second: ReaderIO<E, B>) => <A>(first: ReaderIO<E, A>) => ReaderIO<E, B>
+```
+
+Added in v2.13.0
+
+## asksReaderIO
+
+Effectfully accesses the environment.
+
+**Signature**
+
+```ts
+export declare const asksReaderIO: <R, A>(f: (r: R) => ReaderIO<R, A>) => ReaderIO<R, A>
+```
+
+Added in v2.13.0
+
+## asksReaderIOW
+
+Less strict version of [`asksReaderTask`](#asksreadertask).
+
+**Signature**
+
+```ts
+export declare const asksReaderIOW: <R1, R2, A>(f: (r1: R1) => ReaderIO<R2, A>) => ReaderIO<R1 & R2, A>
+```
+
+Added in v2.13.0
+
+## chainFirst
+
+Composes computations in sequence, using the return value of one computation to determine the next computation and
+keeping only the result of the first.
+
+Derivable from `Chain`.
+
+**Signature**
+
+```ts
+export declare const chainFirst: <A, E, B>(f: (a: A) => ReaderIO<E, B>) => (first: ReaderIO<E, A>) => ReaderIO<E, A>
+```
+
+Added in v2.13.0
+
+## chainFirstIOK
+
+**Signature**
+
+```ts
+export declare const chainFirstIOK: <A, B>(f: (a: A) => I.IO<B>) => <E>(first: ReaderIO<E, A>) => ReaderIO<E, A>
+```
+
+Added in v2.13.0
+
+## chainFirstReaderK
+
+**Signature**
+
+```ts
+export declare const chainFirstReaderK: <A, R, B>(f: (a: A) => R.Reader<R, B>) => (ma: ReaderIO<R, A>) => ReaderIO<R, A>
+```
+
+Added in v2.13.0
+
+## chainFirstReaderKW
+
+Less strict version of [`chainFirstReaderK`](#chainfirstreaderk).
+
+**Signature**
+
+```ts
+export declare const chainFirstReaderKW: <A, R1, B>(
+  f: (a: A) => R.Reader<R1, B>
+) => <R2>(ma: ReaderIO<R2, A>) => ReaderIO<R1 & R2, A>
+```
+
+Added in v2.13.0
+
+## chainFirstW
+
+Less strict version of [`chainFirst`](#chainfirst).
+
+Derivable from `Chain`.
+
+**Signature**
+
+```ts
+export declare const chainFirstW: <R2, A, B>(
+  f: (a: A) => ReaderIO<R2, B>
+) => <R1>(ma: ReaderIO<R1, A>) => ReaderIO<R1 & R2, A>
+```
+
+Added in v2.13.0
+
+## chainIOK
+
+**Signature**
+
+```ts
+export declare const chainIOK: <A, B>(f: (a: A) => I.IO<B>) => <E>(first: ReaderIO<E, A>) => ReaderIO<E, B>
+```
+
+Added in v2.13.0
+
+## chainReaderK
+
+**Signature**
+
+```ts
+export declare const chainReaderK: <A, R, B>(f: (a: A) => R.Reader<R, B>) => (ma: ReaderIO<R, A>) => ReaderIO<R, B>
+```
+
+Added in v2.13.0
+
+## chainReaderKW
+
+Less strict version of [`chainReaderK`](#chainreaderk).
+
+**Signature**
+
+```ts
+export declare const chainReaderKW: <A, R1, B>(
+  f: (a: A) => R.Reader<R1, B>
+) => <R2>(ma: ReaderIO<R2, A>) => ReaderIO<R1 & R2, B>
+```
+
+Added in v2.13.0
+
+## flap
+
+Derivable from `Functor`.
+
+**Signature**
+
+```ts
+export declare const flap: <A>(a: A) => <E, B>(fab: ReaderIO<E, (a: A) => B>) => ReaderIO<E, B>
+```
+
+Added in v2.13.0
+
+## flatten
+
+Derivable from `Chain`.
+
+**Signature**
+
+```ts
+export declare const flatten: <R, A>(mma: ReaderIO<R, ReaderIO<R, A>>) => ReaderIO<R, A>
+```
+
+Added in v2.13.0
+
+## flattenW
+
+Less strict version of [`flatten`](#flatten).
+
+**Signature**
+
+```ts
+export declare const flattenW: <R1, R2, A>(mma: ReaderIO<R1, ReaderIO<R2, A>>) => ReaderIO<R1 & R2, A>
+```
+
+Added in v2.13.0
+
+## fromIOK
+
+**Signature**
+
+```ts
+export declare const fromIOK: <A, B>(f: (...a: A) => I.IO<B>) => <E>(...a: A) => ReaderIO<E, B>
+```
+
+Added in v2.13.0
+
+## fromReaderK
+
+**Signature**
+
+```ts
+export declare const fromReaderK: <A, R, B>(f: (...a: A) => R.Reader<R, B>) => (...a: A) => ReaderIO<R, B>
+```
+
+Added in v2.13.0
+
+## local
+
+Changes the value of the local context during the execution of the action `ma` (similar to `Contravariant`'s
+`contramap`).
+
+**Signature**
+
+```ts
+export declare const local: <R2, R1>(f: (r2: R2) => R1) => <A>(ma: ReaderIO<R1, A>) => ReaderIO<R2, A>
+```
+
+Added in v2.13.0
+
+# constructors
+
+## ask
+
+Reads the current context.
+
+**Signature**
+
+```ts
+export declare const ask: <R>() => ReaderIO<R, R>
+```
+
+Added in v2.13.0
+
+## asks
+
+Projects a value from the global context in a `ReaderTask`.
+
+**Signature**
+
+```ts
+export declare const asks: <R, A>(f: (r: R) => A) => ReaderIO<R, A>
+```
+
+Added in v2.13.0
+
+# instances
+
+## Applicative
+
+**Signature**
+
+```ts
+export declare const Applicative: Applicative2<'ReaderIO'>
+```
+
+Added in v2.13.0
+
+## Apply
+
+**Signature**
+
+```ts
+export declare const Apply: Apply2<'ReaderIO'>
+```
+
+Added in v2.13.0
+
+## Chain
+
+**Signature**
+
+```ts
+export declare const Chain: Chain2<'ReaderIO'>
+```
+
+Added in v2.13.0
+
+## FromIO
+
+**Signature**
+
+```ts
+export declare const FromIO: FromIO2<'ReaderIO'>
+```
+
+Added in v2.13.0
+
+## FromReader
+
+**Signature**
+
+```ts
+export declare const FromReader: FromReader2<'ReaderIO'>
+```
+
+Added in v2.13.0
+
+## Functor
+
+**Signature**
+
+```ts
+export declare const Functor: Functor2<'ReaderIO'>
+```
+
+Added in v2.13.0
+
+## Monad
+
+**Signature**
+
+```ts
+export declare const Monad: Monad2<'ReaderIO'>
+```
+
+Added in v2.13.0
+
+## MonadIO
+
+**Signature**
+
+```ts
+export declare const MonadIO: MonadIO2<'ReaderIO'>
+```
+
+Added in v2.13.0
+
+## Pointed
+
+**Signature**
+
+```ts
+export declare const Pointed: Pointed2<'ReaderIO'>
+```
+
+Added in v2.13.0
+
+## URI
+
+**Signature**
+
+```ts
+export declare const URI: 'ReaderIO'
+```
+
+Added in v2.13.0
+
+## URI (type alias)
+
+**Signature**
+
+```ts
+export type URI = typeof URI
+```
+
+Added in v2.13.0
+
+# model
+
+## ReaderIO (interface)
+
+**Signature**
+
+```ts
+export interface ReaderIO<R, A> {
+  (r: R): I.IO<A>
+}
+```
+
+Added in v2.13.0
+
+# natural transformations
+
+## fromIO
+
+**Signature**
+
+```ts
+export declare const fromIO: NaturalTransformation12<'IO', 'ReaderIO'>
+```
+
+Added in v2.13.0
+
+## fromReader
+
+**Signature**
+
+```ts
+export declare const fromReader: NaturalTransformation22<'Reader', 'ReaderIO'>
+```
+
+Added in v2.13.0
+
+# utils
+
+## ApT
+
+**Signature**
+
+```ts
+export declare const ApT: ReaderIO<unknown, readonly []>
+```
+
+Added in v2.13.0
+
+## Do
+
+**Signature**
+
+```ts
+export declare const Do: ReaderIO<unknown, {}>
+```
+
+Added in v2.13.0
+
+## apS
+
+**Signature**
+
+```ts
+export declare const apS: <N, A, E, B>(
+  name: Exclude<N, keyof A>,
+  fb: ReaderIO<E, B>
+) => (fa: ReaderIO<E, A>) => ReaderIO<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
+
+## apSW
+
+**Signature**
+
+```ts
+export declare const apSW: <A, N extends string, R2, B>(
+  name: Exclude<N, keyof A>,
+  fb: ReaderIO<R2, B>
+) => <R1>(fa: ReaderIO<R1, A>) => ReaderIO<R1 & R2, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
+
+## bind
+
+**Signature**
+
+```ts
+export declare const bind: <N, A, E, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => ReaderIO<E, B>
+) => (ma: ReaderIO<E, A>) => ReaderIO<E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
+
+## bindTo
+
+**Signature**
+
+```ts
+export declare const bindTo: <N>(name: N) => <E, A>(fa: ReaderIO<E, A>) => ReaderIO<E, { readonly [K in N]: A }>
+```
+
+Added in v2.13.0
+
+## bindW
+
+**Signature**
+
+```ts
+export declare const bindW: <N extends string, A, R2, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => ReaderIO<R2, B>
+) => <R1>(fa: ReaderIO<R1, A>) => ReaderIO<R1 & R2, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v2.13.0
+
+## sequenceArray
+
+**Signature**
+
+```ts
+export declare const sequenceArray: <R, A>(arr: readonly ReaderIO<R, A>[]) => ReaderIO<R, readonly A[]>
+```
+
+Added in v2.13.0
+
+## traverseArray
+
+**Signature**
+
+```ts
+export declare const traverseArray: <R, A, B>(
+  f: (a: A) => ReaderIO<R, B>
+) => (as: readonly A[]) => ReaderIO<R, readonly B[]>
+```
+
+Added in v2.13.0
+
+## traverseArrayWithIndex
+
+**Signature**
+
+```ts
+export declare const traverseArrayWithIndex: <R, A, B>(
+  f: (index: number, a: A) => ReaderIO<R, B>
+) => (as: readonly A[]) => ReaderIO<R, readonly B[]>
+```
+
+Added in v2.13.0
+
+## traverseReadonlyArrayWithIndex
+
+Equivalent to `ReadonlyArray#traverseWithIndex(Applicative)`.
+
+**Signature**
+
+```ts
+export declare const traverseReadonlyArrayWithIndex: <A, R, B>(
+  f: (index: number, a: A) => ReaderIO<R, B>
+) => (as: readonly A[]) => ReaderIO<R, readonly B[]>
+```
+
+Added in v2.13.0
+
+## traverseReadonlyNonEmptyArrayWithIndex
+
+Equivalent to `ReadonlyNonEmptyArray#traverseWithIndex(Applicative)`.
+
+**Signature**
+
+```ts
+export declare const traverseReadonlyNonEmptyArrayWithIndex: <A, R, B>(
+  f: (index: number, a: A) => ReaderIO<R, B>
+) => (as: ReadonlyNonEmptyArray<A>) => ReaderIO<R, ReadonlyNonEmptyArray<B>>
+```
+
+Added in v2.13.0

--- a/docs/modules/ReaderT.ts.md
+++ b/docs/modules/ReaderT.ts.md
@@ -1,6 +1,6 @@
 ---
 title: ReaderT.ts
-nav_order: 80
+nav_order: 81
 parent: Modules
 ---
 

--- a/docs/modules/ReaderTask.ts.md
+++ b/docs/modules/ReaderTask.ts.md
@@ -1,6 +1,6 @@
 ---
 title: ReaderTask.ts
-nav_order: 81
+nav_order: 82
 parent: Modules
 ---
 

--- a/docs/modules/ReaderTaskEither.ts.md
+++ b/docs/modules/ReaderTaskEither.ts.md
@@ -1,6 +1,6 @@
 ---
 title: ReaderTaskEither.ts
-nav_order: 82
+nav_order: 83
 parent: Modules
 ---
 

--- a/docs/modules/ReadonlyArray.ts.md
+++ b/docs/modules/ReadonlyArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: ReadonlyArray.ts
-nav_order: 83
+nav_order: 84
 parent: Modules
 ---
 

--- a/docs/modules/ReadonlyMap.ts.md
+++ b/docs/modules/ReadonlyMap.ts.md
@@ -1,6 +1,6 @@
 ---
 title: ReadonlyMap.ts
-nav_order: 84
+nav_order: 85
 parent: Modules
 ---
 

--- a/docs/modules/ReadonlyNonEmptyArray.ts.md
+++ b/docs/modules/ReadonlyNonEmptyArray.ts.md
@@ -1,6 +1,6 @@
 ---
 title: ReadonlyNonEmptyArray.ts
-nav_order: 85
+nav_order: 86
 parent: Modules
 ---
 

--- a/docs/modules/ReadonlyRecord.ts.md
+++ b/docs/modules/ReadonlyRecord.ts.md
@@ -1,6 +1,6 @@
 ---
 title: ReadonlyRecord.ts
-nav_order: 86
+nav_order: 87
 parent: Modules
 ---
 

--- a/docs/modules/ReadonlySet.ts.md
+++ b/docs/modules/ReadonlySet.ts.md
@@ -1,6 +1,6 @@
 ---
 title: ReadonlySet.ts
-nav_order: 87
+nav_order: 88
 parent: Modules
 ---
 

--- a/docs/modules/ReadonlyTuple.ts.md
+++ b/docs/modules/ReadonlyTuple.ts.md
@@ -1,6 +1,6 @@
 ---
 title: ReadonlyTuple.ts
-nav_order: 88
+nav_order: 89
 parent: Modules
 ---
 

--- a/docs/modules/Record.ts.md
+++ b/docs/modules/Record.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Record.ts
-nav_order: 89
+nav_order: 90
 parent: Modules
 ---
 

--- a/docs/modules/Refinement.ts.md
+++ b/docs/modules/Refinement.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Refinement.ts
-nav_order: 90
+nav_order: 91
 parent: Modules
 ---
 

--- a/docs/modules/Ring.ts.md
+++ b/docs/modules/Ring.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Ring.ts
-nav_order: 91
+nav_order: 92
 parent: Modules
 ---
 

--- a/docs/modules/Semigroup.ts.md
+++ b/docs/modules/Semigroup.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Semigroup.ts
-nav_order: 92
+nav_order: 93
 parent: Modules
 ---
 

--- a/docs/modules/Semigroupoid.ts.md
+++ b/docs/modules/Semigroupoid.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Semigroupoid.ts
-nav_order: 93
+nav_order: 94
 parent: Modules
 ---
 

--- a/docs/modules/Semiring.ts.md
+++ b/docs/modules/Semiring.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Semiring.ts
-nav_order: 94
+nav_order: 95
 parent: Modules
 ---
 

--- a/docs/modules/Separated.ts.md
+++ b/docs/modules/Separated.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Separated.ts
-nav_order: 95
+nav_order: 96
 parent: Modules
 ---
 

--- a/docs/modules/Set.ts.md
+++ b/docs/modules/Set.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Set.ts
-nav_order: 96
+nav_order: 97
 parent: Modules
 ---
 

--- a/docs/modules/Show.ts.md
+++ b/docs/modules/Show.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Show.ts
-nav_order: 97
+nav_order: 98
 parent: Modules
 ---
 

--- a/docs/modules/State.ts.md
+++ b/docs/modules/State.ts.md
@@ -1,6 +1,6 @@
 ---
 title: State.ts
-nav_order: 98
+nav_order: 99
 parent: Modules
 ---
 

--- a/docs/modules/StateReaderTaskEither.ts.md
+++ b/docs/modules/StateReaderTaskEither.ts.md
@@ -1,6 +1,6 @@
 ---
 title: StateReaderTaskEither.ts
-nav_order: 99
+nav_order: 100
 parent: Modules
 ---
 

--- a/docs/modules/StateT.ts.md
+++ b/docs/modules/StateT.ts.md
@@ -1,6 +1,6 @@
 ---
 title: StateT.ts
-nav_order: 100
+nav_order: 101
 parent: Modules
 ---
 

--- a/docs/modules/Store.ts.md
+++ b/docs/modules/Store.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Store.ts
-nav_order: 101
+nav_order: 102
 parent: Modules
 ---
 

--- a/docs/modules/Strong.ts.md
+++ b/docs/modules/Strong.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Strong.ts
-nav_order: 103
+nav_order: 104
 parent: Modules
 ---
 

--- a/docs/modules/Task.ts.md
+++ b/docs/modules/Task.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Task.ts
-nav_order: 105
+nav_order: 106
 parent: Modules
 ---
 

--- a/docs/modules/TaskEither.ts.md
+++ b/docs/modules/TaskEither.ts.md
@@ -1,6 +1,6 @@
 ---
 title: TaskEither.ts
-nav_order: 106
+nav_order: 107
 parent: Modules
 ---
 

--- a/docs/modules/TaskOption.ts.md
+++ b/docs/modules/TaskOption.ts.md
@@ -1,6 +1,6 @@
 ---
 title: TaskOption.ts
-nav_order: 107
+nav_order: 108
 parent: Modules
 ---
 

--- a/docs/modules/TaskThese.ts.md
+++ b/docs/modules/TaskThese.ts.md
@@ -1,6 +1,6 @@
 ---
 title: TaskThese.ts
-nav_order: 108
+nav_order: 109
 parent: Modules
 ---
 

--- a/docs/modules/These.ts.md
+++ b/docs/modules/These.ts.md
@@ -1,6 +1,6 @@
 ---
 title: These.ts
-nav_order: 109
+nav_order: 110
 parent: Modules
 ---
 

--- a/docs/modules/TheseT.ts.md
+++ b/docs/modules/TheseT.ts.md
@@ -1,6 +1,6 @@
 ---
 title: TheseT.ts
-nav_order: 110
+nav_order: 111
 parent: Modules
 ---
 

--- a/docs/modules/Traced.ts.md
+++ b/docs/modules/Traced.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Traced.ts
-nav_order: 111
+nav_order: 112
 parent: Modules
 ---
 

--- a/docs/modules/Traversable.ts.md
+++ b/docs/modules/Traversable.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Traversable.ts
-nav_order: 112
+nav_order: 113
 parent: Modules
 ---
 

--- a/docs/modules/TraversableWithIndex.ts.md
+++ b/docs/modules/TraversableWithIndex.ts.md
@@ -1,6 +1,6 @@
 ---
 title: TraversableWithIndex.ts
-nav_order: 113
+nav_order: 114
 parent: Modules
 ---
 

--- a/docs/modules/Tree.ts.md
+++ b/docs/modules/Tree.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Tree.ts
-nav_order: 114
+nav_order: 115
 parent: Modules
 ---
 

--- a/docs/modules/Tuple.ts.md
+++ b/docs/modules/Tuple.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Tuple.ts
-nav_order: 115
+nav_order: 116
 parent: Modules
 ---
 

--- a/docs/modules/Unfoldable.ts.md
+++ b/docs/modules/Unfoldable.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Unfoldable.ts
-nav_order: 116
+nav_order: 117
 parent: Modules
 ---
 

--- a/docs/modules/ValidationT.ts.md
+++ b/docs/modules/ValidationT.ts.md
@@ -1,6 +1,6 @@
 ---
 title: ValidationT.ts
-nav_order: 117
+nav_order: 118
 parent: Modules
 ---
 

--- a/docs/modules/Witherable.ts.md
+++ b/docs/modules/Witherable.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Witherable.ts
-nav_order: 119
+nav_order: 120
 parent: Modules
 ---
 

--- a/docs/modules/Writer.ts.md
+++ b/docs/modules/Writer.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Writer.ts
-nav_order: 120
+nav_order: 121
 parent: Modules
 ---
 

--- a/docs/modules/WriterT.ts.md
+++ b/docs/modules/WriterT.ts.md
@@ -1,6 +1,6 @@
 ---
 title: WriterT.ts
-nav_order: 121
+nav_order: 122
 parent: Modules
 ---
 

--- a/docs/modules/Zero.ts.md
+++ b/docs/modules/Zero.ts.md
@@ -1,6 +1,6 @@
 ---
 title: Zero.ts
-nav_order: 122
+nav_order: 123
 parent: Modules
 ---
 

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -90,6 +90,7 @@ Added in v2.0.0
   - [random](#random)
   - [reader](#reader)
   - [readerEither](#readereither)
+  - [readerIO](#readerio)
   - [readerT](#readert)
   - [readerTask](#readertask)
   - [readerTaskEither](#readertaskeither)
@@ -904,6 +905,16 @@ Added in v2.0.0
 
 ```ts
 export declare const readerEither: typeof readerEither
+```
+
+Added in v2.0.0
+
+## readerIO
+
+**Signature**
+
+```ts
+export declare const readerIO: typeof readerIO
 ```
 
 Added in v2.0.0

--- a/docs/modules/string.ts.md
+++ b/docs/modules/string.ts.md
@@ -1,6 +1,6 @@
 ---
 title: string.ts
-nav_order: 102
+nav_order: 103
 parent: Modules
 ---
 

--- a/docs/modules/struct.ts.md
+++ b/docs/modules/struct.ts.md
@@ -1,6 +1,6 @@
 ---
 title: struct.ts
-nav_order: 104
+nav_order: 105
 parent: Modules
 ---
 

--- a/docs/modules/void.ts.md
+++ b/docs/modules/void.ts.md
@@ -1,6 +1,6 @@
 ---
 title: void.ts
-nav_order: 118
+nav_order: 119
 parent: Modules
 ---
 

--- a/src/ReaderIO.ts
+++ b/src/ReaderIO.ts
@@ -1,0 +1,544 @@
+/**
+ * @since 2.13.0
+ */
+import { Applicative2 } from './Applicative'
+import { apFirst as apFirst_, Apply2, apS as apS_, apSecond as apSecond_ } from './Apply'
+import { bind as bind_, Chain2, chainFirst as chainFirst_ } from './Chain'
+import { chainFirstIOK as chainFirstIOK_, chainIOK as chainIOK_, FromIO2, fromIOK as fromIOK_ } from './FromIO'
+import {
+  ask as ask_,
+  asks as asks_,
+  chainFirstReaderK as chainFirstReaderK_,
+  chainReaderK as chainReaderK_,
+  FromReader2,
+  fromReaderK as fromReaderK_
+} from './FromReader'
+import { flow, identity, pipe, SK } from './function'
+import { bindTo as bindTo_, flap as flap_, Functor2 } from './Functor'
+import * as _ from './internal'
+import * as I from './IO'
+import { Monad2 } from './Monad'
+import { MonadIO2 } from './MonadIO'
+import { Pointed2 } from './Pointed'
+import * as R from './Reader'
+import * as RT from './ReaderT'
+import { ReadonlyNonEmptyArray } from './ReadonlyNonEmptyArray'
+
+/**
+ * @category model
+ * @since 2.13.0
+ */
+
+export interface ReaderIO<R, A> {
+  (r: R): I.IO<A>
+}
+
+// -------------------------------------------------------------------------------------
+// natural transformations
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category natural transformations
+ * @since 2.13.0
+ */
+export const fromReader: FromReader2<URI>['fromReader'] =
+  /*#__PURE__*/
+  RT.fromReader(I.Pointed)
+
+/**
+ * @category natural transformations
+ * @since 2.13.0
+ */
+export const fromIO: FromIO2<URI>['fromIO'] =
+  /*#__PURE__*/
+  R.of
+
+// -------------------------------------------------------------------------------------
+// combinators
+// -------------------------------------------------------------------------------------
+
+/**
+ * Changes the value of the local context during the execution of the action `ma` (similar to `Contravariant`'s
+ * `contramap`).
+ *
+ * @category combinators
+ * @since 2.13.0
+ */
+export const local: <R2, R1>(f: (r2: R2) => R1) => <A>(ma: ReaderIO<R1, A>) => ReaderIO<R2, A> = R.local
+
+/**
+ * Less strict version of [`asksReaderIO`](#asksreaderio).
+ *
+ * @category combinators
+ * @since 2.13.0
+ */
+export const asksReaderIOW: <R1, R2, A>(f: (r1: R1) => ReaderIO<R2, A>) => ReaderIO<R1 & R2, A> = R.asksReaderW
+
+/**
+ * Effectfully accesses the environment.
+ *
+ * @category combinators
+ * @since 2.13.0
+ */
+export const asksReaderIO: <R, A>(f: (r: R) => ReaderIO<R, A>) => ReaderIO<R, A> = asksReaderIOW
+
+// -------------------------------------------------------------------------------------
+// type class members
+// -------------------------------------------------------------------------------------
+
+const _map: Functor2<URI>['map'] = (fa, f) => pipe(fa, map(f))
+const _ap: Apply2<URI>['ap'] = (fab, fa) => pipe(fab, ap(fa))
+const _chain: Chain2<URI>['chain'] = (ma, f) => pipe(ma, chain(f))
+
+/**
+ * `map` can be used to turn functions `(a: A) => B` into functions `(fa: F<A>) => F<B>` whose argument and return types
+ * use the type constructor `F` to represent some computational context.
+ *
+ * @category Functor
+ * @since 2.13.0
+ */
+export const map: <A, B>(f: (a: A) => B) => <R>(fa: ReaderIO<R, A>) => ReaderIO<R, B> =
+  /*#__PURE__*/
+  RT.map(I.Functor)
+
+/**
+ * Apply a function to an argument under a type constructor.
+ *
+ * @category Apply
+ * @since 2.13.0
+ */
+export const ap: <R, A>(fa: ReaderIO<R, A>) => <B>(fab: ReaderIO<R, (a: A) => B>) => ReaderIO<R, B> =
+  /*#__PURE__*/
+  RT.ap(I.Apply)
+
+/**
+ * Less strict version of [`ap`](#ap).
+ *
+ * @category Apply
+ * @since 2.13.0
+ */
+export const apW: <R2, A>(
+  fa: ReaderIO<R2, A>
+) => <R1, B>(fab: ReaderIO<R1, (a: A) => B>) => ReaderIO<R1 & R2, B> = ap as any
+
+/**
+ * @category Pointed
+ * @since 2.13.0
+ */
+export const of: Pointed2<URI>['of'] =
+  /*#__PURE__*/
+  RT.of(I.Pointed)
+
+/**
+ * Composes computations in sequence, using the return value of one computation to determine the next computation.
+ *
+ * @category Monad
+ * @since 2.13.0
+ */
+export const chain: <A, R, B>(f: (a: A) => ReaderIO<R, B>) => (ma: ReaderIO<R, A>) => ReaderIO<R, B> =
+  /*#__PURE__*/
+  RT.chain(I.Monad)
+
+/**
+ * Less strict version of  [`chain`](#chain).
+ *
+ * @category Monad
+ * @since 2.13.0
+ */
+export const chainW: <R2, A, B>(
+  f: (a: A) => ReaderIO<R2, B>
+) => <R1>(ma: ReaderIO<R1, A>) => ReaderIO<R1 & R2, B> = chain as any
+
+/**
+ * Less strict version of [`flatten`](#flatten).
+ *
+ * @category combinators
+ * @since 2.13.0
+ */
+export const flattenW: <R1, R2, A>(mma: ReaderIO<R1, ReaderIO<R2, A>>) => ReaderIO<R1 & R2, A> =
+  /*#__PURE__*/
+  chainW(identity)
+
+/**
+ * Derivable from `Chain`.
+ *
+ * @category combinators
+ * @since 2.13.0
+ */
+export const flatten: <R, A>(mma: ReaderIO<R, ReaderIO<R, A>>) => ReaderIO<R, A> = flattenW
+
+// -------------------------------------------------------------------------------------
+// instances
+// -------------------------------------------------------------------------------------
+
+/**
+ * @category instances
+ * @since 2.13.0
+ */
+export const URI = 'ReaderIO'
+
+/**
+ * @category instances
+ * @since 2.13.0
+ */
+export type URI = typeof URI
+
+declare module './HKT' {
+  interface URItoKind2<E, A> {
+    readonly [URI]: ReaderIO<E, A>
+  }
+}
+
+/**
+ * @category instances
+ * @since 2.13.0
+ */
+export const Functor: Functor2<URI> = {
+  URI,
+  map: _map
+}
+
+/**
+ * Derivable from `Functor`.
+ *
+ * @category combinators
+ * @since 2.13.0
+ */
+export const flap =
+  /*#__PURE__*/
+  flap_(Functor)
+
+/**
+ * @category instances
+ * @since 2.13.0
+ */
+export const Pointed: Pointed2<URI> = {
+  URI,
+  of
+}
+
+/**
+ * @category instances
+ * @since 2.13.0
+ */
+export const Apply: Apply2<URI> = {
+  URI,
+  map: _map,
+  ap: _ap
+}
+
+/**
+ * Combine two effectful actions, keeping only the result of the first.
+ *
+ * Derivable from `Apply`.
+ *
+ * @category combinators
+ * @since 2.13.0
+ */
+export const apFirst =
+  /*#__PURE__*/
+  apFirst_(Apply)
+
+/**
+ * Combine two effectful actions, keeping only the result of the second.
+ *
+ * Derivable from `Apply`.
+ *
+ * @category combinators
+ * @since 2.13.0
+ */
+export const apSecond =
+  /*#__PURE__*/
+  apSecond_(Apply)
+
+/**
+ * @category instances
+ * @since 2.13.0
+ */
+export const Applicative: Applicative2<URI> = {
+  URI,
+  map: _map,
+  ap: _ap,
+  of
+}
+
+/**
+ * @category instances
+ * @since 2.13.0
+ */
+export const Chain: Chain2<URI> = {
+  URI,
+  map: _map,
+  ap: _ap,
+  chain: _chain
+}
+
+/**
+ * @category instances
+ * @since 2.13.0
+ */
+export const Monad: Monad2<URI> = {
+  URI,
+  map: _map,
+  of,
+  ap: _ap,
+  chain: _chain
+}
+
+/**
+ * @category instances
+ * @since 2.13.0
+ */
+export const MonadIO: MonadIO2<URI> = {
+  URI,
+  map: _map,
+  of,
+  ap: _ap,
+  chain: _chain,
+  fromIO
+}
+
+/**
+ * Composes computations in sequence, using the return value of one computation to determine the next computation and
+ * keeping only the result of the first.
+ *
+ * Derivable from `Chain`.
+ *
+ * @category combinators
+ * @since 2.13.0
+ */
+export const chainFirst =
+  /*#__PURE__*/
+  chainFirst_(Chain)
+
+/**
+ * Less strict version of [`chainFirst`](#chainfirst).
+ *
+ * Derivable from `Chain`.
+ *
+ * @category combinators
+ * @since 2.13.0
+ */
+export const chainFirstW: <R2, A, B>(
+  f: (a: A) => ReaderIO<R2, B>
+) => <R1>(ma: ReaderIO<R1, A>) => ReaderIO<R1 & R2, A> = chainFirst as any
+
+/**
+ * @category instances
+ * @since 2.13.0
+ */
+export const FromIO: FromIO2<URI> = {
+  URI,
+  fromIO
+}
+
+/**
+ * @category combinators
+ * @since 2.13.0
+ */
+export const fromIOK =
+  /*#__PURE__*/
+  fromIOK_(FromIO)
+
+/**
+ * @category combinators
+ * @since 2.13.0
+ */
+export const chainIOK =
+  /*#__PURE__*/
+  chainIOK_(FromIO, Chain)
+
+/**
+ * @category combinators
+ * @since 2.13.0
+ */
+export const chainFirstIOK =
+  /*#__PURE__*/
+  chainFirstIOK_(FromIO, Chain)
+
+/**
+ * @category instances
+ * @since 2.13.0
+ */
+export const FromReader: FromReader2<URI> = {
+  URI,
+  fromReader
+}
+
+/**
+ * Reads the current context.
+ *
+ * @category constructors
+ * @since 2.13.0
+ */
+export const ask =
+  /*#__PURE__*/
+  ask_(FromReader)
+
+/**
+ * Projects a value from the global context in a `ReaderIO`.
+ *
+ * @category constructors
+ * @since 2.13.0
+ */
+export const asks =
+  /*#__PURE__*/
+  asks_(FromReader)
+
+/**
+ * @category combinators
+ * @since 2.13.0
+ */
+export const fromReaderK =
+  /*#__PURE__*/
+  fromReaderK_(FromReader)
+
+/**
+ * @category combinators
+ * @since 2.13.0
+ */
+export const chainReaderK =
+  /*#__PURE__*/
+  chainReaderK_(FromReader, Chain)
+
+/**
+ * Less strict version of [`chainReaderK`](#chainreaderk).
+ *
+ * @category combinators
+ * @since 2.13.0
+ */
+export const chainReaderKW: <A, R1, B>(
+  f: (a: A) => R.Reader<R1, B>
+) => <R2>(ma: ReaderIO<R2, A>) => ReaderIO<R1 & R2, B> = chainReaderK as any
+
+/**
+ * @category combinators
+ * @since 2.13.0
+ */
+export const chainFirstReaderK =
+  /*#__PURE__*/
+  chainFirstReaderK_(FromReader, Chain)
+
+/**
+ * Less strict version of [`chainFirstReaderK`](#chainfirstreaderk).
+ *
+ * @category combinators
+ * @since 2.13.0
+ */
+export const chainFirstReaderKW: <A, R1, B>(
+  f: (a: A) => R.Reader<R1, B>
+) => <R2>(ma: ReaderIO<R2, A>) => ReaderIO<R1 & R2, A> = chainFirstReaderK as any
+
+// -------------------------------------------------------------------------------------
+// do notation
+// -------------------------------------------------------------------------------------
+
+/**
+ * @since 2.13.0
+ */
+export const Do: ReaderIO<unknown, {}> =
+  /*#__PURE__*/
+  of(_.emptyRecord)
+
+/**
+ * @since 2.13.0
+ */
+export const bindTo =
+  /*#__PURE__*/
+  bindTo_(Functor)
+
+/**
+ * @since 2.13.0
+ */
+export const bind =
+  /*#__PURE__*/
+  bind_(Chain)
+
+/**
+ * @since 2.13.0
+ */
+export const bindW: <N extends string, A, R2, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => ReaderIO<R2, B>
+) => <R1>(
+  fa: ReaderIO<R1, A>
+) => ReaderIO<R1 & R2, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }> = bind as any
+
+// -------------------------------------------------------------------------------------
+// pipeable sequence S
+// -------------------------------------------------------------------------------------
+
+/**
+ * @since 2.13.0
+ */
+export const apS =
+  /*#__PURE__*/
+  apS_(Apply)
+
+/**
+ * @since 2.13.0
+ */
+export const apSW: <A, N extends string, R2, B>(
+  name: Exclude<N, keyof A>,
+  fb: ReaderIO<R2, B>
+) => <R1>(
+  fa: ReaderIO<R1, A>
+) => ReaderIO<R1 & R2, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }> = apS as any
+
+// -------------------------------------------------------------------------------------
+// sequence T
+// -------------------------------------------------------------------------------------
+
+/**
+ * @since 2.13.0
+ */
+export const ApT: ReaderIO<unknown, readonly []> =
+  /*#__PURE__*/
+  of(_.emptyReadonlyArray)
+
+// -------------------------------------------------------------------------------------
+// array utils
+// -------------------------------------------------------------------------------------
+
+/**
+ * Equivalent to `ReadonlyNonEmptyArray#traverseWithIndex(Applicative)`.
+ *
+ * @since 2.13.0
+ */
+export const traverseReadonlyNonEmptyArrayWithIndex = <A, R, B>(
+  f: (index: number, a: A) => ReaderIO<R, B>
+): ((as: ReadonlyNonEmptyArray<A>) => ReaderIO<R, ReadonlyNonEmptyArray<B>>) =>
+  flow(R.traverseReadonlyNonEmptyArrayWithIndex(f), R.map(I.traverseReadonlyNonEmptyArrayWithIndex(SK)))
+
+/**
+ * Equivalent to `ReadonlyArray#traverseWithIndex(Applicative)`.
+ *
+ * @since 2.13.0
+ */
+export const traverseReadonlyArrayWithIndex = <A, R, B>(
+  f: (index: number, a: A) => ReaderIO<R, B>
+): ((as: ReadonlyArray<A>) => ReaderIO<R, ReadonlyArray<B>>) => {
+  const g = traverseReadonlyNonEmptyArrayWithIndex(f)
+  return (as) => (_.isNonEmpty(as) ? g(as) : ApT)
+}
+
+/**
+ * @since 2.13.0
+ */
+export const traverseArrayWithIndex: <R, A, B>(
+  f: (index: number, a: A) => ReaderIO<R, B>
+) => (as: ReadonlyArray<A>) => ReaderIO<R, ReadonlyArray<B>> = traverseReadonlyArrayWithIndex
+
+/**
+ * @since 2.13.0
+ */
+export const traverseArray = <R, A, B>(
+  f: (a: A) => ReaderIO<R, B>
+): ((as: ReadonlyArray<A>) => ReaderIO<R, ReadonlyArray<B>>) => traverseReadonlyArrayWithIndex((_, a) => f(a))
+
+/**
+ * @since 2.13.0
+ */
+export const sequenceArray: <R, A>(arr: ReadonlyArray<ReaderIO<R, A>>) => ReaderIO<R, ReadonlyArray<A>> =
+  /*#__PURE__*/
+  traverseArray(identity)

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,7 @@ import * as profunctor from './Profunctor'
 import * as random from './Random'
 import * as reader from './Reader'
 import * as readerEither from './ReaderEither'
+import * as readerIO from './ReaderIO'
 import * as readerT from './ReaderT'
 import * as readerTask from './ReaderTask'
 import * as readerTaskEither from './ReaderTaskEither'
@@ -427,6 +428,10 @@ export {
    * @since 2.0.0
    */
   readerEither,
+  /**
+   * @since 2.0.0
+   */
+  readerIO,
   /**
    * @since 2.0.0
    */

--- a/test/ReaderIO.ts
+++ b/test/ReaderIO.ts
@@ -1,0 +1,147 @@
+import { pipe } from '../src/function'
+import * as I from '../src/IO'
+import * as R from '../src/Reader'
+import * as _ from '../src/ReaderIO'
+import * as RA from '../src/ReadonlyArray'
+import { ReadonlyNonEmptyArray } from '../src/ReadonlyNonEmptyArray'
+import * as S from '../src/string'
+import * as U from './util'
+
+describe('ReaderIO', () => {
+  // -------------------------------------------------------------------------------------
+  // pipeables
+  // -------------------------------------------------------------------------------------
+
+  it('map', () => {
+    U.deepStrictEqual(pipe(_.of(1), _.map(U.double))({})(), 2)
+  })
+
+  it('ap', () => {
+    U.deepStrictEqual(pipe(_.of(U.double), _.ap(_.of(1)))({})(), 2)
+  })
+
+  it('apFirst', () => {
+    U.deepStrictEqual(pipe(_.of('a'), _.apFirst(_.of('b')))({})(), 'a')
+  })
+
+  it('apSecond', () => {
+    U.deepStrictEqual(pipe(_.of('a'), _.apSecond(_.of('b')))({})(), 'b')
+  })
+
+  it('chain', () => {
+    const f = (a: string) => _.of(a.length)
+    U.deepStrictEqual(pipe(_.of('foo'), _.chain(f))({})(), 3)
+    U.deepStrictEqual(_.Monad.chain(_.of('foo'), f)({})(), 3)
+  })
+
+  it('chainFirst', () => {
+    const f = (a: string) => _.of(a.length)
+    U.deepStrictEqual(pipe(_.of('foo'), _.chainFirst(f))({})(), 'foo')
+  })
+
+  it('chainFirstW', () => {
+    const f = (a: string) => _.of(a.length)
+    U.deepStrictEqual(pipe(_.of<object, string>('foo'), _.chainFirstW(f))({})(), 'foo')
+  })
+
+  it('flatten', () => {
+    U.deepStrictEqual(pipe(_.of(_.of('a')), _.flatten)({})(), 'a')
+  })
+
+  type R1 = { readonly env1: unknown }
+  type R2 = { readonly env2: unknown }
+
+  it('flattenW', () => {
+    U.deepStrictEqual(pipe(_.of<R1, _.ReaderIO<R2, 'a'>>(_.of('a')), _.flattenW)({ env1: '', env2: '' })(), 'a')
+  })
+
+  it('of', () => {
+    U.deepStrictEqual(_.fromReader(R.of(1))({})(), 1)
+  })
+
+  it('fromIO', async () => {
+    U.deepStrictEqual(_.fromIO(() => 1)({})(), 1)
+  })
+
+  // -------------------------------------------------------------------------------------
+  // constructors
+  // -------------------------------------------------------------------------------------
+
+  it('ask', () => {
+    return U.deepStrictEqual(_.ask<number>()(1)(), 1)
+  })
+
+  it('asks', () => {
+    return U.deepStrictEqual(_.asks((s: string) => s.length)('foo')(), 3)
+  })
+
+  it('fromReader', () => {
+    U.deepStrictEqual(_.fromReader(R.of(1))({})(), 1)
+  })
+
+  // -------------------------------------------------------------------------------------
+  // combinators
+  // -------------------------------------------------------------------------------------
+
+  it('local', () => {
+    U.deepStrictEqual(
+      pipe(
+        _.asks((n: number) => n + 1),
+        _.local(S.size)
+      )('aaa')(),
+      4
+    )
+  })
+
+  it('chainIOK', () => {
+    const f = (s: string) => I.of(s.length)
+    U.deepStrictEqual(pipe(_.of('a'), _.chainIOK(f))(undefined)(), 1)
+  })
+
+  it('fromIOK', () => {
+    const f = _.fromIOK((s: string) => I.of(s.length))
+    U.deepStrictEqual(pipe(_.of('a'), _.chain(f))({})(), 1)
+  })
+
+  // -------------------------------------------------------------------------------------
+  // utils
+  // -------------------------------------------------------------------------------------
+
+  it('do notation', () => {
+    U.deepStrictEqual(
+      pipe(
+        _.of(1),
+        _.bindTo('a'),
+        _.bind('b', () => _.of('b'))
+      )(undefined)(),
+      { a: 1, b: 'b' }
+    )
+  })
+
+  it('apS', () => {
+    U.deepStrictEqual(pipe(_.of(1), _.bindTo('a'), _.apS('b', _.of('b')))(undefined)(), { a: 1, b: 'b' })
+  })
+
+  describe('array utils', () => {
+    const input: ReadonlyNonEmptyArray<string> = ['a', 'b']
+
+    it('traverseReadonlyArrayWithIndex', () => {
+      const f = _.traverseReadonlyArrayWithIndex((i, a: string) => _.of(a + i))
+      U.deepStrictEqual(pipe(RA.empty, f)(undefined)(), RA.empty)
+      U.deepStrictEqual(pipe(input, f)(undefined)(), ['a0', 'b1'])
+    })
+
+    // old
+    it('sequenceArray', () => {
+      // tslint:disable-next-line: readonly-array
+      const log: Array<number | string> = []
+      const append = (n: number): _.ReaderIO<unknown, number> => () => () => {
+        log.push(n)
+        return n
+      }
+      // tslint:disable-next-line: deprecation
+      U.deepStrictEqual(pipe([append(1), append(2)], _.sequenceArray)(undefined)(), [1, 2])
+      U.deepStrictEqual(log, [1, 2])
+    })
+  })
+})


### PR DESCRIPTION
Introduces `ReaderIO`. Against the one from *fp-ts-contrib* it contains all the handy `chain*` / `traverse*` / ... combinators.

Resolves #1612.