### PR TITLE
add pipeable helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,111 @@
 **Note**: A feature tagged as Experimental is in a
 high state of flux, you're at risk of it changing without notice.
 
+# 2.13
+
+## Pipeable helpers
+
+The `pipeable` module now exports a series of `pipe`-able helpers that are useful when you build
+a typeclass instance "on the fly".
+
+**Example**
+
+Here's a simple pipline which validates a `Person` struct
+
+```ts
+import * as E from 'fp-ts/Either'
+import { pipe } from 'fp-ts/function'
+
+const parseString = (u: unknown): E.Either<string, string> =>
+  typeof u === 'string' ? E.right(u) : E.left('not a string')
+
+const parseNumber = (u: unknown): E.Either<string, number> =>
+  typeof u === 'number' ? E.right(u) : E.left('not a number')
+
+interface Person {
+  readonly name: string
+  readonly age: number
+}
+
+const person = (name: string) => (age: number): Person => ({ name, age })
+
+const parsePerson = (input: Record<string, unknown>): E.Either<string, Person> =>
+  pipe(E.of(person), E.ap(parseString(input.name)), E.ap(parseNumber(input.age)))
+
+console.log(parsePerson({})) // => left('not a string')
+```
+
+As you can see the default `ap` exported by the `Either` module return only the first validation error.
+
+You probably already know that if you want to get all validation errors you must create an `Applicative` instance on the fly
+
+```ts
+import * as S from 'fp-ts/Semigroup'
+import * as string from 'fp-ts/string'
+
+const Applicative = E.getApplicativeValidation(pipe(string.Semigroup, S.intercalate(', ')))
+```
+
+The issue here is that `Applicative.ap` is not `pipe`-able and can't be used inside a `pipe`-line
+
+```ts
+const parsePersonAll = (input: Record<string, unknown>): E.Either<string, Person> =>
+  pipe(
+    E.of(person),
+    Applicative.ap(parseString(input.name)), // <= error
+    Applicative.ap(parseNumber(input.age)) // <= error
+  )
+```
+
+This is the time when the new `pipe`-able helpers come to handy
+
+```ts
+import * as P from 'fp-ts/pipeable'
+
+//    v--- this is `pipe`-able
+const ap = P.ap(Applicative)
+
+const parsePersonAll = (input: Record<string, unknown>): E.Either<string, Person> =>
+  pipe(
+    E.of(person),
+    ap(parseString(input.name)), // <= ok
+    ap(parseNumber(input.age)) // <= ok
+  )
+
+console.log(parsePersonAll({})) // => left('not a string, not a number')
+```
+
+Changelog:
+
+- **New Feature**
+  - `pipeable`
+    - add pipeable helpers (@gcanti)
+      - `alt`
+      - `ap`
+      - `bimap`
+      - `chain`
+      - `compose`
+      - `contramap`
+      - `extend`
+      - `filter`
+      - `filterMap`
+      - `filterMapWithIndex`
+      - `filterWithIndex`
+      - `foldMap`
+      - `foldMapWithIndex`
+      - `map`
+      - `mapLeft`
+      - `mapWithIndex`
+      - `partition`
+      - `partitionMap`
+      - `partitionMapWithIndex`
+      - `partitionWithIndex`
+      - `promap`
+      - `reduce`
+      - `reduceRight`
+      - `reduceRightWithIndex`
+      - `reduceWithIndex`
+
 # 2.12.3
 
 - **Polish**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ a typeclass instance "on the fly".
 
 **Example**
 
-Here's a simple pipline which validates a `Person` struct
+Here's a simple `pipe`-line which validates a `Person` struct
 
 ```ts
 import * as E from 'fp-ts/Either'
@@ -72,7 +72,7 @@ const parsePersonAll = (input: Record<string, unknown>): E.Either<string, Person
   )
 ```
 
