### PR TITLE
Update ReadonlyArray.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fp-ts",
-  "version": "2.15.0",
+  "version": "2.16.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fp-ts",
-      "version": "2.15.0",
+      "version": "2.16.4",
       "license": "MIT",
       "devDependencies": {
         "@effect/language-service": "^0.0.19",

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -404,7 +404,10 @@ export const chainWithIndex =
   (as: Array<A>): Array<B> => {
     const out: Array<B> = []
     for (let i = 0; i < as.length; i++) {
-      out.push(...f(i, as[i]))
+      const bs = f(i, as[i])
+      for (let j = 0; j < bs.length; j++) {
+        out.push(bs[j])
+      }
     }
     return out
   }

--- a/src/NonEmptyArray.ts
+++ b/src/NonEmptyArray.ts
@@ -569,7 +569,10 @@ export const chainWithIndex =
   (as: NonEmptyArray<A>): NonEmptyArray<B> => {
     const out: NonEmptyArray<B> = fromReadonlyNonEmptyArray(f(0, head(as)))
     for (let i = 1; i < as.length; i++) {
-      out.push(...f(i, as[i]))
+      const bs = f(i, as[i])
+      for (let j = 0; j < bs.length; j++) {
+        out.push(bs[j])
+      }
     }
     return out
   }

--- a/src/ReadonlyArray.ts
+++ b/src/ReadonlyArray.ts
@@ -289,7 +289,10 @@ export const chainWithIndex =
     }
     const out: Array<B> = []
     for (let i = 0; i < as.length; i++) {
-      out.push(...f(i, as[i]))
+      const bs = f(i, as[i])
+      for (let j = 0; j < bs.length; j++) {
+        out.push(bs[j])
+      }
     }
     return out
   }

--- a/src/ReadonlyNonEmptyArray.ts
+++ b/src/ReadonlyNonEmptyArray.ts
@@ -565,7 +565,10 @@ export const chainWithIndex =
   (as: ReadonlyNonEmptyArray<A>): ReadonlyNonEmptyArray<B> => {
     const out: NonEmptyArray<B> = _.fromReadonlyNonEmptyArray(f(0, head(as)))
     for (let i = 1; i < as.length; i++) {
-      out.push(...f(i, as[i]))
+      const bs = f(i, as[i])
+      for (let j = 0; j < bs.length; j++) {
+        out.push(bs[j])
+      }
     }
     return out
   }


### PR DESCRIPTION
Fix: #1929

Not sure about adding a test here since the size of the input depend on nodejs and/or the machine its running on.


# Example using the change

Note the source code is inline so its simpler to play with.

```
/** Inlined from source code */
const isEmpty = <A>(as: ReadonlyArray<A>): as is readonly [] => as.length === 0;
// const empty: ReadonlyArray<never> = RNEA.empty
const empty: ReadonlyArray<never> = [];

const value = {};
// const a: Array<Array<typeof value>> = [new Array(112201).fill(value)];
/**
 * 112201, the number that failed in production and on an Apple M1 Max 64gb.
 * I had to increase the number to see a similar failure on my desktop workstation hence the
 * `* 2`
 */
const ass: Array<Array<typeof value>> = [new Array(112201 * 2).fill(value)];

// chainWithIndex from ReadonlyArray
const chainWithIndex =
  <A, B>(f: (i: number, a: A) => ReadonlyArray<B>) =>
  (as: ReadonlyArray<A>): ReadonlyArray<B> => {
    if (isEmpty(as)) {
      return empty;
    }
    const out: Array<B> = [];
    for (let i = 0; i < as.length; i++) {
      out.push(...f(i, as[i]));
    }
    return out;
  };

// Alternative implementation
export const chainWithIndex2 =
  <A, B>(f: (i: number, a: A) => ReadonlyArray<B>) =>
  (as: ReadonlyArray<A>): ReadonlyArray<B> => {
    if (isEmpty(as)) {
      return [];
    }
    const out: Array<B> = [];
    for (let i = 0; i < as.length; i++) {
      const bs = f(i, as[i]);
      for (let j = 0; j < bs.length; j++) {
        out.push(bs[j]);
      }
    }
    return out;
  };

const main = () => {
  console.log({ assLength: ass.length });

  {
    console.log("original start");
    try {
      const as = chainWithIndex((_, x) => x)(ass);
      console.log({ asLength: as.length });
    } catch (err: any) {
      console.log("[original][catch]", err.message);
    }
    console.log("original end");
  }

  {
    console.log("alternative start");
    const as = chainWithIndex2((_, x) => x)(ass);
    console.log({ asLength: as.length });
    console.log("alternative end");
  }
  console.log("done");
};

main();
```

Command used to run it:
```
ts-node --transpile-only x.ts
```

Output:
```
{ assLength: 1 }
original start
[original][catch] Maximum call stack size exceeded
original end
alternative start
{ asLength: 224402 }
alternative end
done
```