### PR TITLE
docs: remove david-dm.org from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,6 @@ Functional programming in TypeScript
   <a href="https://github.com/gcanti/fp-ts/actions">
     <img src="https://github.com/gcanti/fp-ts/actions/workflows/main.yml/badge.svg?branch=master" alt="build status" height="20">
   </a>
-  <a href="https://david-dm.org/gcanti/fp-ts">
-    <img src="https://img.shields.io/david/gcanti/fp-ts.svg?style=flat-square" alt="dependency status" height="20">
-  </a>
   <a href="https://www.npmjs.com/package/fp-ts">
     <img src="https://img.shields.io/npm/dm/fp-ts.svg" alt="npm downloads" height="20">
   </a>


### PR DESCRIPTION
The `david-dm.org` website is down for 3 months, and the project `alanshaw/david` is not actively maintained anymore. The `david-dm.org` should be considered dead, thus badges should be removed from README.