### PR TITLE
fix(doc): correct the blog section link, otherwise the original link will lead to a github not found page.

### DIFF
--- a/docs/learning-resources.md
+++ b/docs/learning-resources.md
@@ -53,7 +53,7 @@ has_toc: false
 ## Community Blog Posts
 
 - [When An Error Is Not An Exception](https://dev.to/vncz/forewords-and-domain-model-1p13) — How we rewrote the core of Prism to make it almost totally functional
-- [Introduction series to FP-TS](https://ybogomolov.me/01-higher-kinded-types/) by Yuriy Bogomolov
+- [Introduction series to FP-TS](https://ybogomolov.me/01-higher-kinded-types) by Yuriy Bogomolov
 - [The ReaderTaskMonad](https://andywhite.xyz/posts/) by Andy White
 - [FP-TS for HTTP-requests](https://kimmosaaskilahti.fi/blog/2019/08/29/using-fp-ts-for-http-requests-and-validation/) by Kimmo Sasskilahti
 - [Basic introduction to FP-TS](https://davetayls.me/blog/2018/06/09/fp-ts-02-handling-error-cases) by Dave Tayls


### PR DESCRIPTION
### Description
Correct the blog post section link, otherwise the original link will lead to a GitHub "Not Found" page.

### Current Behavior
Clicking the [link](https://ybogomolov.me/01-higher-kinded-types/)leads to a GitHub "Not Found" page.

https://gcanti.github.io/fp-ts/learning-resources/#community-blog-posts

<img width="785" alt="image" src="https://github.com/user-attachments/assets/f8c569a2-2f37-4101-9ed0-c54528dacd7f">

### Expected Behavior
The corrected link is [here](https://ybogomolov.me/01-higher-kinded-types), which should direct users to the correct page for the blog.