### PR TITLE
feat(option): better return type for Option constructors

### DIFF
--- a/src/Option.ts
+++ b/src/Option.ts
@@ -140,7 +140,7 @@ export type Option<A> = None | Some<A>
  * @category constructors
  * @since 2.0.0
  */
-export const none: Option<never> = _.none
+export const none: None = _.none
 
 /**
  * Constructs a `Some`. Represents an optional value that exists.
@@ -148,7 +148,7 @@ export const none: Option<never> = _.none
  * @category constructors
  * @since 2.0.0
  */
-export const some: <A>(a: A) => Option<A> = _.some
+export const some: <A>(a: A) => Some<A> = _.some
 
 /**
  * Returns a *smart constructor* based on the given predicate.

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -17,10 +17,10 @@ export const isNone = (fa: Option<unknown>): fa is None => fa._tag === 'None'
 export const isSome = <A>(fa: Option<A>): fa is Some<A> => fa._tag === 'Some'
 
 /** @internal */
-export const none: Option<never> = { _tag: 'None' }
+export const none: None = { _tag: 'None' }
 
 /** @internal */
-export const some = <A>(a: A): Option<A> => ({ _tag: 'Some', value: a })
+export const some = <A>(a: A): Some<A> => ({ _tag: 'Some', value: a })
 
 // -------------------------------------------------------------------------------------
 // Either


### PR DESCRIPTION
This makes `some()` constructor return a `Some<A>` and `none` return a `None`, more specific than actual `Option<A>`.

This enables this kind of code to work :

```ts
const updateObjectOrCreate = (
  someObject: Option<SomeType>,
  transformer: (session: SomeType) => SomeType
): option.Some<SomeType> =>
  pipe(
    someObject,
    option.getOrElse(
      constant(
        makeObject(someSaneDefaults)
      )
    ),
    transformer,
    option.some
  );
```

without adding à `as option.Some<Session>`