### PR TITLE
Support `strictBuiltinIteratorReturn`

### DIFF
--- a/src/Map.ts
+++ b/src/Map.ts
@@ -217,10 +217,7 @@ export function pop<K>(E: Eq<K>): (k: K) => <A>(m: Map<K, A>) => Option<[A, Map<
   }
 }
 
-interface Next<A> {
-  readonly done?: boolean
-  readonly value: A
-}
+type Next<A> = IteratorResult<A, undefined>;
 
 // TODO: remove non-curried overloading in v3
 /**

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -217,7 +217,7 @@ export function pop<K>(E: Eq<K>): (k: K) => <A>(m: Map<K, A>) => Option<[A, Map<
   }
 }
 
-type Next<A> = IteratorResult<A, undefined>;
+type Next<A> = IteratorResult<A, undefined>
 
 // TODO: remove non-curried overloading in v3
 /**

--- a/src/ReadonlyMap.ts
+++ b/src/ReadonlyMap.ts
@@ -95,7 +95,7 @@ export function member<K>(E: Eq<K>): <A>(k: K, m?: ReadonlyMap<K, A>) => boolean
   }
 }
 
-type Next<A> = IteratorResult<A, undefined>;
+type Next<A> = IteratorResult<A, undefined>
 
 // TODO: remove non-curried overloading in v3
 /**

--- a/src/ReadonlyMap.ts
+++ b/src/ReadonlyMap.ts
@@ -95,10 +95,7 @@ export function member<K>(E: Eq<K>): <A>(k: K, m?: ReadonlyMap<K, A>) => boolean
   }
 }
 
-interface Next<A> {
-  readonly done?: boolean
-  readonly value: A
-}
+type Next<A> = IteratorResult<A>;
 
 // TODO: remove non-curried overloading in v3
 /**

--- a/src/ReadonlyMap.ts
+++ b/src/ReadonlyMap.ts
@@ -95,7 +95,7 @@ export function member<K>(E: Eq<K>): <A>(k: K, m?: ReadonlyMap<K, A>) => boolean
   }
 }
 
-type Next<A> = IteratorResult<A>;
+type Next<A> = IteratorResult<A, undefined>;
 
 // TODO: remove non-curried overloading in v3
 /**

--- a/src/ReadonlySet.ts
+++ b/src/ReadonlySet.ts
@@ -61,10 +61,7 @@ export function toSet<A>(s: ReadonlySet<A>): Set<A> {
   return new Set(s)
 }
 
-interface Next<A> {
-  readonly done?: boolean
-  readonly value: A
-}
+type Next<A> = IteratorResult<A>;
 
 /**
  * Projects a Set through a function

--- a/src/ReadonlySet.ts
+++ b/src/ReadonlySet.ts
@@ -61,7 +61,7 @@ export function toSet<A>(s: ReadonlySet<A>): Set<A> {
   return new Set(s)
 }
 
-type Next<A> = IteratorResult<A, undefined>;
+type Next<A> = IteratorResult<A, undefined>
 
 /**
  * Projects a Set through a function

--- a/src/ReadonlySet.ts
+++ b/src/ReadonlySet.ts
@@ -61,7 +61,7 @@ export function toSet<A>(s: ReadonlySet<A>): Set<A> {
   return new Set(s)
 }
 
-type Next<A> = IteratorResult<A>;
+type Next<A> = IteratorResult<A, undefined>;
 
 /**
  * Projects a Set through a function

--- a/src/Set.ts
+++ b/src/Set.ts
@@ -67,7 +67,7 @@ export function chain<B>(E: Eq<B>): <A>(f: (x: A) => Set<B>) => (set: Set<A>) =>
   }
 }
 
-type Next<A> = IteratorResult<A, undefined>;
+type Next<A> = IteratorResult<A, undefined>
 
 /**
  * @since 2.0.0

--- a/src/Set.ts
+++ b/src/Set.ts
@@ -67,10 +67,7 @@ export function chain<B>(E: Eq<B>): <A>(f: (x: A) => Set<B>) => (set: Set<A>) =>
   }
 }
 
-interface Next<A> {
-  readonly done?: boolean
-  readonly value: A
-}
+type Next<A> = IteratorResult<A>;
 
 /**
  * @since 2.0.0

--- a/src/Set.ts
+++ b/src/Set.ts
@@ -67,7 +67,7 @@ export function chain<B>(E: Eq<B>): <A>(f: (x: A) => Set<B>) => (set: Set<A>) =>
   }
 }
 
-type Next<A> = IteratorResult<A>;
+type Next<A> = IteratorResult<A, undefined>;
 
 /**
  * @since 2.0.0


### PR DESCRIPTION
This updates the `fp-ts` build to be forwards compatible with microsoft/TypeScript#58243, which uses a stricter return type for built-in iterators under the new `strictBuiltinIteratorReturn` option, which is enabled by default when compiling with `strict`.