### PR TITLE
Don't fail when a value can't be converted to a primitive

### DIFF
--- a/src/Either.ts
+++ b/src/Either.ts
@@ -1456,7 +1456,11 @@ export const toUnion: <E, A>(fa: Either<E, A>) => E | A = /*#__PURE__*/ foldW(id
  * @since 2.0.0
  */
 export function toError(e: unknown): Error {
-  return e instanceof Error ? e : new Error(String(e))
+  try {
+    return e instanceof Error ? e : new Error(String(e))
+  } catch (error) {
+    return new Error()
+  }
 }
 
 /**

--- a/test/Either.ts
+++ b/test/Either.ts
@@ -393,6 +393,20 @@ describe.concurrent('Either', () => {
       }, _.toError),
       _.left(new Error('string error'))
     )
+
+    U.deepStrictEqual(
+      _.tryCatch(() => {
+        throw Object.create(null)
+      }, _.toError),
+      _.left(new Error())
+    )
+
+    U.deepStrictEqual(
+      _.tryCatch(() => {
+        throw { toString: [] }
+      }, _.toError),
+      _.left(new Error())
+    )
   })
 
   describe.concurrent('getEq', () => {


### PR DESCRIPTION
Using Fast Check's `anything` arbitrary, I saw it generated an object with a `toString` property that wasn't a function which returned a string, leading to a 'TypeError: Cannot convert object to primitive value' failure.

This change returns an empty `Error` in those cases.