### PR TITLE
Add `getOrDefault` to `Option` and `Either` based types

### DIFF
--- a/docs/modules/Either.ts.md
+++ b/docs/modules/Either.ts.md
@@ -100,6 +100,7 @@ Added in v2.0.0
 - [destructors](#destructors)
   - [fold](#fold)
   - [foldW](#foldw)
+  - [getOrDefault](#getordefault)
   - [getOrElse](#getorelse)
   - [getOrElseW](#getorelsew)
   - [match](#match)
@@ -600,6 +601,29 @@ export declare const foldW: <E, B, A, C>(onLeft: (e: E) => B, onRight: (a: A) =>
 ```
 
 Added in v2.10.0
+
+## getOrDefault
+
+Returns the wrapped value if it's a `Right` or a default value if is a `Left`.
+
+**Signature**
+
+```ts
+export declare const getOrDefault: <A>(M: Monoid<A>) => <E>(ma: Either<E, A>) => A
+```
+
+**Example**
+
+```ts
+import { getOrDefault, left, right } from 'fp-ts/Either'
+import { pipe } from 'fp-ts/function'
+import { MonoidSum } from 'fp-ts/number'
+
+assert.deepStrictEqual(pipe(right(1), getOrDefault(MonoidSum)), 1)
+assert.deepStrictEqual(pipe(left('error'), getOrDefault(MonoidSum)), 0)
+```
+
+Added in v2.13.0
 
 ## getOrElse
 

--- a/docs/modules/EitherT.ts.md
+++ b/docs/modules/EitherT.ts.md
@@ -29,6 +29,7 @@ Added in v2.0.0
   - [chainNullableK](#chainnullablek)
   - [fromNullable](#fromnullable)
   - [fromNullableK](#fromnullablek)
+  - [getOrDefault](#getordefault)
   - [getOrElse](#getorelse)
   - [left](#left)
   - [leftF](#leftf)
@@ -379,6 +380,31 @@ export declare function fromNullableK<F>(
 ```
 
 Added in v2.12.0
+
+## getOrDefault
+
+**Signature**
+
+```ts
+export declare function getOrDefault<M extends URIS3>(
+  M: Monad3<M>
+): <A>(m: Monoid<A>) => <E, R, ME>(ma: Kind3<M, R, ME, Either<E, A>>) => Kind3<M, R, ME, A>
+export declare function getOrDefault<M extends URIS3, ME>(
+  M: Monad3C<M, ME>
+): <A>(m: Monoid<A>) => <E, R>(ma: Kind3<M, R, ME, Either<E, A>>) => Kind3<M, R, ME, A>
+export declare function getOrDefault<M extends URIS2>(
+  M: Monad2<M>
+): <A>(m: Monoid<A>) => <E, ME>(ma: Kind2<M, ME, Either<E, A>>) => Kind2<M, ME, A>
+export declare function getOrDefault<M extends URIS2, ME>(
+  M: Monad2C<M, ME>
+): <A>(m: Monoid<A>) => <E>(ma: Kind2<M, ME, Either<E, A>>) => Kind2<M, ME, A>
+export declare function getOrDefault<M extends URIS>(
+  M: Monad1<M>
+): <A>(m: Monoid<A>) => <E>(ma: Kind<M, Either<E, A>>) => Kind<M, A>
+export declare function getOrDefault<M>(M: Monad<M>): <A>(m: Monoid<A>) => <E>(ma: HKT<M, Either<E, A>>) => HKT<M, A>
+```
+
+Added in v2.13.0
 
 ## getOrElse
 

--- a/docs/modules/IOEither.ts.md
+++ b/docs/modules/IOEither.ts.md
@@ -74,6 +74,7 @@ Added in v2.0.0
 - [destructors](#destructors)
   - [fold](#fold)
   - [foldW](#foldw)
+  - [getOrDefault](#getordefault)
   - [getOrElse](#getorelse)
   - [getOrElseW](#getorelsew)
   - [match](#match)
@@ -748,6 +749,16 @@ export declare const foldW: <E, B, A, C>(
 ```
 
 Added in v2.10.0
+
+## getOrDefault
+
+**Signature**
+
+```ts
+export declare const getOrDefault: <A>(m: Monoid<A>) => <E>(ma: IOEither<E, A>) => I.IO<A>
+```
+
+Added in v2.13.0
 
 ## getOrElse
 

--- a/docs/modules/IOOption.ts.md
+++ b/docs/modules/IOOption.ts.md
@@ -59,6 +59,7 @@ Added in v2.12.0
   - [some](#some)
 - [destructors](#destructors)
   - [fold](#fold)
+  - [getOrDefault](#getordefault)
   - [getOrElse](#getorelse)
   - [getOrElseW](#getorelsew)
   - [match](#match)
@@ -481,6 +482,16 @@ export declare const fold: <B, A>(onNone: () => I.IO<B>, onSome: (a: A) => I.IO<
 ```
 
 Added in v2.12.0
+
+## getOrDefault
+
+**Signature**
+
+```ts
+export declare const getOrDefault: <A>(m: Monoid<A>) => (fa: IOOption<A>) => I.IO<A>
+```
+
+Added in v2.13.0
 
 ## getOrElse
 

--- a/docs/modules/Option.ts.md
+++ b/docs/modules/Option.ts.md
@@ -92,6 +92,7 @@ Added in v2.0.0
 - [destructors](#destructors)
   - [fold](#fold)
   - [foldW](#foldw)
+  - [getOrDefault](#getordefault)
   - [getOrElse](#getorelse)
   - [getOrElseW](#getorelsew)
   - [match](#match)
@@ -438,6 +439,29 @@ export declare const foldW: <B, A, C>(onNone: Lazy<B>, onSome: (a: A) => C) => (
 ```
 
 Added in v2.10.0
+
+## getOrDefault
+
+Extracts the value out of the structure, if it exists. Otherwise returns the given Monoid instance empty value
+
+**Signature**
+
+```ts
+export declare const getOrDefault: <A>(M: Monoid<A>) => (ma: Option<A>) => A
+```
+
+**Example**
+
+```ts
+import { some, none, getOrDefault } from 'fp-ts/Option'
+import { pipe } from 'fp-ts/function'
+import { MonoidSum } from 'fp-ts/number'
+
+assert.strictEqual(pipe(some(1), getOrDefault(MonoidSum)), 1)
+assert.strictEqual(pipe(none, getOrDefault(MonoidSum)), 0)
+```
+
+Added in v2.13.0
 
 ## getOrElse
 

--- a/docs/modules/OptionT.ts.md
+++ b/docs/modules/OptionT.ts.md
@@ -28,6 +28,7 @@ Added in v2.0.0
   - [fromNullableK](#fromnullablek)
   - [fromOptionK](#fromoptionk)
   - [fromPredicate](#frompredicate)
+  - [getOrDefault](#getordefault)
   - [getOrElse](#getorelse)
   - [map](#map)
   - [match](#match)
@@ -450,6 +451,34 @@ export declare function fromPredicate<F>(
 ```
 
 Added in v2.10.0
+
+## getOrDefault
+
+**Signature**
+
+```ts
+export declare function getOrDefault<M extends URIS4>(
+  M: Monad4<M>
+): <A>(m: Monoid<A>) => <S, R, E>(fa: Kind4<M, S, R, E, Option<A>>) => Kind4<M, S, R, E, A>
+export declare function getOrDefault<M extends URIS3>(
+  M: Monad3<M>
+): <A>(m: Monoid<A>) => <R, E>(fa: Kind3<M, R, E, Option<A>>) => Kind3<M, R, E, A>
+export declare function getOrDefault<M extends URIS3, E>(
+  M: Monad3C<M, E>
+): <A>(m: Monoid<A>) => <R>(fa: Kind3<M, R, E, Option<A>>) => Kind3<M, R, E, A>
+export declare function getOrDefault<M extends URIS2>(
+  M: Monad2<M>
+): <A>(m: Monoid<A>) => <E>(fa: Kind2<M, E, Option<A>>) => Kind2<M, E, A>
+export declare function getOrDefault<M extends URIS2, E>(
+  M: Monad2C<M, E>
+): <A>(m: Monoid<A>) => (fa: Kind2<M, E, Option<A>>) => Kind2<M, E, A>
+export declare function getOrDefault<M extends URIS>(
+  M: Monad1<M>
+): <A>(m: Monoid<A>) => (fa: Kind<M, Option<A>>) => Kind<M, A>
+export declare function getOrDefault<M>(M: Monad<M>): <A>(m: Monoid<A>) => (fa: HKT<M, Option<A>>) => HKT<M, A>
+```
+
+Added in v2.13.0
 
 ## getOrElse
 

--- a/docs/modules/ReaderEither.ts.md
+++ b/docs/modules/ReaderEither.ts.md
@@ -74,6 +74,7 @@ Added in v2.0.0
 - [destructors](#destructors)
   - [fold](#fold)
   - [foldW](#foldw)
+  - [getOrDefault](#getordefault)
   - [getOrElse](#getorelse)
   - [getOrElseW](#getorelsew)
   - [match](#match)
@@ -864,6 +865,16 @@ export declare const foldW: <E, R2, B, A, R3, C>(
 ```
 
 Added in v2.10.0
+
+## getOrDefault
+
+**Signature**
+
+```ts
+export declare const getOrDefault: <A>(m: Monoid<A>) => <E, R>(ma: ReaderEither<R, E, A>) => R.Reader<R, A>
+```
+
+Added in v2.13.0
 
 ## getOrElse
 

--- a/docs/modules/ReaderTaskEither.ts.md
+++ b/docs/modules/ReaderTaskEither.ts.md
@@ -112,6 +112,7 @@ Added in v2.0.0
 - [destructors](#destructors)
   - [fold](#fold)
   - [foldW](#foldw)
+  - [getOrDefault](#getordefault)
   - [getOrElse](#getorelse)
   - [getOrElseW](#getorelsew)
   - [match](#match)
@@ -1406,6 +1407,16 @@ export declare const foldW: <E, R2, B, A, R3, C>(
 ```
 
 Added in v2.10.0
+
+## getOrDefault
+
+**Signature**
+
+```ts
+export declare const getOrDefault: <A>(m: Monoid<A>) => <R, E>(ma: ReaderTaskEither<R, E, A>) => RT.ReaderTask<R, A>
+```
+
+Added in v2.13.0
 
 ## getOrElse
 

--- a/docs/modules/TaskEither.ts.md
+++ b/docs/modules/TaskEither.ts.md
@@ -87,6 +87,7 @@ Added in v2.0.0
 - [destructors](#destructors)
   - [fold](#fold)
   - [foldW](#foldw)
+  - [getOrDefault](#getordefault)
   - [getOrElse](#getorelse)
   - [getOrElseW](#getorelsew)
   - [match](#match)
@@ -981,6 +982,16 @@ export declare const foldW: <E, B, A, C>(
 ```
 
 Added in v2.10.0
+
+## getOrDefault
+
+**Signature**
+
+```ts
+export declare const getOrDefault: <A>(m: Monoid<A>) => <E>(ma: TaskEither<E, A>) => T.Task<A>
+```
+
+Added in v2.13.0
 
 ## getOrElse
 

--- a/docs/modules/TaskOption.ts.md
+++ b/docs/modules/TaskOption.ts.md
@@ -58,6 +58,7 @@ Added in v2.10.0
 - [destructors](#destructors)
   - [fold](#fold)
   - [foldW](#foldw)
+  - [getOrDefault](#getordefault)
   - [getOrElse](#getorelse)
   - [getOrElseW](#getorelsew)
   - [match](#match)
@@ -543,6 +544,16 @@ export declare const foldW: <B, C, A>(
 ```
 
 Added in v2.10.0
+
+## getOrDefault
+
+**Signature**
+
+```ts
+export declare const getOrDefault: <A>(m: Monoid<A>) => (fa: TaskOption<A>) => T.Task<A>
+```
+
+Added in v2.13.0
 
 ## getOrElse
 

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -1098,6 +1098,34 @@ export const getOrElseW = <E, B>(onLeft: (e: E) => B) => <A>(ma: Either<E, A>): 
  */
 export const getOrElse: <E, A>(onLeft: (e: E) => A) => (ma: Either<E, A>) => A = getOrElseW
 
+/**
+ * Returns the wrapped value if it's a `Right` or a default value if is a `Left`.
+ *
+ * @example
+ * import { getOrDefault, left, right } from 'fp-ts/Either'
+ * import { pipe } from 'fp-ts/function'
+ * import { MonoidSum } from 'fp-ts/number'
+ *
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     right(1),
+ *     getOrDefault(MonoidSum)
+ *   ),
+ *   1
+ * )
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     left('error'),
+ *     getOrDefault(MonoidSum)
+ *   ),
+ *   0
+ * )
+ *
+ * @category destructors
+ * @since 2.13.0
+ */
+export const getOrDefault = <A>(M: Monoid<A>) => <E>(ma: Either<E, A>): A => (isLeft(ma) ? M.empty : ma.right)
+
 // -------------------------------------------------------------------------------------
 // combinators
 // -------------------------------------------------------------------------------------

--- a/src/EitherT.ts
+++ b/src/EitherT.ts
@@ -13,6 +13,7 @@ import { flow, Lazy, pipe } from './function'
 import { Functor, Functor1, Functor2, Functor2C, Functor3, Functor3C, map as map_ } from './Functor'
 import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3 } from './HKT'
 import { Monad, Monad1, Monad2, Monad2C, Monad3, Monad3C } from './Monad'
+import { Monoid } from './Monoid'
 import { Pointed, Pointed1, Pointed2, Pointed2C, Pointed3, Pointed3C } from './Pointed'
 import { Semigroup } from './Semigroup'
 
@@ -565,6 +566,33 @@ export function getOrElse<M>(
   M: Monad<M>
 ): <E, A>(onLeft: (e: E) => HKT<M, A>) => (ma: HKT<M, Either<E, A>>) => HKT<M, A> {
   return (onLeft) => (ma) => M.chain(ma, E.match(onLeft, M.of))
+}
+
+/**
+ * @since 2.13.0
+ */
+export function getOrDefault<M extends URIS3>(
+  M: Monad3<M>
+): <A>(m: Monoid<A>) => <E, R, ME>(ma: Kind3<M, R, ME, Either<E, A>>) => Kind3<M, R, ME, A>
+export function getOrDefault<M extends URIS3, ME>(
+  M: Monad3C<M, ME>
+): <A>(m: Monoid<A>) => <E, R>(ma: Kind3<M, R, ME, Either<E, A>>) => Kind3<M, R, ME, A>
+export function getOrDefault<M extends URIS2>(
+  M: Monad2<M>
+): <A>(m: Monoid<A>) => <E, ME>(ma: Kind2<M, ME, Either<E, A>>) => Kind2<M, ME, A>
+export function getOrDefault<M extends URIS2, ME>(
+  M: Monad2C<M, ME>
+): <A>(m: Monoid<A>) => <E>(ma: Kind2<M, ME, Either<E, A>>) => Kind2<M, ME, A>
+export function getOrDefault<M extends URIS>(
+  M: Monad1<M>
+): <A>(m: Monoid<A>) => <E>(ma: Kind<M, Either<E, A>>) => Kind<M, A>
+export function getOrDefault<M>(M: Monad<M>): <A>(m: Monoid<A>) => <E>(ma: HKT<M, Either<E, A>>) => HKT<M, A>
+export function getOrDefault<M>(M: Monad<M>): <A>(m: Monoid<A>) => <E>(ma: HKT<M, Either<E, A>>) => HKT<M, A> {
+  return (m) => (ma) =>
+    M.chain(
+      ma,
+      E.match(() => M.of(m.empty), M.of)
+    )
 }
 
 // -------------------------------------------------------------------------------------

--- a/src/IOEither.ts
+++ b/src/IOEither.ts
@@ -198,6 +198,14 @@ export const getOrElse: <E, A>(onLeft: (e: E) => IO<A>) => (ma: IOEither<E, A>) 
  */
 export const getOrElseW: <E, B>(onLeft: (e: E) => IO<B>) => <A>(ma: IOEither<E, A>) => IO<A | B> = getOrElse as any
 
+/**
+ * @category destructors
+ * @since 2.13.0
+ */
+export const getOrDefault: <A>(m: Monoid<A>) => <E>(ma: IOEither<E, A>) => IO<A> = /*#__PURE__*/ ET.getOrDefault(
+  I.Monad
+)
+
 // -------------------------------------------------------------------------------------
 // interop
 // -------------------------------------------------------------------------------------

--- a/src/IOOption.ts
+++ b/src/IOOption.ts
@@ -45,6 +45,7 @@ import { Zero1, guard as guard_ } from './Zero'
 
 import IO = I.IO
 import Option = O.Option
+import { Monoid } from './Monoid'
 
 // -------------------------------------------------------------------------------------
 // model
@@ -173,6 +174,12 @@ export const getOrElse: <A>(onNone: Lazy<IO<A>>) => (fa: IOOption<A>) => IO<A> =
  * @since 2.12.0
  */
 export const getOrElseW: <B>(onNone: Lazy<IO<B>>) => <A>(ma: IOOption<A>) => IO<A | B> = getOrElse as any
+
+/**
+ * @category destructors
+ * @since 2.13.0
+ */
+export const getOrDefault: <A>(m: Monoid<A>) => (fa: IOOption<A>) => IO<A> = /*#__PURE__*/ OT.getOrDefault(I.Monad)
 
 /**
  * @category destructors

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -904,6 +904,34 @@ export const getOrElseW = <B>(onNone: Lazy<B>) => <A>(ma: Option<A>): A | B => (
  */
 export const getOrElse: <A>(onNone: Lazy<A>) => (ma: Option<A>) => A = getOrElseW
 
+/**
+ * Extracts the value out of the structure, if it exists. Otherwise returns the given Monoid instance empty value
+ *
+ * @example
+ * import { some, none, getOrDefault } from 'fp-ts/Option'
+ * import { pipe } from 'fp-ts/function'
+ * import { MonoidSum } from 'fp-ts/number'
+ *
+ * assert.strictEqual(
+ *   pipe(
+ *     some(1),
+ *     getOrDefault(MonoidSum)
+ *   ),
+ *   1
+ * )
+ * assert.strictEqual(
+ *   pipe(
+ *     none,
+ *     getOrDefault(MonoidSum)
+ *   ),
+ *   0
+ * )
+ *
+ * @category destructors
+ * @since 2.13.0
+ */
+export const getOrDefault = <A>(M: Monoid<A>) => (ma: Option<A>): A => (isNone(ma) ? M.empty : ma.value)
+
 // -------------------------------------------------------------------------------------
 // combinators
 // -------------------------------------------------------------------------------------

--- a/src/OptionT.ts
+++ b/src/OptionT.ts
@@ -14,6 +14,7 @@ import { constant, flow, Lazy, pipe } from './function'
 import { Functor, Functor1, Functor2, Functor2C, Functor3, Functor3C, Functor4, map as map_ } from './Functor'
 import { HKT, Kind, Kind2, Kind3, Kind4, URIS, URIS2, URIS3, URIS4 } from './HKT'
 import { Monad, Monad1, Monad2, Monad2C, Monad3, Monad3C, Monad4 } from './Monad'
+import { Monoid } from './Monoid'
 import * as O from './Option'
 import { Pointed, Pointed1, Pointed2, Pointed2C, Pointed3, Pointed3C, Pointed4 } from './Pointed'
 import { Predicate } from './Predicate'
@@ -424,6 +425,34 @@ export function getOrElse<M extends URIS>(
 export function getOrElse<M>(M: Monad<M>): <A>(onNone: Lazy<HKT<M, A>>) => (fa: HKT<M, Option<A>>) => HKT<M, A>
 export function getOrElse<M>(M: Monad<M>): <A>(onNone: Lazy<HKT<M, A>>) => (fa: HKT<M, Option<A>>) => HKT<M, A> {
   return (onNone) => (fa) => M.chain(fa, O.match(onNone, M.of))
+}
+
+/**
+ * @since 2.13.0
+ */
+export function getOrDefault<M extends URIS4>(
+  M: Monad4<M>
+): <A>(m: Monoid<A>) => <S, R, E>(fa: Kind4<M, S, R, E, Option<A>>) => Kind4<M, S, R, E, A>
+export function getOrDefault<M extends URIS3>(
+  M: Monad3<M>
+): <A>(m: Monoid<A>) => <R, E>(fa: Kind3<M, R, E, Option<A>>) => Kind3<M, R, E, A>
+export function getOrDefault<M extends URIS3, E>(
+  M: Monad3C<M, E>
+): <A>(m: Monoid<A>) => <R>(fa: Kind3<M, R, E, Option<A>>) => Kind3<M, R, E, A>
+export function getOrDefault<M extends URIS2>(
+  M: Monad2<M>
+): <A>(m: Monoid<A>) => <E>(fa: Kind2<M, E, Option<A>>) => Kind2<M, E, A>
+export function getOrDefault<M extends URIS2, E>(
+  M: Monad2C<M, E>
+): <A>(m: Monoid<A>) => (fa: Kind2<M, E, Option<A>>) => Kind2<M, E, A>
+export function getOrDefault<M extends URIS>(M: Monad1<M>): <A>(m: Monoid<A>) => (fa: Kind<M, Option<A>>) => Kind<M, A>
+export function getOrDefault<M>(M: Monad<M>): <A>(m: Monoid<A>) => (fa: HKT<M, Option<A>>) => HKT<M, A>
+export function getOrDefault<M>(M: Monad<M>): <A>(m: Monoid<A>) => (fa: HKT<M, Option<A>>) => HKT<M, A> {
+  return (m) => (fa) =>
+    M.chain(
+      fa,
+      O.match(() => M.of(m.empty), M.of)
+    )
 }
 
 // -------------------------------------------------------------------------------------

--- a/src/ReaderEither.ts
+++ b/src/ReaderEither.ts
@@ -203,6 +203,14 @@ export const getOrElseW: <R2, E, B>(
   onLeft: (e: E) => Reader<R2, B>
 ) => <R1, A>(ma: ReaderEither<R1, E, A>) => Reader<R1 & R2, A | B> = getOrElse as any
 
+/**
+ * @category destructors
+ * @since 2.13.0
+ */
+export const getOrDefault: <A>(
+  m: Monoid<A>
+) => <E, R>(ma: ReaderEither<R, E, A>) => Reader<R, A> = /*#__PURE__*/ ET.getOrDefault(R.Monad)
+
 // -------------------------------------------------------------------------------------
 // interop
 // -------------------------------------------------------------------------------------

--- a/src/ReaderTaskEither.ts
+++ b/src/ReaderTaskEither.ts
@@ -326,6 +326,14 @@ export const getOrElseW: <R2, E, B>(
   onLeft: (e: E) => ReaderTask<R2, B>
 ) => <R1, A>(ma: ReaderTaskEither<R1, E, A>) => ReaderTask<R1 & R2, A | B> = getOrElse as any
 
+/**
+ * @category destructors
+ * @since 2.13.0
+ */
+export const getOrDefault: <A>(
+  m: Monoid<A>
+) => <R, E>(ma: ReaderTaskEither<R, E, A>) => ReaderTask<R, A> = /*#__PURE__*/ ET.getOrDefault(RT.Monad)
+
 // -------------------------------------------------------------------------------------
 // interop
 // -------------------------------------------------------------------------------------

--- a/src/TaskEither.ts
+++ b/src/TaskEither.ts
@@ -243,6 +243,14 @@ export const getOrElseW: <E, B>(
   onLeft: (e: E) => Task<B>
 ) => <A>(ma: TaskEither<E, A>) => Task<A | B> = getOrElse as any
 
+/**
+ * @category destructors
+ * @since 2.13.0
+ */
+export const getOrDefault: <A>(m: Monoid<A>) => <E>(ma: TaskEither<E, A>) => Task<A> = /*#__PURE__*/ ET.getOrDefault(
+  T.Monad
+)
+
 // -------------------------------------------------------------------------------------
 // interop
 // -------------------------------------------------------------------------------------

--- a/src/TaskOption.ts
+++ b/src/TaskOption.ts
@@ -35,6 +35,7 @@ import { IO } from './IO'
 import { Monad1 } from './Monad'
 import { MonadIO1 } from './MonadIO'
 import { MonadTask1 } from './MonadTask'
+import { Monoid } from './Monoid'
 import { NonEmptyArray } from './NonEmptyArray'
 import * as O from './Option'
 import * as OT from './OptionT'
@@ -197,6 +198,12 @@ export const getOrElse: <A>(onNone: Lazy<Task<A>>) => (fa: TaskOption<A>) => Tas
  * @since 2.10.0
  */
 export const getOrElseW: <B>(onNone: Lazy<Task<B>>) => <A>(ma: TaskOption<A>) => Task<A | B> = getOrElse as any
+
+/**
+ * @category destructors
+ * @since 2.13.0
+ */
+export const getOrDefault: <A>(m: Monoid<A>) => (fa: TaskOption<A>) => Task<A> = /*#__PURE__*/ OT.getOrDefault(T.Monad)
 
 // -------------------------------------------------------------------------------------
 // interop

--- a/test/Either.ts
+++ b/test/Either.ts
@@ -1,3 +1,4 @@
+import { number } from '../src'
 import { sequenceT } from '../src/Apply'
 import * as _ from '../src/Either'
 import { identity, pipe } from '../src/function'
@@ -211,6 +212,12 @@ describe('Either', () => {
       ),
       2
     )
+  })
+
+  it('getOrDefault', () => {
+    U.deepStrictEqual(pipe(_.right(12), _.getOrDefault(number.MonoidSum)), 12)
+    U.deepStrictEqual(pipe(_.left('a'), _.getOrDefault(number.MonoidSum)), 0)
+    U.deepStrictEqual(pipe(_.left('a'), _.getOrDefault(number.MonoidProduct)), 1)
   })
 
   it('elem', () => {

--- a/test/EitherT.ts
+++ b/test/EitherT.ts
@@ -1,7 +1,9 @@
 import * as U from './util'
 import * as E from '../src/Either'
+import * as ET from '../src/EitherT'
 import { getEitherM } from '../src/EitherT'
 import * as I from '../src/IO'
+import { string } from '../src'
 
 describe('EitherT', () => {
   const T = getEitherM(I.Monad)
@@ -17,5 +19,10 @@ describe('EitherT', () => {
     const onLeft = (s: string) => I.of(`left(${s})`)
     U.deepStrictEqual(T.getOrElse(I.of(E.right('a')), onLeft)(), 'a')
     U.deepStrictEqual(T.getOrElse(I.of(E.left('bb')), onLeft)(), 'left(bb)')
+  })
+
+  it('getOrDefault', () => {
+    U.deepStrictEqual(ET.getOrDefault(I.Monad)(string.Monoid)(I.of(E.right('a')))(), 'a')
+    U.deepStrictEqual(ET.getOrDefault(I.Monad)(string.Monoid)(I.of(E.left(42)))(), '')
   })
 })

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -8,6 +8,7 @@ import * as S from '../src/string'
 import * as T from '../src/Task'
 import { separated } from '../src/Separated'
 import { ReadonlyNonEmptyArray } from '../src/ReadonlyNonEmptyArray'
+import { number } from '../src'
 
 const p = (n: number): boolean => n > 2
 
@@ -253,6 +254,11 @@ describe('Option', () => {
       ),
       0
     )
+  })
+
+  it('getOrDefault', () => {
+    U.deepStrictEqual(pipe(_.some(1), _.getOrDefault(number.MonoidSum)), 1)
+    U.deepStrictEqual(pipe(_.none, _.getOrDefault(number.MonoidSum)), 0)
   })
 
   it('equals', () => {

--- a/test/OptionT.ts
+++ b/test/OptionT.ts
@@ -1,7 +1,9 @@
 import * as U from './util'
 import * as O from '../src/Option'
+import * as OT from '../src/OptionT'
 import { getOptionM } from '../src/OptionT'
 import * as T from '../src/Task'
+import { number } from '../src'
 
 const MT = getOptionM(T.Monad)
 
@@ -53,6 +55,13 @@ describe('OptionT', () => {
     U.deepStrictEqual(n1, 1)
     const n2 = await MT.getOrElse(T.of(O.none), () => T.of(2))()
     U.deepStrictEqual(n2, 2)
+  })
+
+  it('getOrDefault', async () => {
+    const n1 = await OT.getOrDefault(T.Monad)(number.MonoidSum)(T.of(O.some(1)))()
+    U.deepStrictEqual(n1, 1)
+    const n2 = await OT.getOrDefault(T.Monad)(number.MonoidSum)(T.of(O.none))()
+    U.deepStrictEqual(n2, 0)
   })
 
   it('fromM', async () => {


### PR DESCRIPTION
I added the `getOrDefault` function to `Option`, `Either` and associated transformer types.
This function allows to extract the value if present and default to the provided `Monoid`'s `empty` value if not.

**Examples:**
```ts
import { some, none, getOrDefault } from 'fp-ts/Option'
import { pipe } from 'fp-ts/function'
import { MonoidSum, MonoidProduct } from 'fp-ts/number'

assert.strictEqual(pipe(some(42), getOrDefault(MonoidSum)), 42)
assert.strictEqual(pipe(none, getOrDefault(MonoidSum)), 0)
assert.strictEqual(pipe(none, getOrDefault(MonoidProduct)), 1)
```