### PR TITLE
refactor: recursive type definition of pipe() and flow()

### DIFF
--- a/src/function.ts
+++ b/src/function.ts
@@ -233,112 +233,19 @@ export function flip(f: Function): Function {
  *
  * @since 2.0.0
  */
-export function flow<A extends ReadonlyArray<unknown>, B>(ab: (...a: A) => B): (...a: A) => B
-export function flow<A extends ReadonlyArray<unknown>, B, C>(ab: (...a: A) => B, bc: (b: B) => C): (...a: A) => C
-export function flow<A extends ReadonlyArray<unknown>, B, C, D>(
-  ab: (...a: A) => B,
-  bc: (b: B) => C,
-  cd: (c: C) => D
-): (...a: A) => D
-export function flow<A extends ReadonlyArray<unknown>, B, C, D, E>(
-  ab: (...a: A) => B,
-  bc: (b: B) => C,
-  cd: (c: C) => D,
-  de: (d: D) => E
-): (...a: A) => E
-export function flow<A extends ReadonlyArray<unknown>, B, C, D, E, F>(
-  ab: (...a: A) => B,
-  bc: (b: B) => C,
-  cd: (c: C) => D,
-  de: (d: D) => E,
-  ef: (e: E) => F
-): (...a: A) => F
-export function flow<A extends ReadonlyArray<unknown>, B, C, D, E, F, G>(
-  ab: (...a: A) => B,
-  bc: (b: B) => C,
-  cd: (c: C) => D,
-  de: (d: D) => E,
-  ef: (e: E) => F,
-  fg: (f: F) => G
-): (...a: A) => G
-export function flow<A extends ReadonlyArray<unknown>, B, C, D, E, F, G, H>(
-  ab: (...a: A) => B,
-  bc: (b: B) => C,
-  cd: (c: C) => D,
-  de: (d: D) => E,
-  ef: (e: E) => F,
-  fg: (f: F) => G,
-  gh: (g: G) => H
-): (...a: A) => H
-export function flow<A extends ReadonlyArray<unknown>, B, C, D, E, F, G, H, I>(
-  ab: (...a: A) => B,
-  bc: (b: B) => C,
-  cd: (c: C) => D,
-  de: (d: D) => E,
-  ef: (e: E) => F,
-  fg: (f: F) => G,
-  gh: (g: G) => H,
-  hi: (h: H) => I
-): (...a: A) => I
-export function flow<A extends ReadonlyArray<unknown>, B, C, D, E, F, G, H, I, J>(
-  ab: (...a: A) => B,
-  bc: (b: B) => C,
-  cd: (c: C) => D,
-  de: (d: D) => E,
-  ef: (e: E) => F,
-  fg: (f: F) => G,
-  gh: (g: G) => H,
-  hi: (h: H) => I,
-  ij: (i: I) => J
-): (...a: A) => J
-export function flow(
-  ab: Function,
-  bc?: Function,
-  cd?: Function,
-  de?: Function,
-  ef?: Function,
-  fg?: Function,
-  gh?: Function,
-  hi?: Function,
-  ij?: Function
-): unknown {
-  switch (arguments.length) {
-    case 1:
-      return ab
-    case 2:
-      return function (this: unknown) {
-        return bc!(ab.apply(this, arguments))
-      }
-    case 3:
-      return function (this: unknown) {
-        return cd!(bc!(ab.apply(this, arguments)))
-      }
-    case 4:
-      return function (this: unknown) {
-        return de!(cd!(bc!(ab.apply(this, arguments))))
-      }
-    case 5:
-      return function (this: unknown) {
-        return ef!(de!(cd!(bc!(ab.apply(this, arguments)))))
-      }
-    case 6:
-      return function (this: unknown) {
-        return fg!(ef!(de!(cd!(bc!(ab.apply(this, arguments))))))
-      }
-    case 7:
-      return function (this: unknown) {
-        return gh!(fg!(ef!(de!(cd!(bc!(ab.apply(this, arguments)))))))
-      }
-    case 8:
-      return function (this: unknown) {
-        return hi!(gh!(fg!(ef!(de!(cd!(bc!(ab.apply(this, arguments))))))))
-      }
-    case 9:
-      return function (this: unknown) {
-        return ij!(hi!(gh!(fg!(ef!(de!(cd!(bc!(ab.apply(this, arguments)))))))))
-      }
-  }
-  return
+type FlowFuncs<A extends Array<any>, F extends Array<any>>
+	= F extends [(...args: A) => infer T] ? [(...args: A) => T]
+	: F extends [(...args: A) => infer T, ...infer R] ? [(...args: A) => T, ...PipeFuncs<[T], R>]
+	: never
+
+type FlowOutput<A extends Array<any>, F extends Array<any>>
+	= F extends [(...args: A) => infer T] ? T
+	: F extends [(...args: A) => infer T, ...infer R] ? PipeOutput<[T], R>
+	: never
+
+export function flow<A extends Array<any>, F extends Array<any>>(...fs: FlowFuncs<A, F>): (...args: A) => FlowOutput<A, F> {
+	// @ts-expect-error(TypeScript can't handle the type recursion)
+	return (...args) => fs.reduce((x, f) => [f(...x)], args)[0];
 }
 
 /**
@@ -413,279 +320,21 @@ export function untupled<A extends ReadonlyArray<unknown>, B>(f: (a: A) => B): (
  *
  * @since 2.6.3
  */
-export function pipe<A>(a: A): A
-export function pipe<A, B>(a: A, ab: (a: A) => B): B
-export function pipe<A, B, C>(a: A, ab: (a: A) => B, bc: (b: B) => C): C
-export function pipe<A, B, C, D>(a: A, ab: (a: A) => B, bc: (b: B) => C, cd: (c: C) => D): D
-export function pipe<A, B, C, D, E>(a: A, ab: (a: A) => B, bc: (b: B) => C, cd: (c: C) => D, de: (d: D) => E): E
-export function pipe<A, B, C, D, E, F>(
-  a: A,
-  ab: (a: A) => B,
-  bc: (b: B) => C,
-  cd: (c: C) => D,
-  de: (d: D) => E,
-  ef: (e: E) => F
-): F
-export function pipe<A, B, C, D, E, F, G>(
-  a: A,
-  ab: (a: A) => B,
-  bc: (b: B) => C,
-  cd: (c: C) => D,
-  de: (d: D) => E,
-  ef: (e: E) => F,
-  fg: (f: F) => G
-): G
-export function pipe<A, B, C, D, E, F, G, H>(
-  a: A,
-  ab: (a: A) => B,
-  bc: (b: B) => C,
-  cd: (c: C) => D,
-  de: (d: D) => E,
-  ef: (e: E) => F,
-  fg: (f: F) => G,
-  gh: (g: G) => H
-): H
-export function pipe<A, B, C, D, E, F, G, H, I>(
-  a: A,
-  ab: (a: A) => B,
-  bc: (b: B) => C,
-  cd: (c: C) => D,
-  de: (d: D) => E,
-  ef: (e: E) => F,
-  fg: (f: F) => G,
-  gh: (g: G) => H,
-  hi: (h: H) => I
-): I
-export function pipe<A, B, C, D, E, F, G, H, I, J>(
-  a: A,
-  ab: (a: A) => B,
-  bc: (b: B) => C,
-  cd: (c: C) => D,
-  de: (d: D) => E,
-  ef: (e: E) => F,
-  fg: (f: F) => G,
-  gh: (g: G) => H,
-  hi: (h: H) => I,
-  ij: (i: I) => J
-): J
-export function pipe<A, B, C, D, E, F, G, H, I, J, K>(
-  a: A,
-  ab: (a: A) => B,
-  bc: (b: B) => C,
-  cd: (c: C) => D,
-  de: (d: D) => E,
-  ef: (e: E) => F,
-  fg: (f: F) => G,
-  gh: (g: G) => H,
-  hi: (h: H) => I,
-  ij: (i: I) => J,
-  jk: (j: J) => K
-): K
-export function pipe<A, B, C, D, E, F, G, H, I, J, K, L>(
-  a: A,
-  ab: (a: A) => B,
-  bc: (b: B) => C,
-  cd: (c: C) => D,
-  de: (d: D) => E,
-  ef: (e: E) => F,
-  fg: (f: F) => G,
-  gh: (g: G) => H,
-  hi: (h: H) => I,
-  ij: (i: I) => J,
-  jk: (j: J) => K,
-  kl: (k: K) => L
-): L
-export function pipe<A, B, C, D, E, F, G, H, I, J, K, L, M>(
-  a: A,
-  ab: (a: A) => B,
-  bc: (b: B) => C,
-  cd: (c: C) => D,
-  de: (d: D) => E,
-  ef: (e: E) => F,
-  fg: (f: F) => G,
-  gh: (g: G) => H,
-  hi: (h: H) => I,
-  ij: (i: I) => J,
-  jk: (j: J) => K,
-  kl: (k: K) => L,
-  lm: (l: L) => M
-): M
-export function pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N>(
-  a: A,
-  ab: (a: A) => B,
-  bc: (b: B) => C,
-  cd: (c: C) => D,
-  de: (d: D) => E,
-  ef: (e: E) => F,
-  fg: (f: F) => G,
-  gh: (g: G) => H,
-  hi: (h: H) => I,
-  ij: (i: I) => J,
-  jk: (j: J) => K,
-  kl: (k: K) => L,
-  lm: (l: L) => M,
-  mn: (m: M) => N
-): N
-export function pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>(
-  a: A,
-  ab: (a: A) => B,
-  bc: (b: B) => C,
-  cd: (c: C) => D,
-  de: (d: D) => E,
-  ef: (e: E) => F,
-  fg: (f: F) => G,
-  gh: (g: G) => H,
-  hi: (h: H) => I,
-  ij: (i: I) => J,
-  jk: (j: J) => K,
-  kl: (k: K) => L,
-  lm: (l: L) => M,
-  mn: (m: M) => N,
-  no: (n: N) => O
-): O
+type PipeFuncs<A, F extends Array<any>>
+	= F extends [] ? []
+	: F extends [(x: A) => infer T] ? [(x: A) => T]
+	: F extends [(x: A) => infer T, ...infer R] ? [(x: A) => T, ...PipeFuncs<T, R>]
+	: never
 
-export function pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(
-  a: A,
-  ab: (a: A) => B,
-  bc: (b: B) => C,
-  cd: (c: C) => D,
-  de: (d: D) => E,
-  ef: (e: E) => F,
-  fg: (f: F) => G,
-  gh: (g: G) => H,
-  hi: (h: H) => I,
-  ij: (i: I) => J,
-  jk: (j: J) => K,
-  kl: (k: K) => L,
-  lm: (l: L) => M,
-  mn: (m: M) => N,
-  no: (n: N) => O,
-  op: (o: O) => P
-): P
+type PipeOutput<A, F extends Array<any>>
+	= F extends [] ? A
+	: F extends [(x: A) => infer T] ? T
+	: F extends [(x: A) => infer T, ...infer R] ? PipeOutput<T, R>
+	: never
 
-export function pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>(
-  a: A,
-  ab: (a: A) => B,
-  bc: (b: B) => C,
-  cd: (c: C) => D,
-  de: (d: D) => E,
-  ef: (e: E) => F,
-  fg: (f: F) => G,
-  gh: (g: G) => H,
-  hi: (h: H) => I,
-  ij: (i: I) => J,
-  jk: (j: J) => K,
-  kl: (k: K) => L,
-  lm: (l: L) => M,
-  mn: (m: M) => N,
-  no: (n: N) => O,
-  op: (o: O) => P,
-  pq: (p: P) => Q
-): Q
-
-export function pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>(
-  a: A,
-  ab: (a: A) => B,
-  bc: (b: B) => C,
-  cd: (c: C) => D,
-  de: (d: D) => E,
-  ef: (e: E) => F,
-  fg: (f: F) => G,
-  gh: (g: G) => H,
-  hi: (h: H) => I,
-  ij: (i: I) => J,
-  jk: (j: J) => K,
-  kl: (k: K) => L,
-  lm: (l: L) => M,
-  mn: (m: M) => N,
-  no: (n: N) => O,
-  op: (o: O) => P,
-  pq: (p: P) => Q,
-  qr: (q: Q) => R
-): R
-
-export function pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>(
-  a: A,
-  ab: (a: A) => B,
-  bc: (b: B) => C,
-  cd: (c: C) => D,
-  de: (d: D) => E,
-  ef: (e: E) => F,
-  fg: (f: F) => G,
-  gh: (g: G) => H,
-  hi: (h: H) => I,
-  ij: (i: I) => J,
-  jk: (j: J) => K,
-  kl: (k: K) => L,
-  lm: (l: L) => M,
-  mn: (m: M) => N,
-  no: (n: N) => O,
-  op: (o: O) => P,
-  pq: (p: P) => Q,
-  qr: (q: Q) => R,
-  rs: (r: R) => S
-): S
-
-export function pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>(
-  a: A,
-  ab: (a: A) => B,
-  bc: (b: B) => C,
-  cd: (c: C) => D,
-  de: (d: D) => E,
-  ef: (e: E) => F,
-  fg: (f: F) => G,
-  gh: (g: G) => H,
-  hi: (h: H) => I,
-  ij: (i: I) => J,
-  jk: (j: J) => K,
-  kl: (k: K) => L,
-  lm: (l: L) => M,
-  mn: (m: M) => N,
-  no: (n: N) => O,
-  op: (o: O) => P,
-  pq: (p: P) => Q,
-  qr: (q: Q) => R,
-  rs: (r: R) => S,
-  st: (s: S) => T
-): T
-export function pipe(
-  a: unknown,
-  ab?: Function,
-  bc?: Function,
-  cd?: Function,
-  de?: Function,
-  ef?: Function,
-  fg?: Function,
-  gh?: Function,
-  hi?: Function
-): unknown {
-  switch (arguments.length) {
-    case 1:
-      return a
-    case 2:
-      return ab!(a)
-    case 3:
-      return bc!(ab!(a))
-    case 4:
-      return cd!(bc!(ab!(a)))
-    case 5:
-      return de!(cd!(bc!(ab!(a))))
-    case 6:
-      return ef!(de!(cd!(bc!(ab!(a)))))
-    case 7:
-      return fg!(ef!(de!(cd!(bc!(ab!(a))))))
-    case 8:
-      return gh!(fg!(ef!(de!(cd!(bc!(ab!(a)))))))
-    case 9:
-      return hi!(gh!(fg!(ef!(de!(cd!(bc!(ab!(a))))))))
-    default: {
-      let ret = arguments[0]
-      for (let i = 1; i < arguments.length; i++) {
-        ret = arguments[i](ret)
-      }
-      return ret
-    }
-  }
+export function pipe<A, F extends Array<any>>(x: A, ...fs: PipeFuncs<A, F>): PipeOutput<A, F> {
+	// @ts-expect-error(TypeScript can't handle the type recursion)
+	return fs.reduce((x, f) => f(x), x);
 }
 
 /**

--- a/src/function.ts
+++ b/src/function.ts
@@ -233,17 +233,17 @@ export function flip(f: Function): Function {
  *
  * @since 2.0.0
  */
-type FlowFuncs<A extends Array<any>, F extends Array<any>>
-	= F extends [(...args: A) => infer T] ? [(...args: A) => T]
-	: F extends [(...args: A) => infer T, ...infer R] ? [(...args: A) => T, ...PipeFuncs<[T], R>]
+type FlowFuncs<A extends ReadonlyArray<unknown>, F extends ReadonlyArray<unknown>>
+	= F extends [(...args: A) => unknown] ? F
+	: F extends [(...args: A) => infer T, ...infer R] ? [(...args: A) => T, ...FlowFuncs<[T], R>]
 	: never
 
-type FlowOutput<A extends Array<any>, F extends Array<any>>
+type FlowOutput<A extends ReadonlyArray<unknown>, F extends ReadonlyArray<unknown>>
 	= F extends [(...args: A) => infer T] ? T
-	: F extends [(...args: A) => infer T, ...infer R] ? PipeOutput<[T], R>
+	: F extends [(...args: A) => infer T, ...infer R] ? FlowOutput<[T], R>
 	: never
 
-export function flow<A extends Array<any>, F extends Array<any>>(...fs: FlowFuncs<A, F>): (...args: A) => FlowOutput<A, F> {
+export function flow<A extends ReadonlyArray<unknown>, F extends ReadonlyArray<unknown>>(...fs: FlowFuncs<A, F>): (...args: A) => FlowOutput<A, F> {
 	// @ts-expect-error(TypeScript can't handle the type recursion)
 	return (...args) => fs.reduce((x, f) => [f(...x)], args)[0];
 }
@@ -320,19 +320,18 @@ export function untupled<A extends ReadonlyArray<unknown>, B>(f: (a: A) => B): (
  *
  * @since 2.6.3
  */
-type PipeFuncs<A, F extends Array<any>>
-	= F extends [] ? []
-	: F extends [(x: A) => infer T] ? [(x: A) => T]
+type PipeFuncs<A, F extends ReadonlyArray<unknown>>
+	= F extends [] ? F
 	: F extends [(x: A) => infer T, ...infer R] ? [(x: A) => T, ...PipeFuncs<T, R>]
 	: never
 
-type PipeOutput<A, F extends Array<any>>
+type PipeOutput<A, F extends ReadonlyArray<unknown>>
 	= F extends [] ? A
 	: F extends [(x: A) => infer T] ? T
 	: F extends [(x: A) => infer T, ...infer R] ? PipeOutput<T, R>
 	: never
 
-export function pipe<A, F extends Array<any>>(x: A, ...fs: PipeFuncs<A, F>): PipeOutput<A, F> {
+export function pipe<A, F extends ReadonlyArray<unknown>>(x: A, ...fs: PipeFuncs<A, F>): PipeOutput<A, F> {
 	// @ts-expect-error(TypeScript can't handle the type recursion)
 	return fs.reduce((x, f) => f(x), x);
 }


### PR DESCRIPTION
The current implementation and type definition of the pipe() and flow() functions limits the number of arguments you can pass to them. This PR fixes that without compromising with type-safety from the caller perspective.

I know the need for ts-expect-error doesn't make for the most elegant of solutions but TypeScript isn't smart enough yet to resolve this kind of type recursion outside of type declaration.