-This is the time when the new `pipe`-able helpers come to handy
+That's when the new `pipe`-able helpers come to handy
 
 ```ts
 import * as P from 'fp-ts/pipeable'

--- a/docs/modules/pipeable.ts.md
+++ b/docs/modules/pipeable.ts.md
@@ -12,6 +12,32 @@ Added in v2.0.0
 
 <h2 class="text-delta">Table of contents</h2>
 
+- [pipeable helper](#pipeable-helper)
+  - [alt](#alt)
+  - [ap](#ap)
+  - [bimap](#bimap)
+  - [chain](#chain)
+  - [compose](#compose)
+  - [contramap](#contramap)
+  - [extend](#extend)
+  - [filter](#filter)
+  - [filterMap](#filtermap)
+  - [filterMapWithIndex](#filtermapwithindex)
+  - [filterWithIndex](#filterwithindex)
+  - [foldMap](#foldmap)
+  - [foldMapWithIndex](#foldmapwithindex)
+  - [map](#map)
+  - [mapLeft](#mapleft)
+  - [mapWithIndex](#mapwithindex)
+  - [partition](#partition)
+  - [partitionMap](#partitionmap)
+  - [partitionMapWithIndex](#partitionmapwithindex)
+  - [partitionWithIndex](#partitionwithindex)
+  - [promap](#promap)
+  - [reduce](#reduce)
+  - [reduceRight](#reduceright)
+  - [reduceRightWithIndex](#reducerightwithindex)
+  - [reduceWithIndex](#reducewithindex)
 - [utils](#utils)
   - [~~PipeableAlt1~~ (interface)](#pipeablealt1-interface)
   - [~~PipeableAlt2C~~ (interface)](#pipeablealt2c-interface)
@@ -125,6 +151,890 @@ Added in v2.0.0
   - [~~pipe~~](#pipe)
 
 ---
+
+# pipeable helper
+
+## alt
+
+Returns a pipeable `alt`
+
+**Signature**
+
+```ts
+export declare function alt<F extends URIS4>(
+  F: Alt4<F>
+): <S, R, E, A>(that: Lazy<Kind4<F, S, R, E, A>>) => (fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, A>
+export declare function alt<F extends URIS3>(
+  F: Alt3<F>
+): <R, E, A>(that: Lazy<Kind3<F, R, E, A>>) => (fa: Kind3<F, R, E, A>) => Kind3<F, R, E, A>
+export declare function alt<F extends URIS3, E>(
+  F: Alt3C<F, E>
+): <R, A>(that: Lazy<Kind3<F, R, E, A>>) => (fa: Kind3<F, R, E, A>) => Kind3<F, R, E, A>
+export declare function alt<F extends URIS2>(
+  F: Alt2<F>
+): <E, A>(that: Lazy<Kind2<F, E, A>>) => (fa: Kind2<F, E, A>) => Kind2<F, E, A>
+export declare function alt<F extends URIS2, E>(
+  F: Alt2C<F, E>
+): <A>(that: Lazy<Kind2<F, E, A>>) => (fa: Kind2<F, E, A>) => Kind2<F, E, A>
+export declare function alt<F extends URIS>(F: Alt1<F>): <A>(that: Lazy<Kind<F, A>>) => (fa: Kind<F, A>) => Kind<F, A>
+export declare function alt<F>(F: Alt<F>): <A>(that: Lazy<HKT<F, A>>) => (fa: HKT<F, A>) => HKT<F, A>
+```
+
+Added in v2.13.0
+
+## ap
+
+Returns a pipeable `ap`
+
+**Signature**
+
+```ts
+export declare function ap<F extends URIS4>(
+  F: Apply4<F>
+): <S, R, E, A>(fa: Kind4<F, S, R, E, A>) => <B>(fab: Kind4<F, S, R, E, (a: A) => B>) => Kind4<F, S, R, E, B>
+export declare function ap<F extends URIS3>(
+  F: Apply3<F>
+): <R, E, A>(fa: Kind3<F, R, E, A>) => <B>(fab: Kind3<F, R, E, (a: A) => B>) => Kind3<F, R, E, B>
+export declare function ap<F extends URIS3, E>(
+  F: Apply3C<F, E>
+): <R, A>(fa: Kind3<F, R, E, A>) => <B>(fab: Kind3<F, R, E, (a: A) => B>) => Kind3<F, R, E, B>
+export declare function ap<F extends URIS2>(
+  F: Apply2<F>
+): <E, A>(fa: Kind2<F, E, A>) => <B>(fab: Kind2<F, E, (a: A) => B>) => Kind2<F, E, B>
+export declare function ap<F extends URIS2, E>(
+  F: Apply2C<F, E>
+): <A>(fa: Kind2<F, E, A>) => <B>(fab: Kind2<F, E, (a: A) => B>) => Kind2<F, E, B>
+export declare function ap<F extends URIS>(
+  F: Apply1<F>
+): <A>(fa: Kind<F, A>) => <B>(fab: Kind<F, (a: A) => B>) => Kind<F, B>
+export declare function ap<F>(F: Apply<F>): <A>(fa: HKT<F, A>) => <B>(fab: HKT<F, (a: A) => B>) => HKT<F, B>
+```
+
+Added in v2.13.0
+
+## bimap
+
+Returns a pipeable `bimap`
+
+**Signature**
+
+```ts
+export declare function bimap<F extends URIS4>(
+  F: Bifunctor4<F>
+): <E, G, A, B>(f: (e: E) => G, g: (a: A) => B) => <S, R>(fea: Kind4<F, S, R, E, A>) => Kind4<F, S, R, G, B>
+export declare function bimap<F extends URIS3>(
+  F: Bifunctor3<F>
+): <E, G, A, B>(f: (e: E) => G, g: (a: A) => B) => <R>(fea: Kind3<F, R, E, A>) => Kind3<F, R, G, B>
+export declare function bimap<F extends URIS3, E>(
+  F: Bifunctor3C<F, E>
+): <G, A, B>(f: (e: E) => G, g: (a: A) => B) => <R>(fea: Kind3<F, R, E, A>) => Kind3<F, R, G, B>
+export declare function bimap<F extends URIS2>(
+  F: Bifunctor2<F>
+): <E, G, A, B>(f: (e: E) => G, g: (a: A) => B) => (fea: Kind2<F, E, A>) => Kind2<F, G, B>
+export declare function bimap<F extends URIS2, E>(
+  F: Bifunctor2C<F, E>
+): <G, A, B>(f: (e: E) => G, g: (a: A) => B) => (fea: Kind2<F, E, A>) => Kind2<F, G, B>
+export declare function bimap<F>(
+  F: Bifunctor<F>
+): <E, G, A, B>(f: (e: E) => G, g: (a: A) => B) => (fea: HKT2<F, E, A>) => HKT2<F, G, B>
+```
+
+Added in v2.13.0
+
+## chain
+
+Returns a pipeable `chain`
+
+**Signature**
+
+```ts
+export declare function chain<F extends URIS4>(
+  F: Chain4<F>
+): <A, S, R, E, B>(f: (a: A) => Kind4<F, S, R, E, B>) => (fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, B>
+export declare function chain<F extends URIS3>(
+  F: Chain3<F>
+): <A, R, E, B>(f: (a: A) => Kind3<F, R, E, B>) => (fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export declare function chain<F extends URIS3, E>(
+  F: Chain3C<F, E>
+): <A, R, B>(f: (a: A) => Kind3<F, R, E, B>) => (fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export declare function chain<F extends URIS2>(
+  F: Chain2<F>
+): <A, E, B>(f: (a: A) => Kind2<F, E, B>) => (fa: Kind2<F, E, A>) => Kind2<F, E, B>
+export declare function chain<F extends URIS2, E>(
+  F: Chain2C<F, E>
+): <A, B>(f: (a: A) => Kind2<F, E, B>) => (fa: Kind2<F, E, A>) => Kind2<F, E, B>
+export declare function chain<F extends URIS>(
+  F: Chain1<F>
+): <A, B>(f: (a: A) => Kind<F, B>) => (fa: Kind<F, A>) => Kind<F, B>
+export declare function chain<F>(F: Chain<F>): <A, B>(f: (a: A) => HKT<F, B>) => (fa: HKT<F, A>) => HKT<F, B>
+```
+
+Added in v2.13.0
+
+## compose
+
+Returns a pipeable `compose`
+
+**Signature**
+
+```ts
+export declare function compose<F extends URIS4>(
+  F: Semigroupoid4<F>
+): <S, R, E, A>(ea: Kind4<F, S, R, E, A>) => <B>(ab: Kind4<F, S, R, A, B>) => Kind4<F, S, R, E, B>
+export declare function compose<F extends URIS3>(
+  F: Semigroupoid3<F>
+): <R, E, A>(ea: Kind3<F, R, E, A>) => <B>(ab: Kind3<F, R, A, B>) => Kind3<F, R, E, B>
+export declare function compose<F extends URIS3, E>(
+  F: Semigroupoid3C<F, E>
+): <R, A>(ea: Kind3<F, R, E, A>) => <B>(ab: Kind3<F, R, A, B>) => Kind3<F, R, E, B>
+export declare function compose<F extends URIS2>(
+  F: Semigroupoid2<F>
+): <E, A>(ea: Kind2<F, E, A>) => <B>(ab: Kind2<F, A, B>) => Kind2<F, E, B>
+export declare function compose<F extends URIS2, E>(
+  F: Semigroupoid2C<F, E>
+): <A>(ea: Kind2<F, E, A>) => <B>(ab: Kind2<F, A, B>) => Kind2<F, E, B>
+export declare function compose<F>(
+  F: Semigroupoid<F>
+): <E, A>(ea: HKT2<F, E, A>) => <B>(ab: HKT2<F, A, B>) => HKT2<F, E, B>
+```
+
+Added in v2.13.0
+
+## contramap
+
+Returns a pipeable `contramap`
+
+**Signature**
+
+```ts
+export declare function contramap<F extends URIS4>(
+  F: Contravariant4<F>
+): <A, B>(f: (b: B) => A) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, B>
+export declare function contramap<F extends URIS3>(
+  F: Contravariant3<F>
+): <A, B>(f: (b: B) => A) => <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export declare function contramap<F extends URIS3, E>(
+  F: Contravariant3C<F, E>
+): <A, B>(f: (b: B) => A) => <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export declare function contramap<F extends URIS2>(
+  F: Contravariant2<F>
+): <A, B>(f: (b: B) => A) => <E>(fa: Kind2<F, E, A>) => Kind2<F, E, B>
+export declare function contramap<F extends URIS2, E>(
+  F: Contravariant2C<F, E>
+): <A, B>(f: (b: B) => A) => (fa: Kind2<F, E, A>) => Kind2<F, E, B>
+export declare function contramap<F extends URIS>(
+  F: Contravariant1<F>
+): <A, B>(f: (b: B) => A) => (fa: Kind<F, A>) => Kind<F, B>
+export declare function contramap<F>(F: Contravariant<F>): <A, B>(f: (b: B) => A) => (fa: HKT<F, A>) => HKT<F, B>
+```
+
+Added in v2.13.0
+
+## extend
+
+Returns a pipeable `extend`
+
+**Signature**
+
+```ts
+export declare function extend<F extends URIS4>(
+  F: Extend4<F>
+): <S, R, E, A, B>(f: (wa: Kind4<F, S, R, E, A>) => B) => (wa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, B>
+export declare function extend<F extends URIS3>(
+  F: Extend3<F>
+): <R, E, A, B>(f: (wa: Kind3<F, R, E, A>) => B) => (wa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export declare function extend<F extends URIS3, E>(
+  F: Extend3C<F, E>
+): <R, A, B>(f: (wa: Kind3<F, R, E, A>) => B) => (wa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export declare function extend<F extends URIS2>(
+  F: Extend2<F>
+): <E, A, B>(f: (wa: Kind2<F, E, A>) => B) => (wa: Kind2<F, E, A>) => Kind2<F, E, B>
+export declare function extend<F extends URIS2, E>(
+  F: Extend2C<F, E>
+): <A, B>(f: (wa: Kind2<F, E, A>) => B) => (wa: Kind2<F, E, A>) => Kind2<F, E, B>
+export declare function extend<F extends URIS>(
+  F: Extend1<F>
+): <A, B>(f: (wa: Kind<F, A>) => B) => (wa: Kind<F, A>) => Kind<F, B>
+export declare function extend<F>(F: Extend<F>): <A, B>(f: (wa: HKT<F, A>) => B) => (wa: HKT<F, A>) => HKT<F, B>
+```
+
+Added in v2.13.0
+
+## filter
+
+Returns a pipeable `filter`
+
+**Signature**
+
+```ts
+export declare function filter<F extends URIS4>(
+  F: Filterable4<F>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): <S, R, E>(fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, B>
+  <A>(predicate: Predicate<A>): <S, R, E>(fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, A>
+}
+export declare function filter<F extends URIS3>(
+  F: Filterable3<F>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+  <A>(predicate: Predicate<A>): <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, A>
+}
+export declare function filter<F extends URIS3, E>(
+  F: Filterable3C<F, E>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+  <A>(predicate: Predicate<A>): <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, A>
+}
+export declare function filter<F extends URIS2>(
+  F: Filterable2<F>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): <E>(fa: Kind2<F, E, A>) => Kind2<F, E, B>
+  <A>(predicate: Predicate<A>): <E>(fa: Kind2<F, E, A>) => Kind2<F, E, A>
+}
+export declare function filter<F extends URIS2, E>(
+  F: Filterable2C<F, E>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): (fa: Kind2<F, E, A>) => Kind2<F, E, B>
+  <A>(predicate: Predicate<A>): (fa: Kind2<F, E, A>) => Kind2<F, E, A>
+}
+export declare function filter<F extends URIS>(
+  F: Filterable1<F>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): (fa: Kind<F, A>) => Kind<F, B>
+  <A>(predicate: Predicate<A>): (fa: Kind<F, A>) => Kind<F, A>
+}
+export declare function filter<F>(
+  F: Filterable<F>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): (fa: HKT<F, A>) => HKT<F, B>
+  <A>(predicate: Predicate<A>): (fa: HKT<F, A>) => HKT<F, A>
+}
+```
+
+Added in v2.13.0
+
+## filterMap
+
+Returns a pipeable `filterMap`
+
+**Signature**
+
+```ts
+export declare function filterMap<F extends URIS4>(
+  F: Filterable4<F>
+): <A, B>(f: (a: A) => Option<B>) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, B>
+export declare function filterMap<F extends URIS3>(
+  F: Filterable3<F>
+): <A, B>(f: (a: A) => Option<B>) => <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export declare function filterMap<F extends URIS3, E>(
+  F: Filterable3C<F, E>
+): <A, B>(f: (a: A) => Option<B>) => <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export declare function filterMap<F extends URIS2>(
+  F: Filterable2<F>
+): <A, B>(f: (a: A) => Option<B>) => <E>(fa: Kind2<F, E, A>) => Kind2<F, E, B>
+export declare function filterMap<F extends URIS2, E>(
+  F: Filterable2C<F, E>
+): <A, B>(f: (a: A) => Option<B>) => (fa: Kind2<F, E, A>) => Kind2<F, E, B>
+export declare function filterMap<F extends URIS>(
+  F: Filterable1<F>
+): <A, B>(f: (a: A) => Option<B>) => (fa: Kind<F, A>) => Kind<F, B>
+export declare function filterMap<F>(F: Filterable<F>): <A, B>(f: (a: A) => Option<B>) => (fa: HKT<F, A>) => HKT<F, B>
+```
+
+Added in v2.13.0
+
+## filterMapWithIndex
+
+Returns a pipeable `filterMapWithIndex`
+
+**Signature**
+
+```ts
+export declare function filterMapWithIndex<F extends URIS4, I>(
+  F: FilterableWithIndex4<F, I>
+): <A, B>(f: (i: I, a: A) => Option<B>) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, B>
+export declare function filterMapWithIndex<F extends URIS3, I>(
+  F: FilterableWithIndex3<F, I>
+): <A, B>(f: (i: I, a: A) => Option<B>) => <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export declare function filterMapWithIndex<F extends URIS3, I, E>(
+  F: FilterableWithIndex3C<F, I, E>
+): <A, B>(f: (i: I, a: A) => Option<B>) => <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export declare function filterMapWithIndex<F extends URIS2, I>(
+  F: FilterableWithIndex2<F, I>
+): <A, B>(f: (i: I, a: A) => Option<B>) => <E>(fa: Kind2<F, E, A>) => Kind2<F, E, B>
+export declare function filterMapWithIndex<F extends URIS2, I, E>(
+  F: FilterableWithIndex2C<F, I, E>
+): <A, B>(f: (i: I, a: A) => Option<B>) => (fa: Kind2<F, E, A>) => Kind2<F, E, B>
+export declare function filterMapWithIndex<F extends URIS, I>(
+  F: FilterableWithIndex1<F, I>
+): <A, B>(f: (i: I, a: A) => Option<B>) => (fa: Kind<F, A>) => Kind<F, B>
+export declare function filterMapWithIndex<F, I>(
+  F: FilterableWithIndex<F, I>
+): <A, B>(f: (i: I, a: A) => Option<B>) => (fa: HKT<F, A>) => HKT<F, B>
+```
+
+Added in v2.13.0
+
+## filterWithIndex
+
+Returns a pipeable `filterWithIndex`
+
+**Signature**
+
+```ts
+export declare function filterWithIndex<F extends URIS4, I>(
+  F: FilterableWithIndex4<F, I>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): <S, R, E>(
+    fa: Kind4<F, S, R, E, A>
+  ) => Kind4<F, S, R, E, B>
+  <A>(predicate: PredicateWithIndex<I, A>): <S, R, E>(fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, A>
+}
+export declare function filterWithIndex<F extends URIS3, I>(
+  F: FilterableWithIndex3<F, I>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+  <A>(predicate: PredicateWithIndex<I, A>): <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, A>
+}
+export declare function filterWithIndex<F extends URIS3, I, E>(
+  F: FilterableWithIndex3C<F, I, E>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+  <A>(predicate: PredicateWithIndex<I, A>): <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, A>
+}
+export declare function filterWithIndex<F extends URIS2, I>(
+  F: FilterableWithIndex2<F, I>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): <E>(fa: Kind2<F, E, A>) => Kind2<F, E, B>
+  <A>(predicate: PredicateWithIndex<I, A>): <E>(fa: Kind2<F, E, A>) => Kind2<F, E, A>
+}
+export declare function filterWithIndex<F extends URIS2, E, I>(
+  F: FilterableWithIndex2C<F, I, E>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): (fa: Kind2<F, E, A>) => Kind2<F, E, B>
+  <A>(predicate: PredicateWithIndex<I, A>): (fa: Kind2<F, E, A>) => Kind2<F, E, A>
+}
+export declare function filterWithIndex<F extends URIS, I>(
+  F: FilterableWithIndex1<F, I>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): (fa: Kind<F, A>) => Kind<F, B>
+  <A>(predicate: PredicateWithIndex<I, A>): (fa: Kind<F, A>) => Kind<F, A>
+}
+export declare function filterWithIndex<F, I>(
+  F: FilterableWithIndex<F, I>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): (fa: HKT<F, A>) => HKT<F, B>
+  <A>(predicate: PredicateWithIndex<I, A>): (fa: HKT<F, A>) => HKT<F, A>
+}
+```
+
+Added in v2.13.0
+
+## foldMap
+
+Returns a pipeable `foldMap`
+
+**Signature**
+
+```ts
+export declare function foldMap<F extends URIS4>(
+  F: Foldable4<F>
+): <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => M
+export declare function foldMap<F extends URIS3>(
+  F: Foldable3<F>
+): <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => <R, E>(fa: Kind3<F, R, E, A>) => M
+export declare function foldMap<F extends URIS3, E>(
+  F: Foldable3C<F, E>
+): <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => <R>(fa: Kind3<F, R, E, A>) => M
+export declare function foldMap<F extends URIS2>(
+  F: Foldable2<F>
+): <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => <E>(fa: Kind2<F, E, A>) => M
+export declare function foldMap<F extends URIS2, E>(
+  F: Foldable2C<F, E>
+): <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => (fa: Kind2<F, E, A>) => M
+export declare function foldMap<F extends URIS>(
+  F: Foldable1<F>
+): <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => (fa: Kind<F, A>) => M
+export declare function foldMap<F>(F: Foldable<F>): <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => (fa: HKT<F, A>) => M
+```
+
+Added in v2.13.0
+
+## foldMapWithIndex
+
+Returns a pipeable `foldMapWithIndex`
+
+**Signature**
+
+```ts
+export declare function foldMapWithIndex<F extends URIS4, I>(
+  F: FoldableWithIndex4<F, I>
+): <M>(M: Monoid<M>) => <A>(f: (i: I, a: A) => M) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => M
+export declare function foldMapWithIndex<F extends URIS3, I>(
+  F: FoldableWithIndex3<F, I>
+): <M>(M: Monoid<M>) => <A>(f: (i: I, a: A) => M) => <R, E>(fa: Kind3<F, R, E, A>) => M
+export declare function foldMapWithIndex<F extends URIS3, I, E>(
+  F: FoldableWithIndex3C<F, I, E>
+): <M>(M: Monoid<M>) => <A>(f: (i: I, a: A) => M) => <R>(fa: Kind3<F, R, E, A>) => M
+export declare function foldMapWithIndex<F extends URIS2, I>(
+  F: FoldableWithIndex2<F, I>
+): <M>(M: Monoid<M>) => <A>(f: (i: I, a: A) => M) => <E>(fa: Kind2<F, E, A>) => M
+export declare function foldMapWithIndex<F extends URIS2, I, E>(
+  F: FoldableWithIndex2C<F, I, E>
+): <M>(M: Monoid<M>) => <A>(f: (i: I, a: A) => M) => (fa: Kind2<F, E, A>) => M
+export declare function foldMapWithIndex<F extends URIS, I>(
+  F: FoldableWithIndex1<F, I>
+): <M>(M: Monoid<M>) => <A>(f: (i: I, a: A) => M) => (fa: Kind<F, A>) => M
+export declare function foldMapWithIndex<F, I>(
+  F: FoldableWithIndex<F, I>
+): <M>(M: Monoid<M>) => <A>(f: (i: I, a: A) => M) => (fa: HKT<F, A>) => M
+```
+
+Added in v2.13.0
+
+## map
+
+Returns a pipeable `map`
+
+**Signature**
+
+```ts
+export declare function map<F extends URIS4>(
+  F: Functor4<F>
+): <A, B>(f: (a: A) => B) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, B>
+export declare function map<F extends URIS3>(
+  F: Functor3<F>
+): <A, B>(f: (a: A) => B) => <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export declare function map<F extends URIS3, E>(
+  F: Functor3C<F, E>
+): <A, B>(f: (a: A) => B) => <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export declare function map<F extends URIS2>(
+  F: Functor2<F>
+): <A, B>(f: (a: A) => B) => <E>(fa: Kind2<F, E, A>) => Kind2<F, E, B>
+export declare function map<F extends URIS2, E>(
+  F: Functor2C<F, E>
+): <A, B>(f: (a: A) => B) => (fa: Kind2<F, E, A>) => Kind2<F, E, B>
+export declare function map<F extends URIS>(F: Functor1<F>): <A, B>(f: (a: A) => B) => (fa: Kind<F, A>) => Kind<F, B>
+export declare function map<F>(F: Functor<F>): <A, B>(f: (a: A) => B) => (fa: HKT<F, A>) => HKT<F, B>
+```
+
+Added in v2.13.0
+
+## mapLeft
+
+Returns a pipeable `mapLeft`
+
+**Signature**
+
+```ts
+export declare function mapLeft<F extends URIS4>(
+  F: Bifunctor4<F>
+): <E, G>(f: (e: E) => G) => <S, R, A>(fea: Kind4<F, S, R, E, A>) => Kind4<F, S, R, G, A>
+export declare function mapLeft<F extends URIS3>(
+  F: Bifunctor3<F>
+): <E, G>(f: (e: E) => G) => <R, A>(fea: Kind3<F, R, E, A>) => Kind3<F, R, G, A>
+export declare function mapLeft<F extends URIS3, E>(
+  F: Bifunctor3C<F, E>
+): <E, G>(f: (e: E) => G) => <R, A>(fea: Kind3<F, R, E, A>) => Kind3<F, R, G, A>
+export declare function mapLeft<F extends URIS2>(
+  F: Bifunctor2<F>
+): <E, G>(f: (e: E) => G) => <A>(fea: Kind2<F, E, A>) => Kind2<F, G, A>
+export declare function mapLeft<F extends URIS2, E>(
+  F: Bifunctor2C<F, E>
+): <E, G>(f: (e: E) => G) => <A>(fea: Kind2<F, E, A>) => Kind2<F, G, A>
+export declare function mapLeft<F>(F: Bifunctor<F>): <E, G>(f: (e: E) => G) => <A>(fea: HKT2<F, E, A>) => HKT2<F, G, A>
+```
+
+Added in v2.13.0
+
+## mapWithIndex
+
+Returns a pipeable `mapWithIndex`
+
+**Signature**
+
+```ts
+export declare function mapWithIndex<F extends URIS4, I>(
+  F: FunctorWithIndex4<F, I>
+): <A, B>(f: (i: I, a: A) => B) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, B>
+export declare function mapWithIndex<F extends URIS3, I>(
+  F: FunctorWithIndex3<F, I>
+): <A, B>(f: (i: I, a: A) => B) => <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export declare function mapWithIndex<F extends URIS3, I, E>(
+  F: FunctorWithIndex3C<F, I, E>
+): <A, B>(f: (i: I, a: A) => B) => <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export declare function mapWithIndex<F extends URIS2, I>(
+  F: FunctorWithIndex2<F, I>
+): <A, B>(f: (i: I, a: A) => B) => <E>(fa: Kind2<F, E, A>) => Kind2<F, E, B>
+export declare function mapWithIndex<F extends URIS2, I, E>(
+  F: FunctorWithIndex2C<F, I, E>
+): <A, B>(f: (i: I, a: A) => B) => (fa: Kind2<F, E, A>) => Kind2<F, E, B>
+export declare function mapWithIndex<F extends URIS, I>(
+  F: FunctorWithIndex1<F, I>
+): <A, B>(f: (i: I, a: A) => B) => (fa: Kind<F, A>) => Kind<F, B>
+export declare function mapWithIndex<F, I>(
+  F: FunctorWithIndex<F, I>
+): <A, B>(f: (i: I, a: A) => B) => (fa: HKT<F, A>) => HKT<F, B>
+```
+
+Added in v2.13.0
+
+## partition
+
+Returns a pipeable `partition`
+
+**Signature**
+
+```ts
+export declare function partition<F extends URIS4>(
+  F: Filterable4<F>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): <S, R, E>(
+    fa: Kind4<F, S, R, E, A>
+  ) => Separated<Kind4<F, S, R, E, A>, Kind4<F, S, R, E, B>>
+  <A>(predicate: Predicate<A>): <S, R, E>(
+    fa: Kind4<F, S, R, E, A>
+  ) => Separated<Kind4<F, S, R, E, A>, Kind4<F, S, R, E, A>>
+}
+export declare function partition<F extends URIS3>(
+  F: Filterable3<F>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): <R, E>(
+    fa: Kind3<F, R, E, A>
+  ) => Separated<Kind3<F, R, E, A>, Kind3<F, R, E, B>>
+  <A>(predicate: Predicate<A>): <R, E>(fa: Kind3<F, R, E, A>) => Separated<Kind3<F, R, E, A>, Kind3<F, R, E, A>>
+}
+export declare function partition<F extends URIS3, E>(
+  F: Filterable3C<F, E>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): <R>(
+    fa: Kind3<F, R, E, A>
+  ) => Separated<Kind3<F, R, E, A>, Kind3<F, R, E, B>>
+  <A>(predicate: Predicate<A>): <R>(fa: Kind3<F, R, E, A>) => Separated<Kind3<F, R, E, A>, Kind3<F, R, E, A>>
+}
+export declare function partition<F extends URIS2>(
+  F: Filterable2<F>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): <E>(fa: Kind2<F, E, A>) => Separated<Kind2<F, E, A>, Kind2<F, E, B>>
+  <A>(predicate: Predicate<A>): <E>(fa: Kind2<F, E, A>) => Separated<Kind2<F, E, A>, Kind2<F, E, A>>
+}
+export declare function partition<F extends URIS2, E>(
+  F: Filterable2C<F, E>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): (fa: Kind2<F, E, A>) => Separated<Kind2<F, E, A>, Kind2<F, E, B>>
+  <A>(predicate: Predicate<A>): (fa: Kind2<F, E, A>) => Separated<Kind2<F, E, A>, Kind2<F, E, A>>
+}
+export declare function partition<F extends URIS>(
+  F: Filterable1<F>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): (fa: Kind<F, A>) => Separated<Kind<F, A>, Kind<F, B>>
+  <A>(predicate: Predicate<A>): (fa: Kind<F, A>) => Separated<Kind<F, A>, Kind<F, A>>
+}
+export declare function partition<F>(
+  F: Filterable<F>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): (fa: HKT<F, A>) => Separated<HKT<F, A>, HKT<F, B>>
+  <A>(predicate: Predicate<A>): (fa: HKT<F, A>) => Separated<HKT<F, A>, HKT<F, A>>
+}
+```
+
+Added in v2.13.0
+
+## partitionMap
+
+Returns a pipeable `partitionMap`
+
+**Signature**
+
+```ts
+export declare function partitionMap<F extends URIS4>(
+  F: Filterable4<F>
+): <A, B, C>(
+  f: (a: A) => Either<B, C>
+) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => Separated<Kind4<F, S, R, E, B>, Kind4<F, S, R, E, C>>
+export declare function partitionMap<F extends URIS3>(
+  F: Filterable3<F>
+): <A, B, C>(
+  f: (a: A) => Either<B, C>
+) => <R, E>(fa: Kind3<F, R, E, A>) => Separated<Kind3<F, R, E, B>, Kind3<F, R, E, C>>
+export declare function partitionMap<F extends URIS3, E>(
+  F: Filterable3C<F, E>
+): <A, B, C>(f: (a: A) => Either<B, C>) => <R>(fa: Kind3<F, R, E, A>) => Separated<Kind3<F, R, E, B>, Kind3<F, R, E, C>>
+export declare function partitionMap<F extends URIS2>(
+  F: Filterable2<F>
+): <A, B, C>(f: (a: A) => Either<B, C>) => <E>(fa: Kind2<F, E, A>) => Separated<Kind2<F, E, B>, Kind2<F, E, C>>
+export declare function partitionMap<F extends URIS2, E>(
+  F: Filterable2C<F, E>
+): <A, B, C>(f: (a: A) => Either<B, C>) => (fa: Kind2<F, E, A>) => Separated<Kind2<F, E, B>, Kind2<F, E, C>>
+export declare function partitionMap<F extends URIS>(
+  F: Filterable1<F>
+): <A, B, C>(f: (a: A) => Either<B, C>) => (fa: Kind<F, A>) => Separated<Kind<F, B>, Kind<F, C>>
+export declare function partitionMap<F>(
+  F: Filterable<F>
+): <A, B, C>(f: (a: A) => Either<B, C>) => (fa: HKT<F, A>) => Separated<HKT<F, B>, HKT<F, C>>
+```
+
+Added in v2.13.0
+
+## partitionMapWithIndex
+
+Returns a pipeable `partitionMapWithIndex`
+
+**Signature**
+
+```ts
+export declare function partitionMapWithIndex<F extends URIS4, I>(
+  F: FilterableWithIndex4<F, I>
+): <A, B, C>(
+  f: (i: I, a: A) => Either<B, C>
+) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => Separated<Kind4<F, S, R, E, B>, Kind4<F, S, R, E, C>>
+export declare function partitionMapWithIndex<F extends URIS3, I>(
+  F: FilterableWithIndex3<F, I>
+): <A, B, C>(
+  f: (i: I, a: A) => Either<B, C>
+) => <R, E>(fa: Kind3<F, R, E, A>) => Separated<Kind3<F, R, E, B>, Kind3<F, R, E, C>>
+export declare function partitionMapWithIndex<F extends URIS3, I, E>(
+  F: FilterableWithIndex3C<F, I, E>
+): <A, B, C>(
+  f: (i: I, a: A) => Either<B, C>
+) => <R>(fa: Kind3<F, R, E, A>) => Separated<Kind3<F, R, E, B>, Kind3<F, R, E, C>>
+export declare function partitionMapWithIndex<F extends URIS2, I>(
+  F: FilterableWithIndex2<F, I>
+): <A, B, C>(f: (i: I, a: A) => Either<B, C>) => <E>(fa: Kind2<F, E, A>) => Separated<Kind2<F, E, B>, Kind2<F, E, C>>
+export declare function partitionMapWithIndex<F extends URIS2, I, E>(
+  F: FilterableWithIndex2C<F, I, E>
+): <A, B, C>(f: (i: I, a: A) => Either<B, C>) => (fa: Kind2<F, E, A>) => Separated<Kind2<F, E, B>, Kind2<F, E, C>>
+export declare function partitionMapWithIndex<F extends URIS, I>(
+  F: FilterableWithIndex1<F, I>
+): <A, B, C>(f: (i: I, a: A) => Either<B, C>) => (fa: Kind<F, A>) => Separated<Kind<F, B>, Kind<F, C>>
+export declare function partitionMapWithIndex<F, I>(
+  F: FilterableWithIndex<F, I>
+): <A, B, C>(f: (i: I, a: A) => Either<B, C>) => (fa: HKT<F, A>) => Separated<HKT<F, B>, HKT<F, C>>
+```
+
+Added in v2.13.0
+
+## partitionWithIndex
+
+Returns a pipeable `partitionWithIndex`
+
+**Signature**
+
+```ts
+export declare function partitionWithIndex<F extends URIS4, I>(
+  F: FilterableWithIndex4<F, I>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): <S, R, E>(
+    fa: Kind4<F, S, R, E, A>
+  ) => Separated<Kind4<F, S, R, E, A>, Kind4<F, S, R, E, B>>
+  <A>(predicate: PredicateWithIndex<I, A>): <S, R, E>(
+    fa: Kind4<F, S, R, E, A>
+  ) => Separated<Kind4<F, S, R, E, A>, Kind4<F, S, R, E, A>>
+}
+export declare function partitionWithIndex<F extends URIS3, I>(
+  F: FilterableWithIndex3<F, I>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): <R, E>(
+    fa: Kind3<F, R, E, A>
+  ) => Separated<Kind3<F, R, E, A>, Kind3<F, R, E, B>>
+  <A>(predicate: PredicateWithIndex<I, A>): <R, E>(
+    fa: Kind3<F, R, E, A>
+  ) => Separated<Kind3<F, R, E, A>, Kind3<F, R, E, A>>
+}
+export declare function partitionWithIndex<F extends URIS3, I, E>(
+  F: FilterableWithIndex3C<F, I, E>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): <R>(
+    fa: Kind3<F, R, E, A>
+  ) => Separated<Kind3<F, R, E, A>, Kind3<F, R, E, B>>
+  <A>(predicate: PredicateWithIndex<I, A>): <R>(
+    fa: Kind3<F, R, E, A>
+  ) => Separated<Kind3<F, R, E, A>, Kind3<F, R, E, A>>
+}
+export declare function partitionWithIndex<F extends URIS2, I>(
+  F: FilterableWithIndex2<F, I>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): <E>(
+    fa: Kind2<F, E, A>
+  ) => Separated<Kind2<F, E, A>, Kind2<F, E, B>>
+  <A>(predicate: PredicateWithIndex<I, A>): <E>(fa: Kind2<F, E, A>) => Separated<Kind2<F, E, A>, Kind2<F, E, A>>
+}
+export declare function partitionWithIndex<F extends URIS2, I, E>(
+  F: FilterableWithIndex2C<F, I, E>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): (
+    fa: Kind2<F, E, A>
+  ) => Separated<Kind2<F, E, A>, Kind2<F, E, B>>
+  <A>(predicate: PredicateWithIndex<I, A>): (fa: Kind2<F, E, A>) => Separated<Kind2<F, E, A>, Kind2<F, E, A>>
+}
+export declare function partitionWithIndex<F extends URIS, I>(
+  F: FilterableWithIndex1<F, I>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): (fa: Kind<F, A>) => Separated<Kind<F, A>, Kind<F, B>>
+  <A>(predicate: PredicateWithIndex<I, A>): (fa: Kind<F, A>) => Separated<Kind<F, A>, Kind<F, A>>
+}
+export declare function partitionWithIndex<F, I>(
+  F: FilterableWithIndex<F, I>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): (fa: HKT<F, A>) => Separated<HKT<F, A>, HKT<F, B>>
+  <A>(predicate: PredicateWithIndex<I, A>): (fa: HKT<F, A>) => Separated<HKT<F, A>, HKT<F, A>>
+}
+```
+
+Added in v2.13.0
+
+## promap
+
+Returns a pipeable `promap`
+
+**Signature**
+
+```ts
+export declare function promap<F extends URIS4>(
+  F: Profunctor4<F>
+): <E, A, D, B>(f: (d: D) => E, g: (a: A) => B) => <S, R>(fbc: Kind4<F, S, R, E, A>) => Kind4<F, S, R, D, B>
+export declare function promap<F extends URIS3>(
+  F: Profunctor3<F>
+): <E, A, D, B>(f: (d: D) => E, g: (a: A) => B) => <R>(fbc: Kind3<F, R, E, A>) => Kind3<F, R, D, B>
+export declare function promap<F extends URIS3, E>(
+  F: Profunctor3C<F, E>
+): <A, D, B>(f: (d: D) => E, g: (a: A) => B) => <R>(fbc: Kind3<F, R, E, A>) => Kind3<F, R, D, B>
+export declare function promap<F extends URIS2>(
+  F: Profunctor2<F>
+): <E, A, D, B>(f: (d: D) => E, g: (a: A) => B) => (fbc: Kind2<F, E, A>) => Kind2<F, D, B>
+export declare function promap<F extends URIS2, E>(
+  F: Profunctor2C<F, E>
+): <A, D, B>(f: (d: D) => E, g: (a: A) => B) => (fbc: Kind2<F, E, A>) => Kind2<F, D, B>
+export declare function promap<F>(
+  F: Profunctor<F>
+): <E, A, D, B>(f: (d: D) => E, g: (a: A) => B) => (fbc: HKT2<F, E, A>) => HKT2<F, D, B>
+```
+
+Added in v2.13.0
+
+## reduce
+
+Returns a pipeable `reduce`
+
+**Signature**
+
+```ts
+export declare function reduce<F extends URIS4>(
+  F: Foldable4<F>
+): <A, B>(b: B, f: (b: B, a: A) => B) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => B
+export declare function reduce<F extends URIS3>(
+  F: Foldable3<F>
+): <A, B>(b: B, f: (b: B, a: A) => B) => <R, E>(fa: Kind3<F, R, E, A>) => B
+export declare function reduce<F extends URIS3, E>(
+  F: Foldable3C<F, E>
+): <A, B>(b: B, f: (b: B, a: A) => B) => <R>(fa: Kind3<F, R, E, A>) => B
+export declare function reduce<F extends URIS2>(
+  F: Foldable2<F>
+): <A, B>(b: B, f: (b: B, a: A) => B) => <E>(fa: Kind2<F, E, A>) => B
+export declare function reduce<F extends URIS2, E>(
+  F: Foldable2C<F, E>
+): <A, B>(b: B, f: (b: B, a: A) => B) => (fa: Kind2<F, E, A>) => B
+export declare function reduce<F extends URIS>(
+  F: Foldable1<F>
+): <A, B>(b: B, f: (b: B, a: A) => B) => (fa: Kind<F, A>) => B
+export declare function reduce<F>(F: Foldable<F>): <A, B>(b: B, f: (b: B, a: A) => B) => (fa: HKT<F, A>) => B
+```
+
+Added in v2.13.0
+
+## reduceRight
+
+Returns a pipeable `reduceRight`
+
+**Signature**
+
+```ts
+export declare function reduceRight<F extends URIS4>(
+  F: Foldable4<F>
+): <A, B>(b: B, f: (a: A, b: B) => B) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => B
+export declare function reduceRight<F extends URIS3>(
+  F: Foldable3<F>
+): <A, B>(b: B, f: (a: A, b: B) => B) => <R, E>(fa: Kind3<F, R, E, A>) => B
+export declare function reduceRight<F extends URIS3, E>(
+  F: Foldable3C<F, E>
+): <A, B>(b: B, f: (a: A, b: B) => B) => <R>(fa: Kind3<F, R, E, A>) => B
+export declare function reduceRight<F extends URIS2>(
+  F: Foldable2<F>
+): <A, B>(b: B, f: (a: A, b: B) => B) => <E>(fa: Kind2<F, E, A>) => B
+export declare function reduceRight<F extends URIS2, E>(
+  F: Foldable2C<F, E>
+): <A, B>(b: B, f: (a: A, b: B) => B) => (fa: Kind2<F, E, A>) => B
+export declare function reduceRight<F extends URIS>(
+  F: Foldable1<F>
+): <A, B>(b: B, f: (a: A, b: B) => B) => (fa: Kind<F, A>) => B
+export declare function reduceRight<F>(F: Foldable<F>): <A, B>(b: B, f: (a: A, b: B) => B) => (fa: HKT<F, A>) => B
+```
+
+Added in v2.13.0
+
+## reduceRightWithIndex
+
+Returns a pipeable `reduceRightWithIndex`
+
+**Signature**
+
+```ts
+export declare function reduceRightWithIndex<F extends URIS4, I>(
+  F: FoldableWithIndex4<F, I>
+): <A, B>(b: B, f: (i: I, a: A, b: B) => B) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => B
+export declare function reduceRightWithIndex<F extends URIS3, I>(
+  F: FoldableWithIndex3<F, I>
+): <A, B>(b: B, f: (i: I, a: A, b: B) => B) => <R, E>(fa: Kind3<F, R, E, A>) => B
+export declare function reduceRightWithIndex<F extends URIS3, I, E>(
+  F: FoldableWithIndex3C<F, I, E>
+): <A, B>(b: B, f: (i: I, a: A, b: B) => B) => <R>(fa: Kind3<F, R, E, A>) => B
+export declare function reduceRightWithIndex<F extends URIS2, I>(
+  F: FoldableWithIndex2<F, I>
+): <A, B>(b: B, f: (i: I, a: A, b: B) => B) => <E>(fa: Kind2<F, E, A>) => B
+export declare function reduceRightWithIndex<F extends URIS2, I, E>(
+  F: FoldableWithIndex2C<F, I, E>
+): <A, B>(b: B, f: (i: I, a: A, b: B) => B) => (fa: Kind2<F, E, A>) => B
+export declare function reduceRightWithIndex<F extends URIS, I>(
+  F: FoldableWithIndex1<F, I>
+): <A, B>(b: B, f: (i: I, a: A, b: B) => B) => (fa: Kind<F, A>) => B
+export declare function reduceRightWithIndex<F, I>(
+  F: FoldableWithIndex<F, I>
+): <A, B>(b: B, f: (i: I, a: A, b: B) => B) => (fa: HKT<F, A>) => B
+```
+
+Added in v2.13.0
+
+## reduceWithIndex
+
+Returns a pipeable `reduceWithIndex`
+
+**Signature**
+
+```ts
+export declare function reduceWithIndex<F extends URIS4, I>(
+  F: FoldableWithIndex4<F, I>
+): <A, B>(b: B, f: (i: I, b: B, a: A) => B) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => B
+export declare function reduceWithIndex<F extends URIS3, I>(
+  F: FoldableWithIndex3<F, I>
+): <A, B>(b: B, f: (i: I, b: B, a: A) => B) => <R, E>(fa: Kind3<F, R, E, A>) => B
+export declare function reduceWithIndex<F extends URIS3, I, E>(
+  F: FoldableWithIndex3C<F, I, E>
+): <A, B>(b: B, f: (i: I, b: B, a: A) => B) => <R>(fa: Kind3<F, R, E, A>) => B
+export declare function reduceWithIndex<F extends URIS2, I>(
+  F: FoldableWithIndex2<F, I>
+): <A, B>(b: B, f: (i: I, b: B, a: A) => B) => <E>(fa: Kind2<F, E, A>) => B
+export declare function reduceWithIndex<F extends URIS2, I, E>(
+  F: FoldableWithIndex2C<F, I, E>
+): <A, B>(b: B, f: (i: I, b: B, a: A) => B) => (fa: Kind2<F, E, A>) => B
+export declare function reduceWithIndex<F extends URIS, I>(
+  F: FoldableWithIndex1<F, I>
+): <A, B>(b: B, f: (i: I, b: B, a: A) => B) => (fa: Kind<F, A>) => B
+export declare function reduceWithIndex<F, I>(
+  F: FoldableWithIndex<F, I>
+): <A, B>(b: B, f: (i: I, b: B, a: A) => B) => (fa: HKT<F, A>) => B
+```
+
+Added in v2.13.0
 
 # utils
 

--- a/dtslint/ts3.5/pipeable.ts
+++ b/dtslint/ts3.5/pipeable.ts
@@ -1,0 +1,256 @@
+import * as P from '../../src/pipeable'
+import * as T from '../../src/Task'
+import * as TE from '../../src/TaskEither'
+import * as RTE from '../../src/ReaderTaskEither'
+import * as SRTE from '../../src/StateReaderTaskEither'
+import * as S from '../../src/string'
+import * as TH from '../../src/These'
+import { Chain3C } from '../../src/Chain'
+import * as O from '../../src/Option'
+import * as Eq from '../../src/Eq'
+import * as RA from '../../src/ReadonlyArray'
+import * as R from '../../src/Reader'
+import * as RT from '../../src/ReadonlyTuple'
+
+const TEApplicative = TE.getApplicativeTaskValidation(T.ApplyPar, S.Semigroup)
+const TEAlt = TE.getAltTaskValidation(S.Semigroup)
+const RTEApplicative = RTE.getApplicativeReaderTaskValidation(T.ApplyPar, S.Semigroup)
+const RTEAlt = RTE.getAltReaderTaskValidation(S.Semigroup)
+
+//
+// map
+//
+
+// $ExpectType <A, B>(f: (a: A) => B) => (fa: Task<A>) => Task<B>
+P.map(T.Functor)
+
+// $ExpectType <A, B>(f: (a: A) => B) => <E>(fa: TaskEither<E, A>) => TaskEither<E, B>
+P.map(TE.Functor)
+
+// $ExpectType <A, B>(f: (a: A) => B) => (fa: TaskEither<string, A>) => TaskEither<string, B>
+P.map(TEApplicative)
+
+// $ExpectType <A, B>(f: (a: A) => B) => <R, E>(fa: ReaderTaskEither<R, E, A>) => ReaderTaskEither<R, E, B>
+P.map(RTE.Functor)
+
+// $ExpectType <A, B>(f: (a: A) => B) => <R>(fa: ReaderTaskEither<R, string, A>) => ReaderTaskEither<R, string, B>
+P.map(RTEApplicative)
+
+// $ExpectType <A, B>(f: (a: A) => B) => <S, R, E>(fa: StateReaderTaskEither<S, R, E, A>) => StateReaderTaskEither<S, R, E, B>
+P.map(SRTE.Functor)
+
+//
+// mapWithIndex
+//
+
+// $ExpectType <A, B>(f: (i: number, a: A) => B) => (fa: readonly A[]) => readonly B[]
+P.mapWithIndex(RA.FunctorWithIndex)
+
+//
+// contramap
+//
+
+// $ExpectType <A, B>(f: (b: B) => A) => (fa: Eq<A>) => Eq<B>
+P.contramap(Eq.Contravariant)
+
+//
+// ap
+//
+
+// $ExpectType <A>(fa: Task<A>) => <B>(fab: Task<(a: A) => B>) => Task<B>
+P.ap(T.ApplyPar)
+
+// $ExpectType <E, A>(fa: TaskEither<E, A>) => <B>(fab: TaskEither<E, (a: A) => B>) => TaskEither<E, B>
+P.ap(TE.ApplyPar)
+
+// $ExpectType <A>(fa: TaskEither<string, A>) => <B>(fab: TaskEither<string, (a: A) => B>) => TaskEither<string, B>
+P.ap(TEApplicative)
+
+// $ExpectType <R, E, A>(fa: ReaderTaskEither<R, E, A>) => <B>(fab: ReaderTaskEither<R, E, (a: A) => B>) => ReaderTaskEither<R, E, B>
+P.ap(RTE.ApplyPar)
+
+// $ExpectType <R, A>(fa: ReaderTaskEither<R, string, A>) => <B>(fab: ReaderTaskEither<R, string, (a: A) => B>) => ReaderTaskEither<R, string, B>
+P.ap(RTEApplicative)
+
+// $ExpectType <S, R, E, A>(fa: StateReaderTaskEither<S, R, E, A>) => <B>(fab: StateReaderTaskEither<S, R, E, (a: A) => B>) => StateReaderTaskEither<S, R, E, B>
+P.ap(SRTE.Apply)
+
+//
+// chain
+//
+
+// $ExpectType <A, B>(f: (a: A) => Task<B>) => (fa: Task<A>) => Task<B>
+P.chain(T.Chain)
+
+// $ExpectType <A, E, B>(f: (a: A) => TaskEither<E, B>) => (fa: TaskEither<E, A>) => TaskEither<E, B>
+P.chain(TE.Chain)
+
+const THChain = TH.getChain(S.Semigroup)
+
+// $ExpectType <A, B>(f: (a: A) => These<string, B>) => (fa: These<string, A>) => These<string, B>
+P.chain(THChain)
+
+// $ExpectType <A, R, E, B>(f: (a: A) => ReaderTaskEither<R, E, B>) => (fa: ReaderTaskEither<R, E, A>) => ReaderTaskEither<R, E, B>
+P.chain(RTE.Chain)
+
+declare const Chain3C: Chain3C<RTE.URI, string>
+// $ExpectType <A, R, B>(f: (a: A) => ReaderTaskEither<R, string, B>) => (fa: ReaderTaskEither<R, string, A>) => ReaderTaskEither<R, string, B>
+P.chain(Chain3C)
+
+// $ExpectType <A, S, R, E, B>(f: (a: A) => StateReaderTaskEither<S, R, E, B>) => (fa: StateReaderTaskEither<S, R, E, A>) => StateReaderTaskEither<S, R, E, B>
+P.chain(SRTE.Chain)
+
+//
+// bimap
+//
+
+// $ExpectType <E, G, A, B>(f: (e: E) => G, g: (a: A) => B) => (fea: These<E, A>) => These<G, B>
+P.bimap(TH.Bifunctor)
+
+//
+// mapLeft
+//
+
+// $ExpectType <E, G>(f: (e: E) => G) => <A>(fea: These<E, A>) => These<G, A>
+P.mapLeft(TH.Bifunctor)
+
+//
+// extend
+//
+
+// $ExpectType <A, B>(f: (wa: readonly A[]) => B) => (wa: readonly A[]) => readonly B[]
+P.extend(RA.Extend)
+
+//
+// reduce
+//
+
+// $ExpectType <A, B>(b: B, f: (b: B, a: A) => B) => (fa: readonly A[]) => B
+P.reduce(RA.Foldable)
+
+//
+// foldMap
+//
+
+// $ExpectType <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => (fa: readonly A[]) => M
+P.foldMap(RA.Foldable)
+
+//
+// reduceRight
+//
+
+// $ExpectType <A, B>(b: B, f: (a: A, b: B) => B) => (fa: readonly A[]) => B
+P.reduceRight(RA.Foldable)
+
+//
+// reduceWithIndex
+//
+
+// $ExpectType <A, B>(b: B, f: (i: number, b: B, a: A) => B) => (fa: readonly A[]) => B
+P.reduceWithIndex(RA.FoldableWithIndex)
+
+//
+// foldMapWithIndex
+//
+
+// $ExpectType <M>(M: Monoid<M>) => <A>(f: (i: number, a: A) => M) => (fa: readonly A[]) => M
+P.foldMapWithIndex(RA.FoldableWithIndex)
+
+//
+// reduceRightWithIndex
+//
+
+// $ExpectType <A, B>(b: B, f: (i: number, a: A, b: B) => B) => (fa: readonly A[]) => B
+P.reduceRightWithIndex(RA.FoldableWithIndex)
+
+//
+// alt
+//
+
+// $ExpectType <A>(that: Lazy<Option<A>>) => (fa: Option<A>) => Option<A>
+P.alt(O.Alt)
+
+// $ExpectType <E, A>(that: Lazy<TaskEither<E, A>>) => (fa: TaskEither<E, A>) => TaskEither<E, A>
+P.alt(TE.Alt)
+
+// $ExpectType <A>(that: Lazy<TaskEither<string, A>>) => (fa: TaskEither<string, A>) => TaskEither<string, A>
+P.alt(TEAlt)
+
+// $ExpectType <R, E, A>(that: Lazy<ReaderTaskEither<R, E, A>>) => (fa: ReaderTaskEither<R, E, A>) => ReaderTaskEither<R, E, A>
+P.alt(RTE.Alt)
+
+// $ExpectType <R, A>(that: Lazy<ReaderTaskEither<R, string, A>>) => (fa: ReaderTaskEither<R, string, A>) => ReaderTaskEither<R, string, A>
+P.alt(RTEAlt)
+
+// $ExpectType <S, R, E, A>(that: Lazy<StateReaderTaskEither<S, R, E, A>>) => (fa: StateReaderTaskEither<S, R, E, A>) => StateReaderTaskEither<S, R, E, A>
+P.alt(SRTE.Alt)
+
+//
+// filter
+//
+
+// $ExpectType { <A, B extends A>(refinement: Refinement<A, B>): (fa: readonly A[]) => readonly B[]; <A>(predicate: Predicate<A>): (fa: readonly A[]) => readonly A[]; }
+P.filter(RA.Filterable)
+
+//
+// filterMap
+//
+
+// $ExpectType <A, B>(f: (a: A) => Option<B>) => (fa: readonly A[]) => readonly B[]
+P.filterMap(RA.Filterable)
+
+//
+// partition
+//
+
+// $ExpectType { <A, B extends A>(refinement: Refinement<A, B>): (fa: readonly A[]) => Separated<readonly A[], readonly B[]>; <A>(predicate: Predicate<A>): (fa: readonly A[]) => Separated<readonly A[], readonly A[]>; }
+P.partition(RA.Filterable)
+
+//
+// partitionMap
+//
+
+// $ExpectType <A, B, C>(f: (a: A) => Either<B, C>) => (fa: readonly A[]) => Separated<readonly B[], readonly C[]>
+P.partitionMap(RA.Filterable)
+
+//
+// filterWithIndex
+//
+
+// $ExpectType { <A, B extends A>(refinement: RefinementWithIndex<number, A, B>): (fa: readonly A[]) => readonly B[]; <A>(predicate: PredicateWithIndex<number, A>): (fa: readonly A[]) => readonly A[]; }
+P.filterWithIndex(RA.FilterableWithIndex)
+
+//
+// filterMapWithIndex
+//
+
+// $ExpectType <A, B>(f: (i: number, a: A) => Option<B>) => (fa: readonly A[]) => readonly B[]
+P.filterMapWithIndex(RA.FilterableWithIndex)
+
+//
+// partitionWithIndex
+//
+
+// $ExpectType { <A, B extends A>(refinement: RefinementWithIndex<number, A, B>): (fa: readonly A[]) => Separated<readonly A[], readonly B[]>; <A>(predicate: PredicateWithIndex<number, A>): (fa: readonly A[]) => Separated<readonly A[], readonly A[]>; }
+P.partitionWithIndex(RA.FilterableWithIndex)
+
+//
+// partitionMapWithIndex
+//
+
+// $ExpectType <A, B, C>(f: (i: number, a: A) => Either<B, C>) => (fa: readonly A[]) => Separated<readonly B[], readonly C[]>
+P.partitionMapWithIndex(RA.FilterableWithIndex)
+
+//
+// promap
+//
+
+// $ExpectType <E, A, D, B>(f: (d: D) => E, g: (a: A) => B) => (fbc: Reader<E, A>) => Reader<D, B>
+P.promap(R.Profunctor)
+
+//
+// compose
+//
+
+// $ExpectType <E, A>(ea: readonly [A, E]) => <B>(ab: readonly [B, A]) => readonly [B, E]
+P.compose(RT.Semigroupoid)

--- a/dtslint/ts3.5/tslint.json
+++ b/dtslint/ts3.5/tslint.json
@@ -17,6 +17,7 @@
     "use-default-type-parameter": false,
     "no-relative-import-in-test": false,
     "no-null-undefined-union": false,
-    "invalid-void": false
+    "invalid-void": false,
+    "max-line-length": false
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fp-ts",
-  "version": "2.12.3",
+  "version": "2.13.0",
   "description": "Functional programming in TypeScript",
   "main": "lib/index.js",
   "module": "es6/index.js",

--- a/src/pipeable.ts
+++ b/src/pipeable.ts
@@ -2,9 +2,19 @@
  * @since 2.0.0
  */
 import { Alt, Alt1, Alt2, Alt2C, Alt3, Alt3C, Alt4 } from './Alt'
-import { Apply, Apply1, Apply2, Apply2C, Apply3, Apply3C, Apply4 } from './Apply'
-import { Bifunctor, Bifunctor2, Bifunctor3, Bifunctor3C, Bifunctor4 } from './Bifunctor'
-import { Chain, Chain1, Chain2, Chain2C, Chain3, Chain3C, Chain4 } from './Chain'
+import {
+  Apply,
+  Apply1,
+  Apply2,
+  Apply2C,
+  Apply3,
+  Apply3C,
+  Apply4,
+  apFirst as apFirst_,
+  apSecond as apSecond_
+} from './Apply'
+import { Bifunctor, Bifunctor2, Bifunctor2C, Bifunctor3, Bifunctor3C, Bifunctor4 } from './Bifunctor'
+import { Chain, Chain1, Chain2, Chain2C, Chain3, Chain3C, Chain4, chainFirst as chainFirst_ } from './Chain'
 import {
   Compactable,
   Compactable1,
@@ -12,9 +22,9 @@ import {
   Compactable2C,
   Compactable3,
   Compactable3C,
-  Compactable4,
-  Separated
+  Compactable4
 } from './Compactable'
+import { Separated } from './Separated'
 import {
   Contravariant,
   Contravariant1,
@@ -56,7 +66,9 @@ import {
   FoldableWithIndex3C,
   FoldableWithIndex4
 } from './FoldableWithIndex'
-import { identity, Lazy, pipe as pipeFromFunctionModule, Predicate, Refinement } from './function'
+import { identity, Lazy, pipe as pipeFromFunctionModule } from './function'
+import { Predicate } from './Predicate'
+import { Refinement } from './Refinement'
 import { Functor, Functor1, Functor2, Functor2C, Functor3, Functor3C, Functor4 } from './Functor'
 import {
   FunctorWithIndex,
@@ -88,6 +100,889 @@ import {
   Semigroupoid3C,
   Semigroupoid4
 } from './Semigroupoid'
+
+// -------------------------------------------------------------------------------------
+// pipeable helpers
+// -------------------------------------------------------------------------------------
+
+/**
+ * Returns a pipeable `map`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function map<F extends URIS4>(
+  F: Functor4<F>
+): <A, B>(f: (a: A) => B) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, B>
+export function map<F extends URIS3>(
+  F: Functor3<F>
+): <A, B>(f: (a: A) => B) => <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export function map<F extends URIS3, E>(
+  F: Functor3C<F, E>
+): <A, B>(f: (a: A) => B) => <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export function map<F extends URIS2>(
+  F: Functor2<F>
+): <A, B>(f: (a: A) => B) => <E>(fa: Kind2<F, E, A>) => Kind2<F, E, B>
+export function map<F extends URIS2, E>(
+  F: Functor2C<F, E>
+): <A, B>(f: (a: A) => B) => (fa: Kind2<F, E, A>) => Kind2<F, E, B>
+export function map<F extends URIS>(F: Functor1<F>): <A, B>(f: (a: A) => B) => (fa: Kind<F, A>) => Kind<F, B>
+export function map<F>(F: Functor<F>): <A, B>(f: (a: A) => B) => (fa: HKT<F, A>) => HKT<F, B>
+export function map<F>(F: Functor<F>): <A, B>(f: (a: A) => B) => (fa: HKT<F, A>) => HKT<F, B> {
+  return (f) => (fa) => F.map(fa, f)
+}
+
+/**
+ * Returns a pipeable `contramap`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function contramap<F extends URIS4>(
+  F: Contravariant4<F>
+): <A, B>(f: (b: B) => A) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, B>
+export function contramap<F extends URIS3>(
+  F: Contravariant3<F>
+): <A, B>(f: (b: B) => A) => <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export function contramap<F extends URIS3, E>(
+  F: Contravariant3C<F, E>
+): <A, B>(f: (b: B) => A) => <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export function contramap<F extends URIS2>(
+  F: Contravariant2<F>
+): <A, B>(f: (b: B) => A) => <E>(fa: Kind2<F, E, A>) => Kind2<F, E, B>
+export function contramap<F extends URIS2, E>(
+  F: Contravariant2C<F, E>
+): <A, B>(f: (b: B) => A) => (fa: Kind2<F, E, A>) => Kind2<F, E, B>
+export function contramap<F extends URIS>(
+  F: Contravariant1<F>
+): <A, B>(f: (b: B) => A) => (fa: Kind<F, A>) => Kind<F, B>
+export function contramap<F>(F: Contravariant<F>): <A, B>(f: (b: B) => A) => (fa: HKT<F, A>) => HKT<F, B>
+export function contramap<F>(F: Contravariant<F>): <A, B>(f: (b: B) => A) => (fa: HKT<F, A>) => HKT<F, B> {
+  return (f) => (fa) => F.contramap(fa, f)
+}
+
+/**
+ * Returns a pipeable `mapWithIndex`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function mapWithIndex<F extends URIS4, I>(
+  F: FunctorWithIndex4<F, I>
+): <A, B>(f: (i: I, a: A) => B) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, B>
+export function mapWithIndex<F extends URIS3, I>(
+  F: FunctorWithIndex3<F, I>
+): <A, B>(f: (i: I, a: A) => B) => <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export function mapWithIndex<F extends URIS3, I, E>(
+  F: FunctorWithIndex3C<F, I, E>
+): <A, B>(f: (i: I, a: A) => B) => <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export function mapWithIndex<F extends URIS2, I>(
+  F: FunctorWithIndex2<F, I>
+): <A, B>(f: (i: I, a: A) => B) => <E>(fa: Kind2<F, E, A>) => Kind2<F, E, B>
+export function mapWithIndex<F extends URIS2, I, E>(
+  F: FunctorWithIndex2C<F, I, E>
+): <A, B>(f: (i: I, a: A) => B) => (fa: Kind2<F, E, A>) => Kind2<F, E, B>
+export function mapWithIndex<F extends URIS, I>(
+  F: FunctorWithIndex1<F, I>
+): <A, B>(f: (i: I, a: A) => B) => (fa: Kind<F, A>) => Kind<F, B>
+export function mapWithIndex<F, I>(
+  F: FunctorWithIndex<F, I>
+): <A, B>(f: (i: I, a: A) => B) => (fa: HKT<F, A>) => HKT<F, B>
+export function mapWithIndex<F, I>(
+  F: FunctorWithIndex<F, I>
+): <A, B>(f: (i: I, a: A) => B) => (fa: HKT<F, A>) => HKT<F, B> {
+  return (f) => (fa) => F.mapWithIndex(fa, f)
+}
+
+/**
+ * Returns a pipeable `ap`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function ap<F extends URIS4>(
+  F: Apply4<F>
+): <S, R, E, A>(fa: Kind4<F, S, R, E, A>) => <B>(fab: Kind4<F, S, R, E, (a: A) => B>) => Kind4<F, S, R, E, B>
+export function ap<F extends URIS3>(
+  F: Apply3<F>
+): <R, E, A>(fa: Kind3<F, R, E, A>) => <B>(fab: Kind3<F, R, E, (a: A) => B>) => Kind3<F, R, E, B>
+export function ap<F extends URIS3, E>(
+  F: Apply3C<F, E>
+): <R, A>(fa: Kind3<F, R, E, A>) => <B>(fab: Kind3<F, R, E, (a: A) => B>) => Kind3<F, R, E, B>
+export function ap<F extends URIS2>(
+  F: Apply2<F>
+): <E, A>(fa: Kind2<F, E, A>) => <B>(fab: Kind2<F, E, (a: A) => B>) => Kind2<F, E, B>
+export function ap<F extends URIS2, E>(
+  F: Apply2C<F, E>
+): <A>(fa: Kind2<F, E, A>) => <B>(fab: Kind2<F, E, (a: A) => B>) => Kind2<F, E, B>
+export function ap<F extends URIS>(F: Apply1<F>): <A>(fa: Kind<F, A>) => <B>(fab: Kind<F, (a: A) => B>) => Kind<F, B>
+export function ap<F>(F: Apply<F>): <A>(fa: HKT<F, A>) => <B>(fab: HKT<F, (a: A) => B>) => HKT<F, B>
+export function ap<F>(F: Apply<F>): <A>(fa: HKT<F, A>) => <B>(fab: HKT<F, (a: A) => B>) => HKT<F, B> {
+  return (fa) => (fab) => F.ap(fab, fa)
+}
+
+/**
+ * Returns a pipeable `chain`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function chain<F extends URIS4>(
+  F: Chain4<F>
+): <A, S, R, E, B>(f: (a: A) => Kind4<F, S, R, E, B>) => (fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, B>
+export function chain<F extends URIS3>(
+  F: Chain3<F>
+): <A, R, E, B>(f: (a: A) => Kind3<F, R, E, B>) => (fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export function chain<F extends URIS3, E>(
+  F: Chain3C<F, E>
+): <A, R, B>(f: (a: A) => Kind3<F, R, E, B>) => (fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export function chain<F extends URIS2>(
+  F: Chain2<F>
+): <A, E, B>(f: (a: A) => Kind2<F, E, B>) => (fa: Kind2<F, E, A>) => Kind2<F, E, B>
+export function chain<F extends URIS2, E>(
+  F: Chain2C<F, E>
+): <A, B>(f: (a: A) => Kind2<F, E, B>) => (fa: Kind2<F, E, A>) => Kind2<F, E, B>
+export function chain<F extends URIS>(F: Chain1<F>): <A, B>(f: (a: A) => Kind<F, B>) => (fa: Kind<F, A>) => Kind<F, B>
+export function chain<F>(F: Chain<F>): <A, B>(f: (a: A) => HKT<F, B>) => (fa: HKT<F, A>) => HKT<F, B>
+export function chain<F>(F: Chain<F>): <A, B>(f: (a: A) => HKT<F, B>) => (fa: HKT<F, A>) => HKT<F, B> {
+  return (f) => (fa) => F.chain(fa, f)
+}
+
+/**
+ * Returns a pipeable `bimap`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function bimap<F extends URIS4>(
+  F: Bifunctor4<F>
+): <E, G, A, B>(f: (e: E) => G, g: (a: A) => B) => <S, R>(fea: Kind4<F, S, R, E, A>) => Kind4<F, S, R, G, B>
+export function bimap<F extends URIS3>(
+  F: Bifunctor3<F>
+): <E, G, A, B>(f: (e: E) => G, g: (a: A) => B) => <R>(fea: Kind3<F, R, E, A>) => Kind3<F, R, G, B>
+export function bimap<F extends URIS3, E>(
+  F: Bifunctor3C<F, E>
+): <G, A, B>(f: (e: E) => G, g: (a: A) => B) => <R>(fea: Kind3<F, R, E, A>) => Kind3<F, R, G, B>
+export function bimap<F extends URIS2>(
+  F: Bifunctor2<F>
+): <E, G, A, B>(f: (e: E) => G, g: (a: A) => B) => (fea: Kind2<F, E, A>) => Kind2<F, G, B>
+export function bimap<F extends URIS2, E>(
+  F: Bifunctor2C<F, E>
+): <G, A, B>(f: (e: E) => G, g: (a: A) => B) => (fea: Kind2<F, E, A>) => Kind2<F, G, B>
+export function bimap<F>(
+  F: Bifunctor<F>
+): <E, G, A, B>(f: (e: E) => G, g: (a: A) => B) => (fea: HKT2<F, E, A>) => HKT2<F, G, B>
+export function bimap<F>(
+  F: Bifunctor<F>
+): <E, G, A, B>(f: (e: E) => G, g: (a: A) => B) => (fea: HKT2<F, E, A>) => HKT2<F, G, B> {
+  return (f, g) => (fea) => F.bimap(fea, f, g)
+}
+
+/**
+ * Returns a pipeable `mapLeft`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function mapLeft<F extends URIS4>(
+  F: Bifunctor4<F>
+): <E, G>(f: (e: E) => G) => <S, R, A>(fea: Kind4<F, S, R, E, A>) => Kind4<F, S, R, G, A>
+export function mapLeft<F extends URIS3>(
+  F: Bifunctor3<F>
+): <E, G>(f: (e: E) => G) => <R, A>(fea: Kind3<F, R, E, A>) => Kind3<F, R, G, A>
+export function mapLeft<F extends URIS3, E>(
+  F: Bifunctor3C<F, E>
+): <E, G>(f: (e: E) => G) => <R, A>(fea: Kind3<F, R, E, A>) => Kind3<F, R, G, A>
+export function mapLeft<F extends URIS2>(
+  F: Bifunctor2<F>
+): <E, G>(f: (e: E) => G) => <A>(fea: Kind2<F, E, A>) => Kind2<F, G, A>
+export function mapLeft<F extends URIS2, E>(
+  F: Bifunctor2C<F, E>
+): <E, G>(f: (e: E) => G) => <A>(fea: Kind2<F, E, A>) => Kind2<F, G, A>
+export function mapLeft<F>(F: Bifunctor<F>): <E, G>(f: (e: E) => G) => <A>(fea: HKT2<F, E, A>) => HKT2<F, G, A>
+export function mapLeft<F>(F: Bifunctor<F>): <E, G>(f: (e: E) => G) => <A>(fea: HKT2<F, E, A>) => HKT2<F, G, A> {
+  return (f) => (fea) => F.mapLeft(fea, f)
+}
+
+/**
+ * Returns a pipeable `extend`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function extend<F extends URIS4>(
+  F: Extend4<F>
+): <S, R, E, A, B>(f: (wa: Kind4<F, S, R, E, A>) => B) => (wa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, B>
+export function extend<F extends URIS3>(
+  F: Extend3<F>
+): <R, E, A, B>(f: (wa: Kind3<F, R, E, A>) => B) => (wa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export function extend<F extends URIS3, E>(
+  F: Extend3C<F, E>
+): <R, A, B>(f: (wa: Kind3<F, R, E, A>) => B) => (wa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export function extend<F extends URIS2>(
+  F: Extend2<F>
+): <E, A, B>(f: (wa: Kind2<F, E, A>) => B) => (wa: Kind2<F, E, A>) => Kind2<F, E, B>
+export function extend<F extends URIS2, E>(
+  F: Extend2C<F, E>
+): <A, B>(f: (wa: Kind2<F, E, A>) => B) => (wa: Kind2<F, E, A>) => Kind2<F, E, B>
+export function extend<F extends URIS>(
+  F: Extend1<F>
+): <A, B>(f: (wa: Kind<F, A>) => B) => (wa: Kind<F, A>) => Kind<F, B>
+export function extend<F>(F: Extend<F>): <A, B>(f: (wa: HKT<F, A>) => B) => (wa: HKT<F, A>) => HKT<F, B>
+export function extend<F>(F: Extend<F>): <A, B>(f: (wa: HKT<F, A>) => B) => (wa: HKT<F, A>) => HKT<F, B> {
+  return (f) => (wa) => F.extend(wa, f)
+}
+
+/**
+ * Returns a pipeable `reduce`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function reduce<F extends URIS4>(
+  F: Foldable4<F>
+): <A, B>(b: B, f: (b: B, a: A) => B) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => B
+export function reduce<F extends URIS3>(
+  F: Foldable3<F>
+): <A, B>(b: B, f: (b: B, a: A) => B) => <R, E>(fa: Kind3<F, R, E, A>) => B
+export function reduce<F extends URIS3, E>(
+  F: Foldable3C<F, E>
+): <A, B>(b: B, f: (b: B, a: A) => B) => <R>(fa: Kind3<F, R, E, A>) => B
+export function reduce<F extends URIS2>(
+  F: Foldable2<F>
+): <A, B>(b: B, f: (b: B, a: A) => B) => <E>(fa: Kind2<F, E, A>) => B
+export function reduce<F extends URIS2, E>(
+  F: Foldable2C<F, E>
+): <A, B>(b: B, f: (b: B, a: A) => B) => (fa: Kind2<F, E, A>) => B
+export function reduce<F extends URIS>(F: Foldable1<F>): <A, B>(b: B, f: (b: B, a: A) => B) => (fa: Kind<F, A>) => B
+export function reduce<F>(F: Foldable<F>): <A, B>(b: B, f: (b: B, a: A) => B) => (fa: HKT<F, A>) => B
+export function reduce<F>(F: Foldable<F>): <A, B>(b: B, f: (b: B, a: A) => B) => (fa: HKT<F, A>) => B {
+  return (b, f) => (fa) => F.reduce(fa, b, f)
+}
+
+/**
+ * Returns a pipeable `foldMap`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function foldMap<F extends URIS4>(
+  F: Foldable4<F>
+): <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => M
+export function foldMap<F extends URIS3>(
+  F: Foldable3<F>
+): <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => <R, E>(fa: Kind3<F, R, E, A>) => M
+export function foldMap<F extends URIS3, E>(
+  F: Foldable3C<F, E>
+): <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => <R>(fa: Kind3<F, R, E, A>) => M
+export function foldMap<F extends URIS2>(
+  F: Foldable2<F>
+): <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => <E>(fa: Kind2<F, E, A>) => M
+export function foldMap<F extends URIS2, E>(
+  F: Foldable2C<F, E>
+): <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => (fa: Kind2<F, E, A>) => M
+export function foldMap<F extends URIS>(
+  F: Foldable1<F>
+): <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => (fa: Kind<F, A>) => M
+export function foldMap<F>(F: Foldable<F>): <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => (fa: HKT<F, A>) => M
+export function foldMap<F>(F: Foldable<F>): <M>(M: Monoid<M>) => <A>(f: (a: A) => M) => (fa: HKT<F, A>) => M {
+  return (M) => {
+    const foldMapM = F.foldMap(M)
+    return (f) => (fa) => foldMapM(fa, f)
+  }
+}
+
+/**
+ * Returns a pipeable `reduceRight`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function reduceRight<F extends URIS4>(
+  F: Foldable4<F>
+): <A, B>(b: B, f: (a: A, b: B) => B) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => B
+export function reduceRight<F extends URIS3>(
+  F: Foldable3<F>
+): <A, B>(b: B, f: (a: A, b: B) => B) => <R, E>(fa: Kind3<F, R, E, A>) => B
+export function reduceRight<F extends URIS3, E>(
+  F: Foldable3C<F, E>
+): <A, B>(b: B, f: (a: A, b: B) => B) => <R>(fa: Kind3<F, R, E, A>) => B
+export function reduceRight<F extends URIS2>(
+  F: Foldable2<F>
+): <A, B>(b: B, f: (a: A, b: B) => B) => <E>(fa: Kind2<F, E, A>) => B
+export function reduceRight<F extends URIS2, E>(
+  F: Foldable2C<F, E>
+): <A, B>(b: B, f: (a: A, b: B) => B) => (fa: Kind2<F, E, A>) => B
+export function reduceRight<F extends URIS>(
+  F: Foldable1<F>
+): <A, B>(b: B, f: (a: A, b: B) => B) => (fa: Kind<F, A>) => B
+export function reduceRight<F>(F: Foldable<F>): <A, B>(b: B, f: (a: A, b: B) => B) => (fa: HKT<F, A>) => B
+export function reduceRight<F>(F: Foldable<F>): <A, B>(b: B, f: (a: A, b: B) => B) => (fa: HKT<F, A>) => B {
+  return (b, f) => (fa) => F.reduceRight(fa, b, f)
+}
+
+/**
+ * Returns a pipeable `reduceWithIndex`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function reduceWithIndex<F extends URIS4, I>(
+  F: FoldableWithIndex4<F, I>
+): <A, B>(b: B, f: (i: I, b: B, a: A) => B) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => B
+export function reduceWithIndex<F extends URIS3, I>(
+  F: FoldableWithIndex3<F, I>
+): <A, B>(b: B, f: (i: I, b: B, a: A) => B) => <R, E>(fa: Kind3<F, R, E, A>) => B
+export function reduceWithIndex<F extends URIS3, I, E>(
+  F: FoldableWithIndex3C<F, I, E>
+): <A, B>(b: B, f: (i: I, b: B, a: A) => B) => <R>(fa: Kind3<F, R, E, A>) => B
+export function reduceWithIndex<F extends URIS2, I>(
+  F: FoldableWithIndex2<F, I>
+): <A, B>(b: B, f: (i: I, b: B, a: A) => B) => <E>(fa: Kind2<F, E, A>) => B
+export function reduceWithIndex<F extends URIS2, I, E>(
+  F: FoldableWithIndex2C<F, I, E>
+): <A, B>(b: B, f: (i: I, b: B, a: A) => B) => (fa: Kind2<F, E, A>) => B
+export function reduceWithIndex<F extends URIS, I>(
+  F: FoldableWithIndex1<F, I>
+): <A, B>(b: B, f: (i: I, b: B, a: A) => B) => (fa: Kind<F, A>) => B
+export function reduceWithIndex<F, I>(
+  F: FoldableWithIndex<F, I>
+): <A, B>(b: B, f: (i: I, b: B, a: A) => B) => (fa: HKT<F, A>) => B
+export function reduceWithIndex<F, I>(
+  F: FoldableWithIndex<F, I>
+): <A, B>(b: B, f: (i: I, b: B, a: A) => B) => (fa: HKT<F, A>) => B {
+  return (b, f) => (fa) => F.reduceWithIndex(fa, b, f)
+}
+
+/**
+ * Returns a pipeable `foldMapWithIndex`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function foldMapWithIndex<F extends URIS4, I>(
+  F: FoldableWithIndex4<F, I>
+): <M>(M: Monoid<M>) => <A>(f: (i: I, a: A) => M) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => M
+export function foldMapWithIndex<F extends URIS3, I>(
+  F: FoldableWithIndex3<F, I>
+): <M>(M: Monoid<M>) => <A>(f: (i: I, a: A) => M) => <R, E>(fa: Kind3<F, R, E, A>) => M
+export function foldMapWithIndex<F extends URIS3, I, E>(
+  F: FoldableWithIndex3C<F, I, E>
+): <M>(M: Monoid<M>) => <A>(f: (i: I, a: A) => M) => <R>(fa: Kind3<F, R, E, A>) => M
+export function foldMapWithIndex<F extends URIS2, I>(
+  F: FoldableWithIndex2<F, I>
+): <M>(M: Monoid<M>) => <A>(f: (i: I, a: A) => M) => <E>(fa: Kind2<F, E, A>) => M
+export function foldMapWithIndex<F extends URIS2, I, E>(
+  F: FoldableWithIndex2C<F, I, E>
+): <M>(M: Monoid<M>) => <A>(f: (i: I, a: A) => M) => (fa: Kind2<F, E, A>) => M
+export function foldMapWithIndex<F extends URIS, I>(
+  F: FoldableWithIndex1<F, I>
+): <M>(M: Monoid<M>) => <A>(f: (i: I, a: A) => M) => (fa: Kind<F, A>) => M
+export function foldMapWithIndex<F, I>(
+  F: FoldableWithIndex<F, I>
+): <M>(M: Monoid<M>) => <A>(f: (i: I, a: A) => M) => (fa: HKT<F, A>) => M
+export function foldMapWithIndex<F, I>(
+  F: FoldableWithIndex<F, I>
+): <M>(M: Monoid<M>) => <A>(f: (i: I, a: A) => M) => (fa: HKT<F, A>) => M {
+  return (M) => {
+    const foldMapWithIndexM = F.foldMapWithIndex(M)
+    return (f) => (fa) => foldMapWithIndexM(fa, f)
+  }
+}
+
+/**
+ * Returns a pipeable `reduceRightWithIndex`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function reduceRightWithIndex<F extends URIS4, I>(
+  F: FoldableWithIndex4<F, I>
+): <A, B>(b: B, f: (i: I, a: A, b: B) => B) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => B
+export function reduceRightWithIndex<F extends URIS3, I>(
+  F: FoldableWithIndex3<F, I>
+): <A, B>(b: B, f: (i: I, a: A, b: B) => B) => <R, E>(fa: Kind3<F, R, E, A>) => B
+export function reduceRightWithIndex<F extends URIS3, I, E>(
+  F: FoldableWithIndex3C<F, I, E>
+): <A, B>(b: B, f: (i: I, a: A, b: B) => B) => <R>(fa: Kind3<F, R, E, A>) => B
+export function reduceRightWithIndex<F extends URIS2, I>(
+  F: FoldableWithIndex2<F, I>
+): <A, B>(b: B, f: (i: I, a: A, b: B) => B) => <E>(fa: Kind2<F, E, A>) => B
+export function reduceRightWithIndex<F extends URIS2, I, E>(
+  F: FoldableWithIndex2C<F, I, E>
+): <A, B>(b: B, f: (i: I, a: A, b: B) => B) => (fa: Kind2<F, E, A>) => B
+export function reduceRightWithIndex<F extends URIS, I>(
+  F: FoldableWithIndex1<F, I>
+): <A, B>(b: B, f: (i: I, a: A, b: B) => B) => (fa: Kind<F, A>) => B
+export function reduceRightWithIndex<F, I>(
+  F: FoldableWithIndex<F, I>
+): <A, B>(b: B, f: (i: I, a: A, b: B) => B) => (fa: HKT<F, A>) => B
+export function reduceRightWithIndex<F, I>(
+  F: FoldableWithIndex<F, I>
+): <A, B>(b: B, f: (i: I, a: A, b: B) => B) => (fa: HKT<F, A>) => B {
+  return (b, f) => (fa) => F.reduceRightWithIndex(fa, b, f)
+}
+
+/**
+ * Returns a pipeable `alt`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function alt<F extends URIS4>(
+  F: Alt4<F>
+): <S, R, E, A>(that: Lazy<Kind4<F, S, R, E, A>>) => (fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, A>
+export function alt<F extends URIS3>(
+  F: Alt3<F>
+): <R, E, A>(that: Lazy<Kind3<F, R, E, A>>) => (fa: Kind3<F, R, E, A>) => Kind3<F, R, E, A>
+export function alt<F extends URIS3, E>(
+  F: Alt3C<F, E>
+): <R, A>(that: Lazy<Kind3<F, R, E, A>>) => (fa: Kind3<F, R, E, A>) => Kind3<F, R, E, A>
+export function alt<F extends URIS2>(
+  F: Alt2<F>
+): <E, A>(that: Lazy<Kind2<F, E, A>>) => (fa: Kind2<F, E, A>) => Kind2<F, E, A>
+export function alt<F extends URIS2, E>(
+  F: Alt2C<F, E>
+): <A>(that: Lazy<Kind2<F, E, A>>) => (fa: Kind2<F, E, A>) => Kind2<F, E, A>
+export function alt<F extends URIS>(F: Alt1<F>): <A>(that: Lazy<Kind<F, A>>) => (fa: Kind<F, A>) => Kind<F, A>
+export function alt<F>(F: Alt<F>): <A>(that: Lazy<HKT<F, A>>) => (fa: HKT<F, A>) => HKT<F, A>
+export function alt<F>(F: Alt<F>): <A>(that: Lazy<HKT<F, A>>) => (fa: HKT<F, A>) => HKT<F, A> {
+  return (that) => (fa) => F.alt(fa, that)
+}
+
+/**
+ * Returns a pipeable `filter`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function filter<F extends URIS4>(
+  F: Filterable4<F>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): <S, R, E>(fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, B>
+  <A>(predicate: Predicate<A>): <S, R, E>(fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, A>
+}
+export function filter<F extends URIS3>(
+  F: Filterable3<F>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+  <A>(predicate: Predicate<A>): <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, A>
+}
+export function filter<F extends URIS3, E>(
+  F: Filterable3C<F, E>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+  <A>(predicate: Predicate<A>): <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, A>
+}
+export function filter<F extends URIS2>(
+  F: Filterable2<F>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): <E>(fa: Kind2<F, E, A>) => Kind2<F, E, B>
+  <A>(predicate: Predicate<A>): <E>(fa: Kind2<F, E, A>) => Kind2<F, E, A>
+}
+export function filter<F extends URIS2, E>(
+  F: Filterable2C<F, E>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): (fa: Kind2<F, E, A>) => Kind2<F, E, B>
+  <A>(predicate: Predicate<A>): (fa: Kind2<F, E, A>) => Kind2<F, E, A>
+}
+export function filter<F extends URIS>(
+  F: Filterable1<F>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): (fa: Kind<F, A>) => Kind<F, B>
+  <A>(predicate: Predicate<A>): (fa: Kind<F, A>) => Kind<F, A>
+}
+export function filter<F>(
+  F: Filterable<F>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): (fa: HKT<F, A>) => HKT<F, B>
+  <A>(predicate: Predicate<A>): (fa: HKT<F, A>) => HKT<F, A>
+}
+export function filter<F>(F: Filterable<F>): <A>(predicate: Predicate<A>) => (fa: HKT<F, A>) => HKT<F, A> {
+  return (predicate) => (fa) => F.filter(fa, predicate)
+}
+
+/**
+ * Returns a pipeable `filterMap`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function filterMap<F extends URIS4>(
+  F: Filterable4<F>
+): <A, B>(f: (a: A) => Option<B>) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, B>
+export function filterMap<F extends URIS3>(
+  F: Filterable3<F>
+): <A, B>(f: (a: A) => Option<B>) => <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export function filterMap<F extends URIS3, E>(
+  F: Filterable3C<F, E>
+): <A, B>(f: (a: A) => Option<B>) => <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export function filterMap<F extends URIS2>(
+  F: Filterable2<F>
+): <A, B>(f: (a: A) => Option<B>) => <E>(fa: Kind2<F, E, A>) => Kind2<F, E, B>
+export function filterMap<F extends URIS2, E>(
+  F: Filterable2C<F, E>
+): <A, B>(f: (a: A) => Option<B>) => (fa: Kind2<F, E, A>) => Kind2<F, E, B>
+export function filterMap<F extends URIS>(
+  F: Filterable1<F>
+): <A, B>(f: (a: A) => Option<B>) => (fa: Kind<F, A>) => Kind<F, B>
+export function filterMap<F>(F: Filterable<F>): <A, B>(f: (a: A) => Option<B>) => (fa: HKT<F, A>) => HKT<F, B>
+export function filterMap<F>(F: Filterable<F>): <A, B>(f: (a: A) => Option<B>) => (fa: HKT<F, A>) => HKT<F, B> {
+  return (f) => (fa) => F.filterMap(fa, f)
+}
+
+/**
+ * Returns a pipeable `partition`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function partition<F extends URIS4>(
+  F: Filterable4<F>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): <S, R, E>(
+    fa: Kind4<F, S, R, E, A>
+  ) => Separated<Kind4<F, S, R, E, A>, Kind4<F, S, R, E, B>>
+  <A>(predicate: Predicate<A>): <S, R, E>(
+    fa: Kind4<F, S, R, E, A>
+  ) => Separated<Kind4<F, S, R, E, A>, Kind4<F, S, R, E, A>>
+}
+export function partition<F extends URIS3>(
+  F: Filterable3<F>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): <R, E>(
+    fa: Kind3<F, R, E, A>
+  ) => Separated<Kind3<F, R, E, A>, Kind3<F, R, E, B>>
+  <A>(predicate: Predicate<A>): <R, E>(fa: Kind3<F, R, E, A>) => Separated<Kind3<F, R, E, A>, Kind3<F, R, E, A>>
+}
+export function partition<F extends URIS3, E>(
+  F: Filterable3C<F, E>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): <R>(
+    fa: Kind3<F, R, E, A>
+  ) => Separated<Kind3<F, R, E, A>, Kind3<F, R, E, B>>
+  <A>(predicate: Predicate<A>): <R>(fa: Kind3<F, R, E, A>) => Separated<Kind3<F, R, E, A>, Kind3<F, R, E, A>>
+}
+export function partition<F extends URIS2>(
+  F: Filterable2<F>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): <E>(fa: Kind2<F, E, A>) => Separated<Kind2<F, E, A>, Kind2<F, E, B>>
+  <A>(predicate: Predicate<A>): <E>(fa: Kind2<F, E, A>) => Separated<Kind2<F, E, A>, Kind2<F, E, A>>
+}
+export function partition<F extends URIS2, E>(
+  F: Filterable2C<F, E>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): (fa: Kind2<F, E, A>) => Separated<Kind2<F, E, A>, Kind2<F, E, B>>
+  <A>(predicate: Predicate<A>): (fa: Kind2<F, E, A>) => Separated<Kind2<F, E, A>, Kind2<F, E, A>>
+}
+export function partition<F extends URIS>(
+  F: Filterable1<F>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): (fa: Kind<F, A>) => Separated<Kind<F, A>, Kind<F, B>>
+  <A>(predicate: Predicate<A>): (fa: Kind<F, A>) => Separated<Kind<F, A>, Kind<F, A>>
+}
+export function partition<F>(
+  F: Filterable<F>
+): {
+  <A, B extends A>(refinement: Refinement<A, B>): (fa: HKT<F, A>) => Separated<HKT<F, A>, HKT<F, B>>
+  <A>(predicate: Predicate<A>): (fa: HKT<F, A>) => Separated<HKT<F, A>, HKT<F, A>>
+}
+export function partition<F>(
+  F: Filterable<F>
+): <A>(predicate: Predicate<A>) => (fa: HKT<F, A>) => Separated<HKT<F, A>, HKT<F, A>> {
+  return (f) => (fa) => F.partition(fa, f)
+}
+
+/**
+ * Returns a pipeable `partitionMap`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function partitionMap<F extends URIS4>(
+  F: Filterable4<F>
+): <A, B, C>(
+  f: (a: A) => Either<B, C>
+) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => Separated<Kind4<F, S, R, E, B>, Kind4<F, S, R, E, C>>
+export function partitionMap<F extends URIS3>(
+  F: Filterable3<F>
+): <A, B, C>(
+  f: (a: A) => Either<B, C>
+) => <R, E>(fa: Kind3<F, R, E, A>) => Separated<Kind3<F, R, E, B>, Kind3<F, R, E, C>>
+export function partitionMap<F extends URIS3, E>(
+  F: Filterable3C<F, E>
+): <A, B, C>(f: (a: A) => Either<B, C>) => <R>(fa: Kind3<F, R, E, A>) => Separated<Kind3<F, R, E, B>, Kind3<F, R, E, C>>
+export function partitionMap<F extends URIS2>(
+  F: Filterable2<F>
+): <A, B, C>(f: (a: A) => Either<B, C>) => <E>(fa: Kind2<F, E, A>) => Separated<Kind2<F, E, B>, Kind2<F, E, C>>
+export function partitionMap<F extends URIS2, E>(
+  F: Filterable2C<F, E>
+): <A, B, C>(f: (a: A) => Either<B, C>) => (fa: Kind2<F, E, A>) => Separated<Kind2<F, E, B>, Kind2<F, E, C>>
+export function partitionMap<F extends URIS>(
+  F: Filterable1<F>
+): <A, B, C>(f: (a: A) => Either<B, C>) => (fa: Kind<F, A>) => Separated<Kind<F, B>, Kind<F, C>>
+export function partitionMap<F>(
+  F: Filterable<F>
+): <A, B, C>(f: (a: A) => Either<B, C>) => (fa: HKT<F, A>) => Separated<HKT<F, B>, HKT<F, C>>
+export function partitionMap<F>(
+  F: Filterable<F>
+): <A, B, C>(f: (a: A) => Either<B, C>) => (fa: HKT<F, A>) => Separated<HKT<F, B>, HKT<F, C>> {
+  return (f) => (fa) => F.partitionMap(fa, f)
+}
+
+/**
+ * Returns a pipeable `filterWithIndex`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function filterWithIndex<F extends URIS4, I>(
+  F: FilterableWithIndex4<F, I>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): <S, R, E>(
+    fa: Kind4<F, S, R, E, A>
+  ) => Kind4<F, S, R, E, B>
+  <A>(predicate: PredicateWithIndex<I, A>): <S, R, E>(fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, A>
+}
+export function filterWithIndex<F extends URIS3, I>(
+  F: FilterableWithIndex3<F, I>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+  <A>(predicate: PredicateWithIndex<I, A>): <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, A>
+}
+export function filterWithIndex<F extends URIS3, I, E>(
+  F: FilterableWithIndex3C<F, I, E>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+  <A>(predicate: PredicateWithIndex<I, A>): <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, A>
+}
+export function filterWithIndex<F extends URIS2, I>(
+  F: FilterableWithIndex2<F, I>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): <E>(fa: Kind2<F, E, A>) => Kind2<F, E, B>
+  <A>(predicate: PredicateWithIndex<I, A>): <E>(fa: Kind2<F, E, A>) => Kind2<F, E, A>
+}
+export function filterWithIndex<F extends URIS2, E, I>(
+  F: FilterableWithIndex2C<F, I, E>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): (fa: Kind2<F, E, A>) => Kind2<F, E, B>
+  <A>(predicate: PredicateWithIndex<I, A>): (fa: Kind2<F, E, A>) => Kind2<F, E, A>
+}
+export function filterWithIndex<F extends URIS, I>(
+  F: FilterableWithIndex1<F, I>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): (fa: Kind<F, A>) => Kind<F, B>
+  <A>(predicate: PredicateWithIndex<I, A>): (fa: Kind<F, A>) => Kind<F, A>
+}
+export function filterWithIndex<F, I>(
+  F: FilterableWithIndex<F, I>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): (fa: HKT<F, A>) => HKT<F, B>
+  <A>(predicate: PredicateWithIndex<I, A>): (fa: HKT<F, A>) => HKT<F, A>
+}
+export function filterWithIndex<F, I>(
+  F: FilterableWithIndex<F, I>
+): <A>(predicate: PredicateWithIndex<I, A>) => (fa: HKT<F, A>) => HKT<F, A> {
+  return (predicate) => (fa) => F.filterWithIndex(fa, predicate)
+}
+
+/**
+ * Returns a pipeable `filterMapWithIndex`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function filterMapWithIndex<F extends URIS4, I>(
+  F: FilterableWithIndex4<F, I>
+): <A, B>(f: (i: I, a: A) => Option<B>) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, B>
+export function filterMapWithIndex<F extends URIS3, I>(
+  F: FilterableWithIndex3<F, I>
+): <A, B>(f: (i: I, a: A) => Option<B>) => <R, E>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export function filterMapWithIndex<F extends URIS3, I, E>(
+  F: FilterableWithIndex3C<F, I, E>
+): <A, B>(f: (i: I, a: A) => Option<B>) => <R>(fa: Kind3<F, R, E, A>) => Kind3<F, R, E, B>
+export function filterMapWithIndex<F extends URIS2, I>(
+  F: FilterableWithIndex2<F, I>
+): <A, B>(f: (i: I, a: A) => Option<B>) => <E>(fa: Kind2<F, E, A>) => Kind2<F, E, B>
+export function filterMapWithIndex<F extends URIS2, I, E>(
+  F: FilterableWithIndex2C<F, I, E>
+): <A, B>(f: (i: I, a: A) => Option<B>) => (fa: Kind2<F, E, A>) => Kind2<F, E, B>
+export function filterMapWithIndex<F extends URIS, I>(
+  F: FilterableWithIndex1<F, I>
+): <A, B>(f: (i: I, a: A) => Option<B>) => (fa: Kind<F, A>) => Kind<F, B>
+export function filterMapWithIndex<F, I>(
+  F: FilterableWithIndex<F, I>
+): <A, B>(f: (i: I, a: A) => Option<B>) => (fa: HKT<F, A>) => HKT<F, B>
+export function filterMapWithIndex<F, I>(
+  F: FilterableWithIndex<F, I>
+): <A, B>(f: (i: I, a: A) => Option<B>) => (fa: HKT<F, A>) => HKT<F, B> {
+  return (f) => (fa) => F.filterMapWithIndex(fa, f)
+}
+
+/**
+ * Returns a pipeable `partitionWithIndex`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function partitionWithIndex<F extends URIS4, I>(
+  F: FilterableWithIndex4<F, I>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): <S, R, E>(
+    fa: Kind4<F, S, R, E, A>
+  ) => Separated<Kind4<F, S, R, E, A>, Kind4<F, S, R, E, B>>
+  <A>(predicate: PredicateWithIndex<I, A>): <S, R, E>(
+    fa: Kind4<F, S, R, E, A>
+  ) => Separated<Kind4<F, S, R, E, A>, Kind4<F, S, R, E, A>>
+}
+export function partitionWithIndex<F extends URIS3, I>(
+  F: FilterableWithIndex3<F, I>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): <R, E>(
+    fa: Kind3<F, R, E, A>
+  ) => Separated<Kind3<F, R, E, A>, Kind3<F, R, E, B>>
+  <A>(predicate: PredicateWithIndex<I, A>): <R, E>(
+    fa: Kind3<F, R, E, A>
+  ) => Separated<Kind3<F, R, E, A>, Kind3<F, R, E, A>>
+}
+export function partitionWithIndex<F extends URIS3, I, E>(
+  F: FilterableWithIndex3C<F, I, E>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): <R>(
+    fa: Kind3<F, R, E, A>
+  ) => Separated<Kind3<F, R, E, A>, Kind3<F, R, E, B>>
+  <A>(predicate: PredicateWithIndex<I, A>): <R>(
+    fa: Kind3<F, R, E, A>
+  ) => Separated<Kind3<F, R, E, A>, Kind3<F, R, E, A>>
+}
+export function partitionWithIndex<F extends URIS2, I>(
+  F: FilterableWithIndex2<F, I>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): <E>(
+    fa: Kind2<F, E, A>
+  ) => Separated<Kind2<F, E, A>, Kind2<F, E, B>>
+  <A>(predicate: PredicateWithIndex<I, A>): <E>(fa: Kind2<F, E, A>) => Separated<Kind2<F, E, A>, Kind2<F, E, A>>
+}
+export function partitionWithIndex<F extends URIS2, I, E>(
+  F: FilterableWithIndex2C<F, I, E>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): (
+    fa: Kind2<F, E, A>
+  ) => Separated<Kind2<F, E, A>, Kind2<F, E, B>>
+  <A>(predicate: PredicateWithIndex<I, A>): (fa: Kind2<F, E, A>) => Separated<Kind2<F, E, A>, Kind2<F, E, A>>
+}
+export function partitionWithIndex<F extends URIS, I>(
+  F: FilterableWithIndex1<F, I>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): (fa: Kind<F, A>) => Separated<Kind<F, A>, Kind<F, B>>
+  <A>(predicate: PredicateWithIndex<I, A>): (fa: Kind<F, A>) => Separated<Kind<F, A>, Kind<F, A>>
+}
+export function partitionWithIndex<F, I>(
+  F: FilterableWithIndex<F, I>
+): {
+  <A, B extends A>(refinement: RefinementWithIndex<I, A, B>): (fa: HKT<F, A>) => Separated<HKT<F, A>, HKT<F, B>>
+  <A>(predicate: PredicateWithIndex<I, A>): (fa: HKT<F, A>) => Separated<HKT<F, A>, HKT<F, A>>
+}
+export function partitionWithIndex<F, I>(
+  F: FilterableWithIndex<F, I>
+): <A>(predicate: PredicateWithIndex<I, A>) => (fa: HKT<F, A>) => Separated<HKT<F, A>, HKT<F, A>> {
+  return (f) => (fa) => F.partitionWithIndex(fa, f)
+}
+
+/**
+ * Returns a pipeable `partitionMapWithIndex`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function partitionMapWithIndex<F extends URIS4, I>(
+  F: FilterableWithIndex4<F, I>
+): <A, B, C>(
+  f: (i: I, a: A) => Either<B, C>
+) => <S, R, E>(fa: Kind4<F, S, R, E, A>) => Separated<Kind4<F, S, R, E, B>, Kind4<F, S, R, E, C>>
+export function partitionMapWithIndex<F extends URIS3, I>(
+  F: FilterableWithIndex3<F, I>
+): <A, B, C>(
+  f: (i: I, a: A) => Either<B, C>
+) => <R, E>(fa: Kind3<F, R, E, A>) => Separated<Kind3<F, R, E, B>, Kind3<F, R, E, C>>
+export function partitionMapWithIndex<F extends URIS3, I, E>(
+  F: FilterableWithIndex3C<F, I, E>
+): <A, B, C>(
+  f: (i: I, a: A) => Either<B, C>
+) => <R>(fa: Kind3<F, R, E, A>) => Separated<Kind3<F, R, E, B>, Kind3<F, R, E, C>>
+export function partitionMapWithIndex<F extends URIS2, I>(
+  F: FilterableWithIndex2<F, I>
+): <A, B, C>(f: (i: I, a: A) => Either<B, C>) => <E>(fa: Kind2<F, E, A>) => Separated<Kind2<F, E, B>, Kind2<F, E, C>>
+export function partitionMapWithIndex<F extends URIS2, I, E>(
+  F: FilterableWithIndex2C<F, I, E>
+): <A, B, C>(f: (i: I, a: A) => Either<B, C>) => (fa: Kind2<F, E, A>) => Separated<Kind2<F, E, B>, Kind2<F, E, C>>
+export function partitionMapWithIndex<F extends URIS, I>(
+  F: FilterableWithIndex1<F, I>
+): <A, B, C>(f: (i: I, a: A) => Either<B, C>) => (fa: Kind<F, A>) => Separated<Kind<F, B>, Kind<F, C>>
+export function partitionMapWithIndex<F, I>(
+  F: FilterableWithIndex<F, I>
+): <A, B, C>(f: (i: I, a: A) => Either<B, C>) => (fa: HKT<F, A>) => Separated<HKT<F, B>, HKT<F, C>>
+export function partitionMapWithIndex<F, I>(
+  F: FilterableWithIndex<F, I>
+): <A, B, C>(f: (i: I, a: A) => Either<B, C>) => (fa: HKT<F, A>) => Separated<HKT<F, B>, HKT<F, C>> {
+  return (f) => (fa) => F.partitionMapWithIndex(fa, f)
+}
+
+/**
+ * Returns a pipeable `promap`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function promap<F extends URIS4>(
+  F: Profunctor4<F>
+): <E, A, D, B>(f: (d: D) => E, g: (a: A) => B) => <S, R>(fbc: Kind4<F, S, R, E, A>) => Kind4<F, S, R, D, B>
+export function promap<F extends URIS3>(
+  F: Profunctor3<F>
+): <E, A, D, B>(f: (d: D) => E, g: (a: A) => B) => <R>(fbc: Kind3<F, R, E, A>) => Kind3<F, R, D, B>
+export function promap<F extends URIS3, E>(
+  F: Profunctor3C<F, E>
+): <A, D, B>(f: (d: D) => E, g: (a: A) => B) => <R>(fbc: Kind3<F, R, E, A>) => Kind3<F, R, D, B>
+export function promap<F extends URIS2>(
+  F: Profunctor2<F>
+): <E, A, D, B>(f: (d: D) => E, g: (a: A) => B) => (fbc: Kind2<F, E, A>) => Kind2<F, D, B>
+export function promap<F extends URIS2, E>(
+  F: Profunctor2C<F, E>
+): <A, D, B>(f: (d: D) => E, g: (a: A) => B) => (fbc: Kind2<F, E, A>) => Kind2<F, D, B>
+export function promap<F>(
+  F: Profunctor<F>
+): <E, A, D, B>(f: (d: D) => E, g: (a: A) => B) => (fbc: HKT2<F, E, A>) => HKT2<F, D, B>
+export function promap<F>(
+  F: Profunctor<F>
+): <E, A, D, B>(f: (d: D) => E, g: (a: A) => B) => (fbc: HKT2<F, E, A>) => HKT2<F, D, B> {
+  return (f, g) => (fbc) => F.promap(fbc, f, g)
+}
+
+/**
+ * Returns a pipeable `compose`
+ *
+ * @category pipeable helper
+ * @since 2.13.0
+ */
+export function compose<F extends URIS4>(
+  F: Semigroupoid4<F>
+): <S, R, E, A>(ea: Kind4<F, S, R, E, A>) => <B>(ab: Kind4<F, S, R, A, B>) => Kind4<F, S, R, E, B>
+export function compose<F extends URIS3>(
+  F: Semigroupoid3<F>
+): <R, E, A>(ea: Kind3<F, R, E, A>) => <B>(ab: Kind3<F, R, A, B>) => Kind3<F, R, E, B>
+export function compose<F extends URIS3, E>(
+  F: Semigroupoid3C<F, E>
+): <R, A>(ea: Kind3<F, R, E, A>) => <B>(ab: Kind3<F, R, A, B>) => Kind3<F, R, E, B>
+export function compose<F extends URIS2>(
+  F: Semigroupoid2<F>
+): <E, A>(ea: Kind2<F, E, A>) => <B>(ab: Kind2<F, A, B>) => Kind2<F, E, B>
+export function compose<F extends URIS2, E>(
+  F: Semigroupoid2C<F, E>
+): <A>(ea: Kind2<F, E, A>) => <B>(ab: Kind2<F, A, B>) => Kind2<F, E, B>
+export function compose<F>(F: Semigroupoid<F>): <E, A>(ea: HKT2<F, E, A>) => <B>(ab: HKT2<F, A, B>) => HKT2<F, E, B>
+export function compose<F>(F: Semigroupoid<F>): <E, A>(ea: HKT2<F, E, A>) => <B>(ab: HKT2<F, A, B>) => HKT2<F, E, B> {
+  return (ea) => (ab) => F.compose(ab, ea)
+}
 
 // -------------------------------------------------------------------------------------
 // deprecated
@@ -1536,119 +2431,66 @@ export function pipeable<F, I>(
 export function pipeable<F, I>(I: { readonly URI: F } & I): Record<string, unknown> {
   const r: any = {}
   if (isFunctor<F>(I)) {
-    const map: PipeableFunctor<F>['map'] = (f) => (fa) => I.map(fa, f)
-    r.map = map
+    r.map = map(I)
   }
   if (isContravariant<F>(I)) {
-    const contramap: PipeableContravariant<F>['contramap'] = (f) => (fa) => I.contramap(fa, f)
-    r.contramap = contramap
+    r.contramap = contramap(I)
   }
   if (isFunctorWithIndex<F>(I)) {
-    const mapWithIndex: PipeableFunctorWithIndex<F, unknown>['mapWithIndex'] = (f) => (fa) => I.mapWithIndex(fa, f)
-    r.mapWithIndex = mapWithIndex
+    r.mapWithIndex = mapWithIndex(I)
   }
   if (isApply<F>(I)) {
-    const ap: PipeableApply<F>['ap'] = (fa) => (fab) => I.ap(fab, fa)
-    const apFirst: PipeableApply<F>['apFirst'] = (fb) => (fa) =>
-      I.ap(
-        I.map(fa, (a) => () => a),
-        fb
-      )
-    r.ap = ap
-    r.apFirst = apFirst
-    r.apSecond = <B>(fb: HKT<F, B>) => <A>(fa: HKT<F, A>): HKT<F, B> =>
-      I.ap(
-        I.map(fa, () => (b: B) => b),
-        fb
-      )
+    r.ap = ap(I)
+    r.apFirst = apFirst_(I)
+    r.apSecond = apSecond_(I)
   }
   if (isChain<F>(I)) {
-    const chain: PipeableChain<F>['chain'] = (f) => (ma) => I.chain(ma, f)
-    const chainFirst: PipeableChain<F>['chainFirst'] = (f) => (ma) => I.chain(ma, (a) => I.map(f(a), () => a))
-    const flatten: PipeableChain<F>['flatten'] = (mma) => I.chain(mma, identity)
-    r.chain = chain
-    r.chainFirst = chainFirst
-    r.flatten = flatten
+    r.chain = chain(I)
+    r.chainFirst = chainFirst_(I)
+    r.flatten = r.chain(identity)
   }
   if (isBifunctor<F>(I)) {
-    const bimap: PipeableBifunctor<F>['bimap'] = (f, g) => (fa) => I.bimap(fa, f, g)
-    const mapLeft: PipeableBifunctor<F>['mapLeft'] = (f) => (fa) => I.mapLeft(fa, f)
-    r.bimap = bimap
-    r.mapLeft = mapLeft
+    r.bimap = bimap(I)
+    r.mapLeft = mapLeft(I)
   }
   if (isExtend<F>(I)) {
-    const extend: PipeableExtend<F>['extend'] = (f) => (wa) => I.extend(wa, f)
-    const duplicate: PipeableExtend<F>['duplicate'] = (wa) => I.extend(wa, identity)
-    r.extend = extend
-    r.duplicate = duplicate
+    r.extend = extend(I)
+    r.duplicate = r.extend(identity)
   }
   if (isFoldable<F>(I)) {
-    const reduce: PipeableFoldable<F>['reduce'] = (b, f) => (fa) => I.reduce(fa, b, f)
-    const foldMap: PipeableFoldable<F>['foldMap'] = (M) => {
-      const foldMapM = I.foldMap(M)
-      return (f) => (fa) => foldMapM(fa, f)
-    }
-    const reduceRight: PipeableFoldable<F>['reduceRight'] = (b, f) => (fa) => I.reduceRight(fa, b, f)
-    r.reduce = reduce
-    r.foldMap = foldMap
-    r.reduceRight = reduceRight
+    r.reduce = reduce(I)
+    r.foldMap = foldMap(I)
+    r.reduceRight = reduceRight(I)
   }
   if (isFoldableWithIndex<F>(I)) {
-    const reduceWithIndex: PipeableFoldableWithIndex<F, unknown>['reduceWithIndex'] = (b, f) => (fa) =>
-      I.reduceWithIndex(fa, b, f)
-    const foldMapWithIndex: PipeableFoldableWithIndex<F, unknown>['foldMapWithIndex'] = (M) => {
-      const foldMapM = I.foldMapWithIndex(M)
-      return (f) => (fa) => foldMapM(fa, f)
-    }
-    const reduceRightWithIndex: PipeableFoldableWithIndex<F, unknown>['reduceRightWithIndex'] = (b, f) => (fa) =>
-      I.reduceRightWithIndex(fa, b, f)
-    r.reduceWithIndex = reduceWithIndex
-    r.foldMapWithIndex = foldMapWithIndex
-    r.reduceRightWithIndex = reduceRightWithIndex
+    r.reduceWithIndex = reduceWithIndex(I)
+    r.foldMapWithIndex = foldMapWithIndex(I)
+    r.reduceRightWithIndex = reduceRightWithIndex(I)
   }
   if (isAlt<F>(I)) {
-    const alt: PipeableAlt<F>['alt'] = (that) => (fa) => I.alt(fa, that)
-    r.alt = alt
+    r.alt = alt(I)
   }
   if (isCompactable<F>(I)) {
     r.compact = I.compact
     r.separate = I.separate
   }
   if (isFilterable<F>(I)) {
-    const filter: PipeableFilterable<F>['filter'] = <A>(predicate: Predicate<A>) => (fa: HKT<F, A>) =>
-      I.filter(fa, predicate)
-    const filterMap: PipeableFilterable<F>['filterMap'] = (f) => (fa) => I.filterMap(fa, f)
-    const partition: PipeableFilterable<F>['partition'] = <A>(predicate: Predicate<A>) => (fa: HKT<F, A>) =>
-      I.partition(fa, predicate)
-    const partitionMap: PipeableFilterable<F>['partitionMap'] = (f) => (fa) => I.partitionMap(fa, f)
-    r.filter = filter
-    r.filterMap = filterMap
-    r.partition = partition
-    r.partitionMap = partitionMap
+    r.filter = filter(I)
+    r.filterMap = filterMap(I)
+    r.partition = partition(I)
+    r.partitionMap = partitionMap(I)
   }
   if (isFilterableWithIndex<F>(I)) {
-    const filterWithIndex: PipeableFilterableWithIndex<F, unknown>['filterWithIndex'] = <A>(
-      predicateWithIndex: PredicateWithIndex<unknown, A>
-    ) => (fa: HKT<F, A>) => I.filterWithIndex(fa, predicateWithIndex)
-    const filterMapWithIndex: PipeableFilterableWithIndex<F, unknown>['filterMapWithIndex'] = (f) => (fa) =>
-      I.filterMapWithIndex(fa, f)
-    const partitionWithIndex: PipeableFilterableWithIndex<F, unknown>['partitionWithIndex'] = <A>(
-      predicateWithIndex: PredicateWithIndex<unknown, A>
-    ) => (fa: HKT<F, A>) => I.partitionWithIndex(fa, predicateWithIndex)
-    const partitionMapWithIndex: PipeableFilterableWithIndex<F, unknown>['partitionMapWithIndex'] = (f) => (fa) =>
-      I.partitionMapWithIndex(fa, f)
-    r.filterWithIndex = filterWithIndex
-    r.filterMapWithIndex = filterMapWithIndex
-    r.partitionWithIndex = partitionWithIndex
-    r.partitionMapWithIndex = partitionMapWithIndex
+    r.filterWithIndex = filterWithIndex(I)
+    r.filterMapWithIndex = filterMapWithIndex(I)
+    r.partitionWithIndex = partitionWithIndex(I)
+    r.partitionMapWithIndex = partitionMapWithIndex(I)
   }
   if (isProfunctor<F>(I)) {
-    const promap: PipeableProfunctor<F>['promap'] = (f, g) => (fa) => I.promap(fa, f, g)
-    r.promap = promap
+    r.promap = promap(I)
   }
   if (isSemigroupoid<F>(I)) {
-    const compose: PipeableSemigroupoid<F>['compose'] = (that) => (fa) => I.compose(fa, that)
-    r.compose = compose
+    r.compose = compose(I)
   }
   if (isMonadThrow<F>(I)) {
     const fromOption: PipeableMonadThrow<F>['fromOption'] = (onNone) => (ma) =>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "forceConsistentCasingInFileNames": true,
     "stripInternal": true
   },
-  "include": ["./src", "./test", "./scripts", "./perf"]
+  "include": ["./src", "./test", "./scripts", "./perf", "./dtslint"]
 }


### PR DESCRIPTION
# Motivation

The `pipeable` module now exports a series of `pipe`-able helpers that are useful when you build
a typeclass instance "on the fly".

**Example**

Here's a simple `pipe`-line which validates a `Person` struct

```ts
import * as E from 'fp-ts/Either'
import { pipe } from 'fp-ts/function'

