### PR TITLE
Flip the arguments of a curried function

### DIFF
--- a/docs/modules/function.ts.md
+++ b/docs/modules/function.ts.md
@@ -291,12 +291,22 @@ Added in v3.0.0
 
 ## flip
 
-Flips the order of the arguments of a function of two arguments.
+Flips the arguments of a curried function.
 
 **Signature**
 
 ```ts
-export declare const flip: <A, B, C>(f: (a: A, b: B) => C) => (b: B, a: A) => C
+export declare const flip: <A, B, C>(f: (a: A) => (b: B) => C) => (b: B) => (a: A) => C
+```
+
+**Example**
+
+```ts
+import { flip } from 'fp-ts/function'
+
+const f = (a: number) => (b: string) => a - b.length
+
+assert.strictEqual(flip(f)('aaa')(2), -1)
 ```
 
 Added in v3.0.0

--- a/dtslint/ts4.1/function.ts
+++ b/dtslint/ts4.1/function.ts
@@ -2,17 +2,6 @@ import * as _ from '../../src/function'
 import * as A from '../../src/ReadonlyArray'
 
 //
-// flip
-//
-
-// should handle generics
-declare function snoc<A>(init: ReadonlyArray<A>, end: A): ReadonlyArray<A>
-_.flip(snoc) // $ExpectType <A>(b: A, a: readonly A[]) => ReadonlyArray<A>
-
-// $ExpectType <A>(init: readonly A[], end: A) => Option<A>
-_.flow(snoc, A.head)
-
-//
 // tupled
 //
 

--- a/src/function.ts
+++ b/src/function.ts
@@ -199,11 +199,18 @@ export const constUndefined: Lazy<undefined> =
 export const constVoid: Lazy<void> = constUndefined
 
 /**
- * Flips the order of the arguments of a function of two arguments.
+ * Flips the arguments of a curried function.
+ *
+ * @example
+ * import { flip } from 'fp-ts/function'
+ *
+ * const f = (a: number) => (b: string) => a - b.length
+ *
+ * assert.strictEqual(flip(f)('aaa')(2), -1)
  *
  * @since 3.0.0
  */
-export const flip = <A, B, C>(f: (a: A, b: B) => C): ((b: B, a: A) => C) => (b, a) => f(a, b)
+export const flip = <A, B, C>(f: (a: A) => (b: B) => C): ((b: B) => (a: A) => C) => (b) => (a) => f(a)(b)
 
 /**
  * Performs left-to-right function composition. The first argument may have any arity, the remaining arguments must be unary.

--- a/test/function.ts
+++ b/test/function.ts
@@ -12,8 +12,8 @@ const g = U.double
 
 describe('function', () => {
   it('flip', () => {
-    const f = (a: number, b: string) => a - b.length
-    U.deepStrictEqual(_.flip(f)('aaa', 2), -1)
+    const f = (a: number) => (b: string) => a - b.length
+    U.deepStrictEqual(_.flip(f)('aaa')(2), -1)
   })
 
   it('unsafeCoerce', () => {


### PR DESCRIPTION
This is the follow-up to #1748 on v3, replacing the deprecation. (The commits there haven't been merged into the new branch yet, so this will create a conflict if it does.)