### PR TITLE
feat: add chainTaskOptionKW

### DIFF
--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -440,6 +440,15 @@ export const chainTaskOptionK = <E>(
 
 /**
  * @category combinators
+ */
+export const chainTaskOptionKW: <E2>(
+  onNone: Lazy<E2>
+) => <A, B>(
+  f: (a: A) => TaskOption<B>
+) => <E1>(ma: TaskEither<E1, A>) => TaskEither<E1 | E2, B> = chainTaskOptionK as any
+
+/**
+ * @category combinators
  * @since 2.4.0
  */
 export const fromIOEitherK = <E, A extends ReadonlyArray<unknown>, B>(

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -440,6 +440,7 @@ export const chainTaskOptionK = <E>(
 
 /**
  * @category combinators
+ * @since 2.12.3
  */
 export const chainTaskOptionKW: <E2>(
   onNone: Lazy<E2>


### PR DESCRIPTION
if we wanted to chain a function which returns TaskOption in a TaskEither pipeline we would have to do

```typescript
import * as TE from 'fp-ts/TaskEither'
import * as TO from 'fp-ts/TaskOption'

declare const fooTaskEither: TE.TaskEither<'no', number>;
declare const getTaskOption: (x: number) => TO.TaskOption<boolean>;

const x = pipe(
  fooTaskEither,
  TE.chainW(TE.fromTaskOptionK(() => 'big no' as const)(getTaskOption)),
);

// x : TE.TaskEither<'big no' | 'no', boolean>
```

but I thought it would be a better idea if we could do this instead:

```typescript
const x = pipe(
  fooTaskEither,
  chainTaskOptionKW(() => 'big no' as const)(getTaskOption),
);

// x : TE.TaskEither<'big no' | 'no', boolean>
```