const parseString = (u: unknown): E.Either<string, string> =>
  typeof u === 'string' ? E.right(u) : E.left('not a string')

const parseNumber = (u: unknown): E.Either<string, number> =>
  typeof u === 'number' ? E.right(u) : E.left('not a number')

interface Person {
  readonly name: string
  readonly age: number
}

const person = (name: string) => (age: number): Person => ({ name, age })

const parsePerson = (input: Record<string, unknown>): E.Either<string, Person> =>
  pipe(E.of(person), E.ap(parseString(input.name)), E.ap(parseNumber(input.age)))

console.log(parsePerson({})) // => left('not a string')
```

As you can see the default `ap` exported by the `Either` module return only the first validation error.

You probably already know that if you want to get all validation errors you must create an `Applicative` instance on the fly

```ts
import * as S from 'fp-ts/Semigroup'
import * as string from 'fp-ts/string'

const Applicative = E.getApplicativeValidation(pipe(string.Semigroup, S.intercalate(', ')))
```

The issue here is that `Applicative.ap` is not `pipe`-able and can't be used inside a `pipe`-line

```ts
const parsePersonAll = (input: Record<string, unknown>): E.Either<string, Person> =>
  pipe(
    E.of(person),
    Applicative.ap(parseString(input.name)), // <= error
    Applicative.ap(parseNumber(input.age)) // <= error
  )
```

That's when the new `pipe`-able helpers come to handy

```ts
import * as P from 'fp-ts/pipeable'

//    v--- this is `pipe`-able
const ap = P.ap(Applicative)

const parsePersonAll = (input: Record<string, unknown>): E.Either<string, Person> =>
  pipe(
    E.of(person),
    ap(parseString(input.name)), // <= ok
    ap(parseNumber(input.age)) // <= ok
  )

console.log(parsePersonAll({})) // => left('not a string, not a number')
```
