### PR TITLE
docs: add fp-ts Tutorial series on YouTube to Learning Resources

### DIFF
--- a/docs/learning-resources.md
+++ b/docs/learning-resources.md
@@ -11,6 +11,7 @@ has_toc: false
 - [Mostly adequate guide to FP](https://github.com/MostlyAdequate/mostly-adequate-guide) by [@DrBoolean](https://github.com/DrBoolean)
 - [The State monad](https://paulgray.net/the-state-monad/) by Paul Gray
 - [Functional Programming with TypeScript](https://www.youtube.com/playlist?list=PLuPevXgCPUIMbCxBEnc1dNwboH6e2ImQo) by Sahand Javid
+- [fp-ts Tutorial series on YouTube](https://www.youtube.com/playlist?list=PLUMXrUa_EuePN94nJ2hAui5nWDj8RO3lH) by [@MrFunctor](https://github.com/MrFunctor)
 
 ## Getting started with fp-ts series
 


### PR DESCRIPTION
Hello! 👋
I've been working on an [fp-ts Tutorial series on YouTube](https://www.youtube.com/playlist?list=PLUMXrUa_EuePN94nJ2hAui5nWDj8RO3lH) for some time now, and I've made a good amount of videos that will help people getting started with fp-ts. In these videos, I try to cover fp-ts in a practical way that does not require prior knowledge of functional programming.

Given that many people are finding these videos helpful, I think it's a good idea to add a link to the series in the Learning Resources. Let me know what you think! Thank you! 🙏