### PR TITLE
fix(function): narrow the return types of `constTrue` and `constFalse`

### DIFF
--- a/src/function.ts
+++ b/src/function.ts
@@ -163,7 +163,7 @@ export function constant<A>(a: A): Lazy<A> {
  *
  * @since 2.0.0
  */
-export const constTrue: Lazy<boolean> =
+export const constTrue: Lazy<true> =
   /*#__PURE__*/
   constant(true)
 
@@ -172,7 +172,7 @@ export const constTrue: Lazy<boolean> =
  *
  * @since 2.0.0
  */
-export const constFalse: Lazy<boolean> =
+export const constFalse: Lazy<false> =
   /*#__PURE__*/
   constant(false)
 

--- a/test/function.ts
+++ b/test/function.ts
@@ -28,11 +28,19 @@ describe('function', () => {
   })
 
   it('constTrue', () => {
-    U.deepStrictEqual(_.constTrue(), true)
+    const a: true = _.constTrue()
+    // @ts-expect-error
+    const b: false = _.constTrue()
+
+    U.deepStrictEqual(a, true)
   })
 
   it('constFalse', () => {
-    U.deepStrictEqual(_.constFalse(), false)
+    const a: false = _.constFalse()
+    // @ts-expect-error
+    const b: true = _.constFalse()
+
+    U.deepStrictEqual(a, false)
   })
 
   it('constNull', () => {


### PR DESCRIPTION
Fixes #1749