### PR TITLE
Implement generic types for fromEntries of Record and ReadonlyRecord

### DIFF
--- a/src/ReadonlyRecord.ts
+++ b/src/ReadonlyRecord.ts
@@ -1120,8 +1120,8 @@ export const toEntries = toReadonlyArray
  * @since 2.12.0
  * @category conversions
  */
-export const fromEntries = <A>(fa: ReadonlyArray<readonly [string, A]>): ReadonlyRecord<string, A> => {
-  const out: Record<string, A> = {}
+export const fromEntries = <K extends string, A>(fa: ReadonlyArray<readonly [K, A]>): ReadonlyRecord<K, A> => {
+  const out: Record<K, A> = Object.create(null)
   for (const a of fa) {
     out[a[0]] = a[1]
   }

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -808,7 +808,7 @@ export const toEntries = toArray
  * @since 2.12.0
  * @category conversions
  */
-export const fromEntries = <A>(fa: Array<[string, A]>): Record<string, A> => fromFoldable(Se.last<A>(), A.Foldable)(fa)
+export const fromEntries = <K extends string, A>(fa: Array<[K, A]>): Record<K, A> => fromFoldable(Se.last<A>(), A.Foldable)(fa)
 
 /**
  * Create a `Record` from a foldable collection using the specified functions to


### PR DESCRIPTION
I am heavily use types, and most of my `Record` inputs are typed with generic keys, so i really miss this feature.

I was forced to use `Object.create(null)` because otherwise typescript throwed compile error.