### PR TITLE
ReadonlyArray Difference Prefer Non-Deprecated

### DIFF
--- a/src/ReadonlyArray.ts
+++ b/src/ReadonlyArray.ts
@@ -1343,8 +1343,8 @@ export function intersection<A>(
  * @since 2.5.0
  */
 export function difference<A>(E: Eq<A>): {
-  (xs: ReadonlyArray<A>): (ys: ReadonlyArray<A>) => ReadonlyArray<A>
   (xs: ReadonlyArray<A>, ys: ReadonlyArray<A>): ReadonlyArray<A>
+  (xs: ReadonlyArray<A>): (ys: ReadonlyArray<A>) => ReadonlyArray<A>
 }
 export function difference<A>(
   E: Eq<A>


### PR DESCRIPTION
# Prefer Non-Deprecated Function Signature for ReadonlyArray Difference

Currently there two function signatures for the difference function in the ReadonlyArray module and one is deprecated. Typescript seems to give preference to the deprecated signature as shown here:
![Screenshot_20230124_083241](https://user-images.githubusercontent.com/42924425/214477575-a4d90877-be93-47a2-bb1c-aa212566a617.png)

This PR changes the order of the signatures, prioritizing the non-deprecated signature:
![Screenshot_20230124_083322](https://user-images.githubusercontent.com/42924425/214477580-d7e12bbe-540b-4f19-a88a-c3953449045f.png)

**Before submitting a pull request,** please make sure the following is done:

- Fork [the repository](https://github.com/gcanti/fp-ts) and create your branch from `master`.
- Run `npm install` in the repository root.
- If you've fixed a bug or added code that should be tested, add tests!
- Ensure the test suite passes (`npm test`).

**Note**. If you've fixed a bug please link the related issue or, if missing, open an issue before sending a PR.

#1804 

**Note**. If you find a typo in the **documentation**, make sure to modify the corresponding source (docs are generated).

**Note**. If you want to send a PR related to `fp-ts@1.x` please create your branch from `1.x`
